### PR TITLE
feat: Mirror target via junction/symlink aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ every donor, the per-skill sync status, and what is being skipped and why.
 |-----------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<package>...`        | both   | Restrict to matching donors. Exact (`acme/foo`) or wildcard (`acme/*`, `*`). Listed packages are treated as **trusted** for this run (see [Trust](#trust)). |
 | `--target=PATH`, `-t` | both   | Override `extra.skills.target`.                                                                                                                             |
+| `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces `extra.skills.aliases` entirely. See [Aliases](#aliases). |
 | `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                           |
 | `--discovery`         | both   | Include packages that ship a `skills/` directory but do not declare `extra.skills`.                                                                         |
 | `--dry-run`           | update | Print actions; no files written.                                                                                                                            |
@@ -97,6 +98,7 @@ composer skills:update                      # sync everything that is trusted
 composer skills:update acme/skills-basic    # sync one package (implicit trust)
 composer skills:update 'acme/*'             # sync an entire vendor namespace
 composer skills:update --discovery          # also include packages without extra.skills
+composer skills:update --alias=.claude/skills   # mirror target via a junction/symlink
 composer skills:update --dry-run            # preview, write nothing
 composer skills:show                        # inspect: per-skill status, what is skipped
 ```
@@ -148,6 +150,7 @@ All settings live under `extra.skills` in the consumer project's `composer.json`
   "extra": {
     "skills": {
       "target": ".agents/skills",
+      "aliases": [".claude/skills", ".cursor/skills"],
       "trusted": ["acme/*", "myorg/skills-internal"],
       "trusted-replace": false,
       "discovery": false
@@ -156,18 +159,75 @@ All settings live under `extra.skills` in the consumer project's `composer.json`
 }
 ```
 
-| Key               | Type     | Default          | Description                                                   |
-|-------------------|----------|------------------|---------------------------------------------------------------|
-| `target`          | string   | `.agents/skills` | Destination directory, relative to the project root.          |
-| `trusted`         | string[] | `[]`             | Extra trust patterns (see [Trust](#trust)).                   |
-| `trusted-replace` | bool     | `false`          | When `true`, the built-in trust list is ignored.              |
-| `discovery`       | bool     | `false`          | When `true`, auto-discovery is on by default (CLI overrides). |
+| Key               | Type     | Default          | Description                                                                              |
+|-------------------|----------|------------------|------------------------------------------------------------------------------------------|
+| `target`          | string   | `.agents/skills` | Destination directory, relative to the project root.                                     |
+| `aliases`         | string[] | `[]`             | Mirror paths (junction/symlink) pointing at `target`. See [Aliases](#aliases).           |
+| `trusted`         | string[] | `[]`             | Extra trust patterns (see [Trust](#trust)).                                              |
+| `trusted-replace` | bool     | `false`          | When `true`, the built-in trust list is ignored.                                         |
+| `discovery`       | bool     | `false`          | When `true`, auto-discovery is on by default (CLI overrides).                            |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
 directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent projects.
 
 A malformed `extra.skills` in the project is **fatal**. The same block in a *donor* package is
 skipped with a `-v` warning — one bad vendor never blocks the rest.
+
+
+## Aliases
+
+A single project often needs the same skills directory available to several coding agents at
+once — Claude Code at `.claude/skills`, Cursor at `.cursor/skills`, plus an agent-agnostic
+`.agents/skills`. Copying the same bytes into N places wastes disk and forces them out of sync.
+
+`aliases` keeps **one** real directory (`target`) and creates additional paths as
+OS-level mirrors:
+
+- **POSIX** — symbolic links via `symlink(2)`.
+- **Windows** — directory **junctions** via `mklink /J`. Junctions work without
+  admin/dev-mode privilege, unlike `SeCreateSymbolicLink`. Cross-volume junctions are
+  refused with a non-zero exit; the plugin never silently degrades to a copy.
+
+```jsonc
+{
+  "extra": {
+    "skills": {
+      "target":  ".agents/skills",
+      "aliases": [".claude/skills", ".cursor/skills"]
+    }
+  }
+}
+```
+
+`skills:update` produces one real `.agents/skills/` plus two link paths pointing at it. Reads
+through any path see the same files.
+
+### Behaviour
+
+- **Idempotent.** A second run sees the existing link and treats it as already-correct.
+- **Non-destructive.** If the alias path already exists as a real directory, the run fails
+  with a non-zero exit and leaves the directory untouched. To convert it, remove the
+  directory manually and re-run — the plugin never destroys user content.
+- **Stale aliases not pruned.** Removing an entry from `aliases` does not delete the
+  junction/symlink on disk. Clean it up manually if needed.
+- **CLI override is total.** `--alias=PATH` (repeatable) replaces `extra.skills.aliases`
+  for that run — there is no merging.
+
+```bash
+composer skills:update --alias=.claude/skills --alias=.cursor/skills
+```
+
+### Git
+
+Alias paths are build artefacts and typically belong in `.gitignore`:
+
+```gitignore
+.claude/skills
+.cursor/skills
+```
+
+On Windows, `git status` reads junctions transparently — but committing a junction is rarely
+what you want, so the ignore line is the safer default.
 
 
 ## Trust

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -53,6 +53,8 @@ final readonly class ProjectConfigMapper
             throw new MalformedProjectConfig('extra.skills.target must be a non-empty string');
         }
 
+        $aliases = $this->mapAliases($skills['aliases'] ?? [], $target);
+
         $trusted = $this->mapTrusted($skills['trusted'] ?? []);
 
         $replace = $skills['trusted-replace'] ?? false;
@@ -70,7 +72,85 @@ final readonly class ProjectConfigMapper
             trusted: $trusted,
             trustedReplace: $replace,
             discovery: $discovery,
+            aliases: $aliases,
         );
+    }
+
+    /**
+     * Cheap normalisation purely for same-string detection at the config
+     * level: forward-slash separators and no trailing slash. Not a path
+     * resolver — that's `SyncPlanner`'s job.
+     *
+     * @psalm-pure
+     */
+    private static function lexicalNormalise(string $path): string
+    {
+        return \rtrim(\str_replace('\\', '/', $path), '/');
+    }
+
+    /**
+     * Validate and return the `aliases` list. Each entry must be a non-empty
+     * string. After light lexical normalisation (separator unification,
+     * trailing-slash strip) no alias may equal `$target`, and no two aliases
+     * may collide.
+     *
+     * Resolution against the project root happens later in {@see \LLM\Skills\Sync\SyncPlanner};
+     * this method only catches the obvious raw-string mistakes. The planner
+     * runs a second pass against fully resolved absolute paths, which catches
+     * cases like `./.claude/skills` vs `.claude/skills` after both join the
+     * project root.
+     *
+     * @param non-empty-string $target the already-validated target path; used to forbid
+     *         `target == alias` configurations up front
+     *
+     * @return list<non-empty-string>
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-pure
+     */
+    private function mapAliases(mixed $raw, string $target): array
+    {
+        if ($raw === []) {
+            return [];
+        }
+        if (!\is_array($raw) || !\array_is_list($raw)) {
+            throw new MalformedProjectConfig('extra.skills.aliases must be a list of non-empty strings');
+        }
+
+        $normalisedTarget = self::lexicalNormalise($target);
+
+        $out = [];
+        $seen = [];
+        /** @var int $index */
+        foreach ($raw as $index => $value) {
+            if (!\is_string($value) || $value === '') {
+                throw new MalformedProjectConfig(\sprintf(
+                    'extra.skills.aliases[%d] must be a non-empty string',
+                    $index,
+                ));
+            }
+
+            $normalised = self::lexicalNormalise($value);
+            if ($normalised === $normalisedTarget) {
+                throw new MalformedProjectConfig(\sprintf(
+                    'extra.skills.aliases[%d] (%s) cannot equal extra.skills.target',
+                    $index,
+                    $value,
+                ));
+            }
+            if (isset($seen[$normalised])) {
+                throw new MalformedProjectConfig(\sprintf(
+                    'extra.skills.aliases[%d] (%s) duplicates an earlier entry',
+                    $index,
+                    $value,
+                ));
+            }
+            $seen[$normalised] = true;
+            $out[] = $value;
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Config/Mapper/VendorConfigMapper.php
+++ b/src/Config/Mapper/VendorConfigMapper.php
@@ -68,7 +68,7 @@ final readonly class VendorConfigMapper
             );
         }
 
-        if (!$packageRoot->join($source)->match((string) $packageRoot . '/*')) {
+        if (!$packageRoot->join($source)->match($packageRoot->join('*'))) {
             throw new MalformedVendorConfig(
                 $packageName,
                 'extra.skills.source must not escape the package root',

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -30,6 +30,10 @@ final readonly class ProjectConfig
      * @param bool $trustedReplace when true, skip the built-in trusted list entirely
      * @param bool $discovery when true, treat installed packages without `extra.skills` as
      *         potential donors if they ship a `skills/` directory; CLI `--discovery` overrides this
+     * @param list<non-empty-string> $aliases extra paths that should be created as junctions
+     *         (Windows) or symbolic links (POSIX) pointing at the resolved `$target`. The target
+     *         itself is the only place skills are physically written; aliases are mirrors. Empty
+     *         list means "no aliases", which is the default and matches the entire 1.x contract.
      *
      * @psalm-mutation-free
      */
@@ -38,6 +42,7 @@ final readonly class ProjectConfig
         public TrustedVendors $trusted,
         public bool $trustedReplace,
         public bool $discovery = false,
+        public array $aliases = [],
     ) {}
 
     /**
@@ -53,6 +58,7 @@ final readonly class ProjectConfig
             trusted: TrustedVendors::empty(),
             trustedReplace: false,
             discovery: false,
+            aliases: [],
         );
     }
 
@@ -63,6 +69,16 @@ final readonly class ProjectConfig
      */
     public function withTarget(string $target): self
     {
-        return new self($target, $this->trusted, $this->trustedReplace, $this->discovery);
+        return new self($target, $this->trusted, $this->trustedReplace, $this->discovery, $this->aliases);
+    }
+
+    /**
+     * @param list<non-empty-string> $aliases
+     *
+     * @psalm-mutation-free
+     */
+    public function withAliases(array $aliases): self
+    {
+        return new self($this->target, $this->trusted, $this->trustedReplace, $this->discovery, $aliases);
     }
 }

--- a/src/Config/SyncOptions.php
+++ b/src/Config/SyncOptions.php
@@ -23,6 +23,10 @@ final readonly class SyncOptions
      * @param bool $dryRun when `true`, the runner prints what would happen but does not write any files
      * @param bool|null $discovery `--discovery/-d` CLI flag: `true` to opt in, `false` to opt out,
      *         `null` (default) to defer to project config (`extra.skills.discovery`)
+     * @param list<non-empty-string>|null $aliasOverrides `--alias=` overrides: `null` means "use the project's
+     *         configured aliases", a list (including the empty one) means "the CLI list replaces project
+     *         config entirely". Symmetric with {@see $targetOverride}: passing `--alias` at all is an
+     *         explicit takeover, never a merge.
      *
      * @psalm-mutation-free
      */
@@ -33,6 +37,7 @@ final readonly class SyncOptions
         public bool $interactive,
         public bool $dryRun = false,
         public ?bool $discovery = null,
+        public ?array $aliasOverrides = null,
     ) {}
 
     /**
@@ -47,6 +52,7 @@ final readonly class SyncOptions
             interactive: false,
             dryRun: false,
             discovery: null,
+            aliasOverrides: null,
         );
     }
 

--- a/src/Console/SyncCliDefinition.php
+++ b/src/Console/SyncCliDefinition.php
@@ -60,6 +60,14 @@ final class SyncCliDefinition
                 'Destination directory for synced skills. Overrides extra.skills.target.',
             )
             ->addOption(
+                'alias',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Additional path that should be created as a junction (Windows) or '
+                . 'symlink (POSIX) pointing at the target. Repeatable. Passing the flag '
+                . 'at all replaces extra.skills.aliases entirely (no merging).',
+            )
+            ->addOption(
                 'trust',
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
@@ -92,6 +100,8 @@ final class SyncCliDefinition
         $rawTarget = $input->getOption('target');
         $targetOverride = \is_string($rawTarget) && $rawTarget !== '' ? $rawTarget : null;
 
+        $aliasOverrides = self::parseAliases($input);
+
         return new SyncOptions(
             packageFilters: self::parsePatterns($rawPackages, 'package argument'),
             extraTrusted: self::parsePatterns($rawTrust, '--trust option'),
@@ -99,7 +109,36 @@ final class SyncCliDefinition
             interactive: $input->isInteractive(),
             dryRun: (bool) $input->getOption('dry-run'),
             discovery: $input->getOption('discovery') === true ? true : null,
+            aliasOverrides: $aliasOverrides,
         );
+    }
+
+    /**
+     * Convert `--alias=PATH` entries into an override list. Returns `null`
+     * when the flag was not present at all (so the runner can fall back to
+     * project config); returns a `list<non-empty-string>` (possibly empty)
+     * once the flag has been used, signalling an explicit takeover.
+     *
+     * @return list<non-empty-string>|null
+     *
+     * @throws \InvalidArgumentException when an alias value is not a non-empty string
+     */
+    private static function parseAliases(InputInterface $input): ?array
+    {
+        $raw = (array) $input->getOption('alias');
+        if ($raw === []) {
+            return null;
+        }
+
+        $out = [];
+        foreach ($raw as $value) {
+            if (!\is_string($value) || $value === '') {
+                throw new \InvalidArgumentException('--alias option must be a non-empty string');
+            }
+            $out[] = $value;
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Show/AliasInspection.php
+++ b/src/Show/AliasInspection.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Show;
+
+use Internal\Path;
+
+/**
+ * One row of `skills:show`'s `Aliases:` header.
+ *
+ * Carries the configured alias path plus, when present, the path the
+ * alias currently resolves to on disk if it does **not** point at the
+ * configured target. Used to flag "this alias exists but points at the
+ * wrong place" without having to read the formatter's mind from raw
+ * paths alone.
+ *
+ * @psalm-immutable
+ */
+final readonly class AliasInspection
+{
+    /**
+     * @param Path $alias absolute alias path as configured
+     * @param non-empty-string|null $driftResolvedTo absolute path the alias currently resolves to,
+     *         non-null **only** when the alias exists on disk and resolves somewhere other than the
+     *         configured target. `null` means "no drift" (either the link is correct or the alias
+     *         doesn't exist yet).
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public Path $alias,
+        public ?string $driftResolvedTo = null,
+    ) {}
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function hasDrift(): bool
+    {
+        return $this->driftResolvedTo !== null;
+    }
+}

--- a/src/Show/InspectionBuilder.php
+++ b/src/Show/InspectionBuilder.php
@@ -22,6 +22,7 @@ use LLM\Skills\Discovery\SkillFrontmatterReader;
 use LLM\Skills\Info;
 use LLM\Skills\Sync\SkillConflict;
 use LLM\Skills\Sync\SyncEngine;
+use LLM\Skills\Sync\SyncPlan;
 use LLM\Skills\Sync\SyncPlanner;
 
 /**
@@ -114,7 +115,75 @@ final readonly class InspectionBuilder
             skipped: $skipped,
             discoveryActive: $discoveryActive,
             undeclaredCandidatesCount: \count($resolution->excluded),
+            aliases: $this->inspectAliases($plan),
         );
+    }
+
+    /**
+     * @psalm-pure
+     */
+    private static function pathsEqual(string $a, string $b): bool
+    {
+        $aNorm = \rtrim(\str_replace('/', \DIRECTORY_SEPARATOR, $a), \DIRECTORY_SEPARATOR);
+        $bNorm = \rtrim(\str_replace('/', \DIRECTORY_SEPARATOR, $b), \DIRECTORY_SEPARATOR);
+
+        return \DIRECTORY_SEPARATOR === '\\'
+            ? \strcasecmp($aNorm, $bNorm) === 0
+            : $aNorm === $bNorm;
+    }
+
+    /**
+     * For each configured alias, decide whether it currently points at
+     * the target on disk. The check is intentionally observational —
+     * it never creates, removes, or touches anything. A non-existent
+     * alias is **not** drift (the next sync will create it); only an
+     * existing junction/symlink/directory pointing somewhere else is.
+     *
+     * @return list<AliasInspection>
+     */
+    private function inspectAliases(SyncPlan $plan): array
+    {
+        if ($plan->aliases === []) {
+            return [];
+        }
+
+        $resolvedTarget = \realpath((string) $plan->target);
+
+        $out = [];
+        foreach ($plan->aliases as $alias) {
+            $out[] = new AliasInspection($alias, $this->detectAliasDrift($alias, $resolvedTarget));
+        }
+
+        return $out;
+    }
+
+    /**
+     * Return the resolved path the alias currently points at, but only
+     * when that resolution disagrees with the target. `null` means
+     * "nothing to report" — either the alias is correct, doesn't exist
+     * yet, or can't be resolved.
+     *
+     * @param string|false $resolvedTarget result of {@see \realpath()} on the configured target
+     *
+     * @return non-empty-string|null
+     */
+    private function detectAliasDrift(\Internal\Path $alias, string|false $resolvedTarget): ?string
+    {
+        $aliasStr = (string) $alias;
+        if (!\file_exists($aliasStr) && !\is_link($aliasStr)) {
+            return null;
+        }
+
+        $resolvedAlias = \realpath($aliasStr);
+        if ($resolvedAlias === false || $resolvedAlias === '') {
+            return null;
+        }
+
+        if ($resolvedTarget !== false && $resolvedTarget !== '' && self::pathsEqual($resolvedAlias, $resolvedTarget)) {
+            return null;
+        }
+
+        return $resolvedAlias;
     }
 
     /**

--- a/src/Show/InspectionReport.php
+++ b/src/Show/InspectionReport.php
@@ -28,6 +28,9 @@ final readonly class InspectionReport
      * @param bool $discoveryActive whether the effective `--discovery` flag is on for this run
      * @param int $undeclaredCandidatesCount how many installed packages ship a `skills/` directory but
      *         do not declare `extra.skills`; drives the "rerun with --discovery" hint when discovery is off
+     * @param list<AliasInspection> $aliases mirrors of `$target`, each with optional drift info.
+     *         Empty list means "no aliases configured", which is the default and corresponds to
+     *         the entire 1.x contract — the formatter hides the `Aliases:` header in that case.
      *
      * @psalm-mutation-free
      */
@@ -37,5 +40,6 @@ final readonly class InspectionReport
         public array $skipped,
         public bool $discoveryActive = false,
         public int $undeclaredCandidatesCount = 0,
+        public array $aliases = [],
     ) {}
 }

--- a/src/Show/ReportFormatter.php
+++ b/src/Show/ReportFormatter.php
@@ -82,13 +82,18 @@ final readonly class ReportFormatter
 
         $hint = $this->formatDiscoveryHint($report);
 
-        if ($main === [] && $skipped === [] && $hint === []) {
+        if ($main === [] && $skipped === [] && $hint === [] && $report->aliases === []) {
             return ['No donor packages found.'];
         }
 
-        // Target header — single line at the top so the per-skill rows
-        // can use the second column for description rather than path.
-        $lines = ['Target: ' . (string) $report->target, ''];
+        // Target header — one line per concept. `Aliases:` is omitted
+        // entirely when there are no aliases so the common single-target
+        // setup keeps its short two-line header.
+        $lines = ['Target: ' . (string) $report->target];
+        if ($report->aliases !== []) {
+            $lines[] = $this->formatAliasesHeader($report->aliases);
+        }
+        $lines[] = '';
         if ($main !== []) {
             $lines = [...$lines, ...$main];
         }
@@ -104,6 +109,31 @@ final readonly class ReportFormatter
         }
 
         return $lines;
+    }
+
+    /**
+     * Single-line summary of every configured alias path, with any
+     * drift annotated inline so the reader does not have to cross-
+     * reference paths against the target by eye.
+     *
+     * @param list<AliasInspection> $aliases
+     *
+     * @psalm-pure
+     */
+    private function formatAliasesHeader(array $aliases): string
+    {
+        $parts = [];
+        foreach ($aliases as $entry) {
+            $label = (string) $entry->alias;
+            if ($entry->hasDrift()) {
+                /** @var non-empty-string $drift */
+                $drift = $entry->driftResolvedTo;
+                $label .= ' <fg=yellow>[drift: → ' . $drift . ']</>';
+            }
+            $parts[] = $label;
+        }
+
+        return 'Aliases: ' . \implode(', ', $parts);
     }
 
     /**

--- a/src/Sync/LinkResult.php
+++ b/src/Sync/LinkResult.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Sync;
+
+use Internal\Path;
+
+/**
+ * Outcome of a single {@see SymlinkLinker::link()} call.
+ *
+ * The linker never throws on filesystem-level failures: each alias is
+ * independent, and the runner needs to print a per-alias outcome and
+ * decide on the exit code only once the whole list has been processed.
+ * Errors travel inside this object so the caller can decide whether to
+ * surface them as warnings, fail the run, or both.
+ *
+ * Statuses:
+ *
+ * - {@see LinkStatus::Created}        — a new junction/symlink was put in place.
+ * - {@see LinkStatus::AlreadyCorrect} — the alias path already pointed at the target; no-op.
+ * - {@see LinkStatus::WouldCreate}    — dry-run; nothing was written, but the linker would have created it.
+ * - {@see LinkStatus::Failed}         — any error from §4.2 of the multitarget spec. `$reason` is non-null.
+ *
+ * @psalm-immutable
+ */
+final readonly class LinkResult
+{
+    /**
+     * @param Path $alias the alias path the linker tried to create
+     * @param Path $target absolute path the alias points at (or would have pointed at)
+     * @param non-empty-string|null $reason human-readable failure detail; non-null only when `$status` is
+     *         {@see LinkStatus::Failed}
+     *
+     * @psalm-mutation-free
+     */
+    private function __construct(
+        public Path $alias,
+        public Path $target,
+        public LinkStatus $status,
+        public ?string $reason = null,
+    ) {}
+
+    /**
+     * @psalm-pure
+     */
+    public static function created(Path $alias, Path $target): self
+    {
+        return new self($alias, $target, LinkStatus::Created);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function alreadyCorrect(Path $alias, Path $target): self
+    {
+        return new self($alias, $target, LinkStatus::AlreadyCorrect);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function wouldCreate(Path $alias, Path $target): self
+    {
+        return new self($alias, $target, LinkStatus::WouldCreate);
+    }
+
+    /**
+     * @param non-empty-string $reason
+     *
+     * @psalm-pure
+     */
+    public static function failed(Path $alias, Path $target, string $reason): self
+    {
+        return new self($alias, $target, LinkStatus::Failed, $reason);
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isFailure(): bool
+    {
+        return $this->status === LinkStatus::Failed;
+    }
+}

--- a/src/Sync/LinkStatus.php
+++ b/src/Sync/LinkStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Sync;
+
+/**
+ * Discrete outcomes a {@see SymlinkLinker::link()} call can produce.
+ *
+ * See {@see LinkResult} for the carrying type and the meaning of each
+ * case.
+ */
+enum LinkStatus: string
+{
+    case Created = 'created';
+    case AlreadyCorrect = 'already-correct';
+    case WouldCreate = 'would-create';
+    case Failed = 'failed';
+}

--- a/src/Sync/SymlinkLinker.php
+++ b/src/Sync/SymlinkLinker.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Sync;
+
+use Internal\Path;
+
+/**
+ * Creates one OS-level link per alias, pointing at the copy target.
+ *
+ * Runs **after** {@see SyncEngine} so the link target exists by the
+ * time we create the alias. One alias = one junction/symlink, never
+ * per-skill.
+ *
+ * Platform split:
+ *
+ * - **Windows**: directory **junctions** via `mklink /J`. Junctions
+ *   work without admin/dev-mode (unlike symbolic links, which need
+ *   `SeCreateSymbolicLink`). They are local-FS-only — if the alias
+ *   and target would live on different volumes, the link cannot be
+ *   created and the linker emits a {@see LinkStatus::Failed} result
+ *   rather than silently degrading to a copy.
+ * - **POSIX**: standard {@see \symlink()}.
+ *
+ * §4.2 state matrix — applied to the alias path *before* creating
+ * anything:
+ *
+ * | Existing state                  | Action                          |
+ * |---------------------------------|---------------------------------|
+ * | Does not exist                  | Create the link.                |
+ * | Symlink/junction → target       | No-op, success.                 |
+ * | Symlink/junction → elsewhere    | Failed (do not overwrite).      |
+ * | Real directory                  | Failed (would destroy content). |
+ * | Regular file                    | Failed.                         |
+ *
+ * No "force" mode: the plugin never destroys user-owned content. To
+ * replace a real directory with an alias the user removes the
+ * directory themselves and re-runs.
+ */
+final readonly class SymlinkLinker
+{
+    /**
+     * Try to make `$alias` point at `$target`.
+     *
+     * The linker never throws on filesystem-level failures — every
+     * failure path is captured in the returned {@see LinkResult} so
+     * the runner can decide policy (warn vs. fail-run) in one place.
+     *
+     * @param Path $target absolute path that the alias must point at; the linker assumes
+     *         the directory exists (callers run this after {@see SyncEngine} has copied)
+     * @param bool $dryRun when `true`, the linker performs every read-only check but never
+     *         writes; a would-be-created alias is reported as {@see LinkStatus::WouldCreate}
+     */
+    public function link(Path $alias, Path $target, bool $dryRun = false): LinkResult
+    {
+        // Use native separators throughout — PHP's `is_dir`/`is_link` on
+        // Windows return *false* for an NTFS junction reached via a
+        // forward-slash path, even though the junction is perfectly valid.
+        // {@see \Internal\Path} normalises to forward slashes, so we
+        // re-platformise here once and operate on a single native form for
+        // every filesystem check below.
+        $aliasStr = self::nativePath((string) $alias);
+        $targetStr = self::nativePath((string) $target);
+
+        // Stat cache invalidation: when the previous call to `link()`
+        // (or anything else in the same process) probed `$aliasStr` and
+        // got "does not exist", a subsequent `mklink /J` invoked
+        // out-of-process leaves PHP's stat cache stale. Without clearing,
+        // `is_link` / `is_dir` checks below would still report the
+        // pre-creation state on the second call.
+        \clearstatcache(true, $aliasStr);
+        \clearstatcache(true, $targetStr);
+
+        // The target may legitimately not exist yet in dry-run mode (the
+        // copy phase did not create it because we are not writing). Fall
+        // back to the literal path so the §4.2 state matrix can still
+        // report collisions — the only thing it really needs the target
+        // path for is the "link already points at $target?" comparison.
+        $resolved = \realpath($targetStr);
+        if ($resolved === false) {
+            if (!$dryRun) {
+                return LinkResult::failed(
+                    $alias,
+                    $target,
+                    'target directory does not exist: ' . $targetStr,
+                );
+            }
+            $resolvedTarget = $targetStr;
+        } else {
+            $resolvedTarget = $resolved;
+        }
+
+        if (\file_exists($aliasStr) || \is_link($aliasStr)) {
+            return $this->handleExisting($alias, $target, $aliasStr, $resolvedTarget);
+        }
+
+        // Windows-only: cross-volume junction is impossible. Detect by
+        // comparing drive prefixes (or UNC roots) before touching the FS.
+        if (self::isWindows() && self::crossVolume($aliasStr, $resolvedTarget)) {
+            return LinkResult::failed(
+                $alias,
+                $target,
+                'cross-volume junctions are not supported on Windows '
+                . '(target is on a different drive or share)',
+            );
+        }
+
+        if ($dryRun) {
+            return LinkResult::wouldCreate($alias, $target);
+        }
+
+        $parentCreated = $this->ensureParent($aliasStr);
+        if ($parentCreated !== null) {
+            return LinkResult::failed($alias, $target, $parentCreated);
+        }
+
+        $createError = $this->createLink($aliasStr, $resolvedTarget);
+        if ($createError !== null) {
+            return LinkResult::failed($alias, $target, $createError);
+        }
+
+        return LinkResult::created($alias, $target);
+    }
+
+    /**
+     * Cross-volume detection for Windows. Compares the drive letter
+     * (or UNC root) of two normalised paths. Used before `mklink /J`,
+     * since junctions cannot cross volumes.
+     *
+     * @psalm-pure
+     */
+    private static function crossVolume(string $aliasPath, string $targetPath): bool
+    {
+        $aliasVolume = self::volumeOf($aliasPath);
+        $targetVolume = self::volumeOf($targetPath);
+        if ($aliasVolume === null || $targetVolume === null) {
+            return false;
+        }
+
+        return \strcasecmp($aliasVolume, $targetVolume) !== 0;
+    }
+
+    /**
+     * Extract the volume prefix of an absolute Windows path: a drive
+     * letter (`C:`) or a UNC share root (`\\server\share`). Returns
+     * `null` for paths that have neither (relative paths, POSIX
+     * absolutes that should never reach this code on Windows).
+     *
+     * @return non-empty-string|null
+     *
+     * @psalm-pure
+     */
+    private static function volumeOf(string $path): ?string
+    {
+        if ($path === '') {
+            return null;
+        }
+
+        $normalised = \str_replace('/', '\\', $path);
+
+        if (\preg_match('~^([a-zA-Z]:)~', $normalised, $m) === 1) {
+            $drive = $m[1];
+            return $drive === '' ? null : $drive;
+        }
+
+        if (\str_starts_with($normalised, '\\\\')) {
+            // UNC: \\server\share — first two segments after the leading \\.
+            $rest = \substr($normalised, 2);
+            $parts = \explode('\\', $rest);
+            if (\count($parts) >= 2 && $parts[0] !== '' && $parts[1] !== '') {
+                return '\\\\' . $parts[0] . '\\' . $parts[1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    private static function pathsEqual(string $a, string $b): bool
+    {
+        if (self::isWindows()) {
+            return \strcasecmp(
+                \str_replace('/', '\\', \rtrim($a, '/\\')),
+                \str_replace('/', '\\', \rtrim($b, '/\\')),
+            ) === 0;
+        }
+
+        return \rtrim($a, '/') === \rtrim($b, '/');
+    }
+
+    /**
+     * @psalm-pure
+     */
+    private static function isWindows(): bool
+    {
+        return \DIRECTORY_SEPARATOR === '\\';
+    }
+
+    /**
+     * Convert a forward-slash-normalised path to native separators.
+     * No-op on POSIX where `DIRECTORY_SEPARATOR === '/'` already.
+     *
+     * @psalm-pure
+     */
+    private static function nativePath(string $path): string
+    {
+        return self::isWindows()
+            ? \str_replace('/', '\\', $path)
+            : $path;
+    }
+
+    /**
+     * Detect an NTFS junction (or any other "directory-shaped link"
+     * whose realpath escapes the parent). Called only when `is_link()`
+     * has already returned false and `is_dir()` true, so this is the
+     * fallback path that distinguishes "junction" from "plain
+     * directory" on Windows.
+     */
+    private static function isJunction(string $path): bool
+    {
+        $resolved = \realpath($path);
+        $parentResolved = \realpath(\dirname($path));
+        if ($resolved === false || $parentResolved === false) {
+            return false;
+        }
+
+        $expected = $parentResolved . \DIRECTORY_SEPARATOR . \basename($path);
+
+        return self::isWindows()
+            ? \strcasecmp($resolved, $expected) !== 0
+            : $resolved !== $expected;
+    }
+
+    /**
+     * The alias path already exists — figure out whether it is an
+     * acceptable no-op (link → target) or a fatal collision. The
+     * state matrix is identical between dry-run and normal modes;
+     * collisions block creation either way.
+     */
+    private function handleExisting(
+        Path $alias,
+        Path $target,
+        string $aliasStr,
+        string $resolvedTarget,
+    ): LinkResult {
+        // Windows NTFS junctions are a third state PHP cannot detect via
+        // `is_link()` *or* `is_dir()` reliably in every build (some report
+        // is_dir=true, some false; readlink results vary too). The robust
+        // signal is realpath escaping the parent dir — see {@see isJunction()}.
+        // Test the junction case before is_dir so a junction-shaped alias
+        // is never mis-classified as a "real directory" and rejected.
+        if (\is_link($aliasStr) || self::isJunction($aliasStr)) {
+            return $this->compareLinkTarget($alias, $target, $aliasStr, $resolvedTarget);
+        }
+
+        if (\is_dir($aliasStr)) {
+            return LinkResult::failed(
+                $alias,
+                $target,
+                'a real directory already exists at the alias path; refusing to replace it',
+            );
+        }
+
+        return LinkResult::failed(
+            $alias,
+            $target,
+            'a regular file already exists at the alias path',
+        );
+    }
+
+    /**
+     * Compare the resolved target of an existing link with the
+     * expected one. Equal → no-op success; different → fatal.
+     */
+    private function compareLinkTarget(
+        Path $alias,
+        Path $target,
+        string $aliasStr,
+        string $resolvedTarget,
+    ): LinkResult {
+        $resolvedExisting = \realpath($aliasStr);
+        if ($resolvedExisting === false) {
+            return LinkResult::failed(
+                $alias,
+                $target,
+                'existing link at alias path cannot be resolved (broken link?)',
+            );
+        }
+
+        if (self::pathsEqual($resolvedExisting, $resolvedTarget)) {
+            return LinkResult::alreadyCorrect($alias, $target);
+        }
+
+        return LinkResult::failed(
+            $alias,
+            $target,
+            \sprintf(
+                'existing link points elsewhere (%s); refusing to overwrite',
+                $resolvedExisting,
+            ),
+        );
+    }
+
+    /**
+     * Ensure the parent directory of `$aliasStr` exists. Returns `null`
+     * on success or an error message on failure.
+     *
+     * @return non-empty-string|null
+     */
+    private function ensureParent(string $aliasStr): ?string
+    {
+        $parent = \dirname($aliasStr);
+        if ($parent === '' || $parent === '.' || \is_dir($parent)) {
+            return null;
+        }
+        if (!@\mkdir($parent, recursive: true) && !\is_dir($parent)) {
+            return 'failed to create parent directory: ' . $parent;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return non-empty-string|null error message on failure, `null` on success
+     */
+    private function createLink(string $aliasStr, string $resolvedTarget): ?string
+    {
+        if (self::isWindows()) {
+            return $this->createJunction($aliasStr, $resolvedTarget);
+        }
+
+        if (!@\symlink($resolvedTarget, $aliasStr)) {
+            $err = \error_get_last()['message'] ?? 'unknown error';
+            return 'symlink() failed: ' . $err;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    private function createJunction(string $aliasStr, string $resolvedTarget): ?string
+    {
+        $aliasNative = \str_replace('/', '\\', $aliasStr);
+        $targetNative = \str_replace('/', '\\', $resolvedTarget);
+
+        $cmd = \sprintf(
+            'mklink /J %s %s',
+            \escapeshellarg($aliasNative),
+            \escapeshellarg($targetNative),
+        );
+
+        $rawOutput = [];
+        $exit = -1;
+        // `mklink` is a cmd.exe builtin, so it must be invoked via cmd /c.
+        @\exec('cmd /c ' . $cmd . ' 2>&1', $rawOutput, $exit);
+
+        if ($exit !== 0) {
+            $lines = [];
+            /** @var mixed $line */
+            foreach ($rawOutput as $line) {
+                if (\is_string($line) && $line !== '') {
+                    $lines[] = $line;
+                }
+            }
+            $tail = $lines === [] ? 'no output' : \implode(' ', $lines);
+            return 'mklink /J failed: ' . $tail;
+        }
+
+        return null;
+    }
+}

--- a/src/Sync/SyncPlan.php
+++ b/src/Sync/SyncPlan.php
@@ -25,6 +25,9 @@ final readonly class SyncPlan
      * @param list<non-empty-string> $skippedUntrustedNames donors discovered automatically (no positional
      *         arg) that are not in any trust list; skipped silently except for the trailing `[skip]` notice
      * @param Path $target absolute destination directory
+     * @param list<Path> $aliases absolute alias paths; each is created as a junction (Windows) or
+     *         symlink (POSIX) pointing at `$target` after the copy phase completes. Empty list means
+     *         "no aliases for this run".
      * @param list<VendorConfig> $filteredOutDonors donors that were discovered but excluded by a positional
      *         `<package>` pattern. The sync command ignores this field — it exists for `show`, which lists
      *         these under `Skipped:` with a `filtered-out` reason.
@@ -35,6 +38,7 @@ final readonly class SyncPlan
         public array $approvedDonors,
         public array $skippedUntrustedNames,
         public Path $target,
+        public array $aliases = [],
         public array $filteredOutDonors = [],
     ) {}
 }

--- a/src/Sync/SyncPlanner.php
+++ b/src/Sync/SyncPlanner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Sync;
 
 use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\SyncOptions;
 use LLM\Skills\Config\TrustedVendors;
@@ -70,10 +71,13 @@ final readonly class SyncPlanner
             }
         }
 
+        $target = $this->resolveTarget($project, $options, $projectRoot);
+
         return new SyncPlan(
             approvedDonors: $approved,
             skippedUntrustedNames: $skipped,
-            target: $this->resolveTarget($project, $options, $projectRoot),
+            target: $target,
+            aliases: $this->resolveAliases($project, $options, $projectRoot, $target),
             filteredOutDonors: $filteredOut,
         );
     }
@@ -154,6 +158,70 @@ final readonly class SyncPlanner
         /** @var non-empty-string $raw */
         $raw = $options->targetOverride ?? $project->target;
 
+        return $this->resolvePath($raw, $projectRoot);
+    }
+
+    /**
+     * Resolve every alias entry to an absolute {@see Path}. The CLI list,
+     * when present, replaces the project's aliases entirely — passing any
+     * `--alias` is an explicit takeover, matching `--target` semantics.
+     *
+     * Post-resolution checks: aliases must not match the resolved target
+     * and must not collide with each other. These mirror the lexical
+     * checks the mapper already runs against the raw config, but they
+     * have to run again here because the CLI input is unstructured and
+     * because relative paths could collapse to the same absolute path
+     * even when their raw strings differ.
+     *
+     * @return list<Path>
+     *
+     * @throws MalformedProjectConfig
+     */
+    private function resolveAliases(
+        ProjectConfig $project,
+        SyncOptions $options,
+        Path $projectRoot,
+        Path $target,
+    ): array {
+        $raw = $options->aliasOverrides ?? $project->aliases;
+        if ($raw === []) {
+            return [];
+        }
+
+        $targetStr = (string) $target;
+
+        $out = [];
+        $seen = [];
+        foreach ($raw as $entry) {
+            $resolved = $this->resolvePath($entry, $projectRoot);
+            $resolvedStr = (string) $resolved;
+
+            if ($resolvedStr === $targetStr) {
+                throw new MalformedProjectConfig(\sprintf(
+                    'alias "%s" resolves to the target path %s; an alias cannot point at itself',
+                    $entry,
+                    $targetStr,
+                ));
+            }
+            if (isset($seen[$resolvedStr])) {
+                throw new MalformedProjectConfig(\sprintf(
+                    'alias "%s" resolves to %s, which duplicates an earlier alias',
+                    $entry,
+                    $resolvedStr,
+                ));
+            }
+            $seen[$resolvedStr] = true;
+            $out[] = $resolved;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param non-empty-string $raw
+     */
+    private function resolvePath(string $raw, Path $projectRoot): Path
+    {
         return self::isAbsolute($raw)
             ? Path::create($raw)
             : $projectRoot->join($raw);

--- a/src/Sync/SyncPlanner.php
+++ b/src/Sync/SyncPlanner.php
@@ -72,6 +72,7 @@ final readonly class SyncPlanner
         }
 
         $target = $this->resolveTarget($project, $options, $projectRoot);
+        $this->assertWithinProject($target, $projectRoot, 'target', $options->targetOverride ?? $project->target);
 
         return new SyncPlan(
             approvedDonors: $approved,
@@ -101,6 +102,52 @@ final readonly class SyncPlanner
         }
 
         return false;
+    }
+
+    /**
+     * Reject paths that resolve outside the project root.
+     *
+     * The project's own `composer.json` is trusted input (the user
+     * wrote it), so this is not a sandbox boundary against malicious
+     * actors — it's a footgun guard. A typo like `target: "../.."`
+     * or a CLI argument like `--target=/etc/passwd` would otherwise
+     * happily start writing files (or planting junctions) outside
+     * the project. Donor packages are already pinned to their own
+     * roots ({@see \LLM\Skills\Config\Mapper\VendorConfigMapper},
+     * {@see \LLM\Skills\Discovery\AutoDiscoveryProbe}); this check
+     * brings the project side in line with that posture.
+     *
+     * Uses the same {@see Path::match()} idiom as the vendor-side
+     * escape check ({@see \LLM\Skills\Config\Mapper\VendorConfigMapper})
+     * so containment semantics — separator normalisation,
+     * case-insensitivity on Windows, `..` collapse — stay consistent
+     * across the codebase.
+     *
+     * @param non-empty-string $context human-readable label of the config field, e.g. `target`
+     *        or `alias[0]`; goes into the error message
+     * @param non-empty-string $raw the user-supplied value, included verbatim in the error so
+     *        the user can locate the offending entry in their config
+     *
+     * @throws MalformedProjectConfig
+     */
+    private function assertWithinProject(
+        Path $resolved,
+        Path $projectRoot,
+        string $context,
+        string $raw,
+    ): void {
+        if ($resolved->match($projectRoot->join('*'))) {
+            return;
+        }
+
+        throw new MalformedProjectConfig(\sprintf(
+            '%s "%s" resolves to "%s", which is outside the project root "%s"; '
+            . 'target and aliases must stay inside the project',
+            $context,
+            $raw,
+            $resolved,
+            $projectRoot,
+        ));
     }
 
     /**
@@ -192,8 +239,9 @@ final readonly class SyncPlanner
 
         $out = [];
         $seen = [];
-        foreach ($raw as $entry) {
+        foreach ($raw as $index => $entry) {
             $resolved = $this->resolvePath($entry, $projectRoot);
+            $this->assertWithinProject($resolved, $projectRoot, \sprintf('alias[%d]', $index), $entry);
             $resolvedStr = (string) $resolved;
 
             if ($resolvedStr === $targetStr) {

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -59,6 +59,7 @@ final readonly class SyncRunner
         private SkillEnumerator $skillEnumerator = new SkillEnumerator(),
         private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
         private DiscoveryResolver $discoveryResolver = new DiscoveryResolver(),
+        private SymlinkLinker $symlinkLinker = new SymlinkLinker(),
     ) {}
 
     public function run(Composer $composer, IOInterface $io, SyncOptions $options): int
@@ -130,9 +131,64 @@ final readonly class SyncRunner
             (string) $plan->target,
         ));
 
+        $aliasFailed = $this->processAliases($io, $plan, $options->dryRun);
+
         $this->emitTrailingDiagnostics($io, $plan, $resolution->excluded);
 
-        return Command::SUCCESS;
+        // Alias errors fail the run loudly — silent partial success would
+        // mask broken `.claude/skills` / `.cursor/skills` aliases on CI,
+        // which is exactly the footgun §4.2 of the multitarget spec
+        // exists to prevent.
+        return $aliasFailed ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Process every alias declared in the plan through {@see SymlinkLinker}.
+     * Returns `true` if any alias errored — the caller turns that into a
+     * non-zero exit code per §4.2 of the multitarget spec.
+     */
+    private function processAliases(IOInterface $io, SyncPlan $plan, bool $dryRun): bool
+    {
+        if ($plan->aliases === []) {
+            return false;
+        }
+
+        $anyFailed = false;
+        foreach ($plan->aliases as $alias) {
+            $result = $this->symlinkLinker->link($alias, $plan->target, $dryRun);
+            $this->emitAliasOutcome($io, $result);
+            if ($result->isFailure()) {
+                $anyFailed = true;
+            }
+        }
+
+        return $anyFailed;
+    }
+
+    private function emitAliasOutcome(IOInterface $io, LinkResult $result): void
+    {
+        $aliasStr = (string) $result->alias;
+        $targetStr = (string) $result->target;
+
+        switch ($result->status) {
+            case LinkStatus::Created:
+                $io->write(\sprintf('<info>[link]</info> %s → %s', $aliasStr, $targetStr));
+                return;
+            case LinkStatus::AlreadyCorrect:
+                $io->write(\sprintf('<info>[link]</info> %s → %s (already correct)', $aliasStr, $targetStr));
+                return;
+            case LinkStatus::WouldCreate:
+                $io->write(\sprintf('<info>[would link]</info> %s → %s', $aliasStr, $targetStr));
+                return;
+            case LinkStatus::Failed:
+                $io->writeError(\sprintf(
+                    '<error>[link-failed] %s → %s: %s</error>',
+                    $aliasStr,
+                    $targetStr,
+                    $result->reason ?? 'unknown error',
+                ));
+                return;
+        }
     }
 
     /**

--- a/tests/Acceptance/SkillsSyncTest.php
+++ b/tests/Acceptance/SkillsSyncTest.php
@@ -696,6 +696,42 @@ final class SkillsSyncTest
         );
     }
 
+    public function targetEscapingProjectRootIsRejected(): void
+    {
+        // Containment guard: a CLI `--target=../escape` (or anything
+        // that resolves outside the project tree) must fail loudly,
+        // never start writing files into a parent directory.
+        $process = $this->runSync('--target=../escape');
+
+        Assert::notSame($process->getExitCode(), 0);
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'outside the project root'),
+            'stderr must explain the containment failure. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \is_dir(Info::PROJECT_DIR . '/../escape'),
+            'no directory must be created outside the project root',
+        );
+    }
+
+    public function aliasEscapingProjectRootIsRejected(): void
+    {
+        // Same guard for `--alias`: a junction at `../escape` would
+        // expose an arbitrary parent location through the project
+        // tree. Reject before any junction is created.
+        $process = $this->runSync('--alias=../escape');
+
+        Assert::notSame($process->getExitCode(), 0);
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'outside the project root'),
+            'stderr must explain the containment failure. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \file_exists(Info::PROJECT_DIR . '/../escape'),
+            'no junction must be created outside the project root',
+        );
+    }
+
     #[WithSandboxExtras([
         'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
         'aliases' => ['.claude/skills-alias'],

--- a/tests/Acceptance/SkillsSyncTest.php
+++ b/tests/Acceptance/SkillsSyncTest.php
@@ -39,6 +39,8 @@ use Testo\Test;
 final class SkillsSyncTest
 {
     private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const ALIAS_CLAUDE = Info::PROJECT_DIR . '/.claude/skills-alias';
+    private const ALIAS_CURSOR = Info::PROJECT_DIR . '/.cursor/skills-alias';
 
     /**
      * Wipe the synced skills directory before each test so assertions reflect
@@ -50,6 +52,8 @@ final class SkillsSyncTest
         Filesystem::removeRecursive(self::TARGET_DIR);
         Filesystem::removeRecursive(Info::PROJECT_DIR . '/custom-skills-target');
         Filesystem::removeRecursive(Info::PROJECT_DIR . '/config-target');
+        Filesystem::removeRecursive(self::ALIAS_CLAUDE);
+        Filesystem::removeRecursive(self::ALIAS_CURSOR);
     }
 
     // ── basic happy path ────────────────────────────────────────────────────
@@ -521,6 +525,196 @@ final class SkillsSyncTest
         Assert::true(\is_file(self::TARGET_DIR . '/greeting/SKILL.md'));
     }
 
+    // ── aliases ─────────────────────────────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function aliasConfiguredInProjectIsCreatedAsLinkPointingAtTarget(): void
+    {
+        $process = $this->runSync();
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'sync must succeed with an alias configured. stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::true(
+            \file_exists(self::ALIAS_CLAUDE),
+            'alias path must exist after sync. stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::true(
+            $this->aliasResolvesToTarget(self::ALIAS_CLAUDE),
+            'alias must resolve to the configured target (.agents/skills)',
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function aliasContentsMatchTarget(): void
+    {
+        // Behavioural proof that the link is real: skill files copied
+        // into the target must be visible through the alias path.
+        $this->runSync();
+
+        Assert::true(\is_file(self::ALIAS_CLAUDE . '/greeting/SKILL.md'));
+        Assert::true(\is_file(self::ALIAS_CLAUDE . '/refactor/SKILL.md'));
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias', '.cursor/skills-alias'],
+    ])]
+    public function multipleAliasesAreAllCreated(): void
+    {
+        $process = $this->runSync();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true($this->aliasResolvesToTarget(self::ALIAS_CLAUDE));
+        Assert::true($this->aliasResolvesToTarget(self::ALIAS_CURSOR));
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function aliasCreationIsIdempotent(): void
+    {
+        // A second run must accept the existing link as already-correct
+        // and exit cleanly. The §4.2 state-matrix's "link → target → noop"
+        // path is what makes routine re-runs safe.
+        $first = $this->runSync();
+        $second = $this->runSync();
+
+        Assert::same($first->getExitCode(), 0, 'first run failed: ' . $first->getErrorOutput());
+        Assert::same($second->getExitCode(), 0, 'second run failed: ' . $second->getErrorOutput());
+        Assert::true($this->aliasResolvesToTarget(self::ALIAS_CLAUDE));
+    }
+
+    public function cliAliasFlagReplacesProjectConfigAliases(): void
+    {
+        // Default sandbox has no aliases; pass one via `--alias` to prove
+        // the CLI surface works. Plain sync without --alias has nothing
+        // at the alias path, but with the flag the link materialises.
+        $process = $this->runSync('--alias=.claude/skills-alias');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            $this->aliasResolvesToTarget(self::ALIAS_CLAUDE),
+            '--alias must create the link. stderr: ' . $process->getErrorOutput(),
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function cliAliasFlagReplacesProjectAliasesEntirely(): void
+    {
+        // Project config has `.claude/skills-alias`, CLI passes only
+        // `.cursor/skills-alias`. The takeover semantics in §3 of the
+        // spec mean only the cursor alias is created — the claude one
+        // is NOT inherited from project config.
+        $process = $this->runSync('--alias=.cursor/skills-alias');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true($this->aliasResolvesToTarget(self::ALIAS_CURSOR));
+        Assert::false(
+            \file_exists(self::ALIAS_CLAUDE),
+            'project alias must not be created when CLI --alias takes over',
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function aliasOutputLineIsEmittedAfterCopyReport(): void
+    {
+        $process = $this->runSync();
+
+        Assert::true(
+            \str_contains($process->getOutput(), '[link]'),
+            '[link] line must appear in stdout. Got: ' . $process->getOutput(),
+        );
+        Assert::true(
+            \str_contains($process->getOutput(), '.claude/skills-alias')
+            || \str_contains($process->getOutput(), '.claude\\skills-alias'),
+            '[link] line must name the alias path. Got: ' . $process->getOutput(),
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function preExistingRealDirectoryAtAliasPathFailsTheRun(): void
+    {
+        // §4.2: the linker never destroys user-owned content. A real
+        // directory at the alias path is a fatal misconfiguration the
+        // user must resolve before any link can be created. Exit code
+        // is non-zero so CI catches it.
+        \mkdir(self::ALIAS_CLAUDE, 0o777, true);
+        \file_put_contents(self::ALIAS_CLAUDE . '/user-file.txt', 'precious user content');
+
+        $process = $this->runSync();
+
+        Assert::notSame(
+            $process->getExitCode(),
+            0,
+            'real directory at alias path must fail the run',
+        );
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'link-failed')
+            || \str_contains($process->getErrorOutput(), 'real directory'),
+            'stderr must explain the alias failure. Got: ' . $process->getErrorOutput(),
+        );
+        // User content is left untouched — the linker refuses to wipe.
+        Assert::true(\is_file(self::ALIAS_CLAUDE . '/user-file.txt'));
+        Assert::same(\file_get_contents(self::ALIAS_CLAUDE . '/user-file.txt'), 'precious user content');
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.agents/skills'],
+    ])]
+    public function aliasEqualToTargetIsRejectedByConfig(): void
+    {
+        // Mapper-level lexical validation: the alias and the target
+        // point at the same location. Fail loudly, do not invoke the
+        // linker at all.
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0);
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'extra.skills.aliases')
+            || \str_contains($process->getErrorOutput(), 'alias'),
+            'stderr must mention the alias config error. Got: ' . $process->getErrorOutput(),
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+        'aliases' => ['.claude/skills-alias'],
+    ])]
+    public function dryRunDoesNotCreateAliasOnDisk(): void
+    {
+        $process = $this->runSync('--dry-run');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::false(
+            \file_exists(self::ALIAS_CLAUDE),
+            'dry-run must not create the alias',
+        );
+        Assert::true(
+            \str_contains($process->getOutput(), '[would link]'),
+            'dry-run must announce the would-be link. Got: ' . $process->getOutput(),
+        );
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private function runSync(string ...$args): Process
@@ -536,6 +730,26 @@ final class SkillsSyncTest
             timeout: 60,
             mustSucceed: false,
         );
+    }
+
+    /**
+     * Behavioural check: does `$aliasPath` resolve, on disk, to the same
+     * canonical path as the sandbox's default target dir? Used in lieu
+     * of `is_link` because PHP can't reliably detect NTFS junctions —
+     * the realpath comparison works across symlinks, junctions and
+     * platform separators.
+     */
+    private function aliasResolvesToTarget(string $aliasPath): bool
+    {
+        $resolvedAlias = \realpath($aliasPath);
+        $resolvedTarget = \realpath(self::TARGET_DIR);
+        if ($resolvedAlias === false || $resolvedTarget === false) {
+            return false;
+        }
+
+        return \DIRECTORY_SEPARATOR === '\\'
+            ? \strcasecmp($resolvedAlias, $resolvedTarget) === 0
+            : $resolvedAlias === $resolvedTarget;
     }
 
     /**

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -165,4 +165,108 @@ final class ProjectConfigMapperTest
 
         (new ProjectConfigMapper())->fromExtra(['skills' => ['discovery' => 'yes']]);
     }
+
+    public function aliasesDefaultToEmptyListWhenAbsent(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra(['skills' => ['target' => 'custom/skills']]);
+
+        Assert::same($cfg->aliases, []);
+    }
+
+    public function aliasesDefaultToEmptyListWhenExplicitEmpty(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra(['skills' => ['aliases' => []]]);
+
+        Assert::same($cfg->aliases, []);
+    }
+
+    public function mapsAliasesAsConfigured(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'target' => '.agents/skills',
+                'aliases' => ['.claude/skills', '.cursor/skills'],
+            ],
+        ]);
+
+        Assert::same($cfg->aliases, ['.claude/skills', '.cursor/skills']);
+    }
+
+    public function aliasesNotAListThrows(): void
+    {
+        // Associative arrays are rejected — `aliases` is a list-shape only,
+        // any keys other than 0..N break the contract.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.aliases');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['aliases' => ['one' => '.claude/skills']],
+        ]);
+    }
+
+    public function aliasesScalarThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.aliases');
+
+        (new ProjectConfigMapper())->fromExtra(['skills' => ['aliases' => '.claude/skills']]);
+    }
+
+    public function aliasesNonStringEntryThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.aliases');
+
+        (new ProjectConfigMapper())->fromExtra(['skills' => ['aliases' => [42]]]);
+    }
+
+    public function aliasesEmptyStringEntryThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.aliases');
+
+        (new ProjectConfigMapper())->fromExtra(['skills' => ['aliases' => ['']]]);
+    }
+
+    public function aliasEqualToTargetThrows(): void
+    {
+        // An alias of itself is nonsense — caught lexically up front so
+        // misconfigurations never reach the planner.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('cannot equal extra.skills.target');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'target' => '.agents/skills',
+                'aliases' => ['.agents/skills'],
+            ],
+        ]);
+    }
+
+    public function aliasEqualToTargetIsDetectedAfterLexicalNormalisation(): void
+    {
+        // Backslash vs forward slash and trailing-slash variants must not
+        // sneak past the equality check.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('cannot equal extra.skills.target');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'target' => '.agents/skills',
+                'aliases' => ['.agents\\skills/'],
+            ],
+        ]);
+    }
+
+    public function duplicateAliasesThrow(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('duplicates an earlier entry');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'aliases' => ['.claude/skills', '.claude/skills'],
+            ],
+        ]);
+    }
 }

--- a/tests/Unit/Show/ReportFormatterTest.php
+++ b/tests/Unit/Show/ReportFormatterTest.php
@@ -7,6 +7,7 @@ namespace LLM\Skills\Tests\Unit\Show;
 use Internal\Path;
 use LLM\Skills\Config\VendorConfig;
 use LLM\Skills\Discovery\Skill;
+use LLM\Skills\Show\AliasInspection;
 use LLM\Skills\Show\DonorInspection;
 use LLM\Skills\Show\InspectionReport;
 use LLM\Skills\Show\ReportFormatter;
@@ -311,6 +312,97 @@ final class ReportFormatterTest
             static fn(string $l) => \str_contains($l, 'skills-') && \str_contains($l, '<fg=cyan>'),
         );
         Assert::same(\count($packages), 2);
+    }
+
+    public function omitsAliasesLineWhenReportHasNoAliases(): void
+    {
+        // Default single-target setup — the `Aliases:` header would be
+        // pure noise. The first line must be just `Target: …`, immediately
+        // followed by the blank separator.
+        $donor = $this->donorInspection(
+            packageName: 'acme/skills-basic',
+            source: '.claude/skills',
+            trust: TrustSource::Project,
+            skills: [['greeting', SyncStatus::InSync]],
+        );
+        $lines = (new ReportFormatter())->format(new InspectionReport(
+            target: Path::create('/p/.agents/skills'),
+            donors: [$donor],
+            skipped: [],
+        ));
+
+        foreach ($lines as $line) {
+            Assert::false(
+                \str_starts_with($line, 'Aliases:'),
+                'no Aliases: line expected when aliases array is empty; got: ' . $line,
+            );
+        }
+    }
+
+    public function rendersAliasesLineAfterTargetWhenAliasesPresent(): void
+    {
+        $donor = $this->donorInspection(
+            packageName: 'acme/skills-basic',
+            source: '.claude/skills',
+            trust: TrustSource::Project,
+            skills: [['greeting', SyncStatus::InSync]],
+        );
+        $lines = (new ReportFormatter())->format(new InspectionReport(
+            target: Path::create('/p/.agents/skills'),
+            donors: [$donor],
+            skipped: [],
+            aliases: [
+                new AliasInspection(Path::create('/p/.claude/skills')),
+                new AliasInspection(Path::create('/p/.cursor/skills')),
+            ],
+        ));
+
+        // Layout: line 0 = Target, line 1 = Aliases, line 2 = blank separator.
+        Assert::true(\str_starts_with($lines[0], 'Target:'));
+        Assert::true(\str_starts_with($lines[1], 'Aliases:'));
+        Assert::same($lines[2], '');
+        Assert::true(\str_contains($lines[1], '.claude/skills'));
+        Assert::true(\str_contains($lines[1], '.cursor/skills'));
+        // Comma-separated on a single line — no per-alias rows.
+        Assert::true(\str_contains($lines[1], ', '));
+    }
+
+    public function annotatesAliasWithDriftMarkerWhenItPointsElsewhere(): void
+    {
+        // An existing alias resolving to a path other than the configured
+        // target must surface inline so the user does not have to compare
+        // paths by eye.
+        $lines = (new ReportFormatter())->format(new InspectionReport(
+            target: Path::create('/p/.agents/skills'),
+            donors: [],
+            skipped: [],
+            aliases: [
+                new AliasInspection(
+                    Path::create('/p/.claude/skills'),
+                    driftResolvedTo: '/old/path',
+                ),
+            ],
+        ));
+
+        $aliasesLine = $this->findLineStartingWith($lines, 'Aliases:');
+        Assert::true($aliasesLine !== null, 'Aliases: line must be present');
+        Assert::true(
+            \str_contains($aliasesLine, '[drift: → /old/path]'),
+            'drift marker must point at the resolved path. Got: ' . $aliasesLine,
+        );
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function findLineStartingWith(array $lines, string $prefix): ?string
+    {
+        foreach ($lines as $line) {
+            if (\str_starts_with($line, $prefix)) {
+                return $line;
+            }
+        }
+        return null;
     }
 
     private function renderJoined(DonorInspection ...$donors): string

--- a/tests/Unit/Sync/SymlinkLinkerTest.php
+++ b/tests/Unit/Sync/SymlinkLinkerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Sync;
+
+use Internal\Path;
+use LLM\Skills\Sync\LinkStatus;
+use LLM\Skills\Sync\SymlinkLinker;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Tests for {@see SymlinkLinker} — the §4.2 state matrix from the
+ * multi-target spec.
+ *
+ * Each test runs against its own temporary tree:
+ *
+ *   <tmp>/
+ *     target/       — the directory the alias should point at
+ *     other/        — a second real dir, used for "points elsewhere" cases
+ *
+ * The {@see BeforeTest} hook creates an empty `<tmp>` plus `target/`;
+ * `<tmp>/other/` is created on demand by tests that need it. The
+ * {@see AfterTest} hook tears the tree down with the junction-safe
+ * {@see Filesystem::removeRecursive()} helper so a stray junction never
+ * deletes anything outside the tmp tree.
+ */
+#[Test]
+final class SymlinkLinkerTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-link-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+        \mkdir($this->tmp . '/target', 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function createsLinkWhenAliasPathDoesNotExist(): void
+    {
+        $aliasPath = $this->tmp . '/alias';
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($result->status, LinkStatus::Created);
+        Assert::true(\file_exists($aliasPath), 'alias path must exist after create');
+        Assert::true(
+            $this->resolvesToTarget($aliasPath),
+            'alias must resolve to the target (i.e. it is a junction/symlink, not a real dir)',
+        );
+    }
+
+    public function linkResolvesToTheTarget(): void
+    {
+        // After linking, files written into the target must be visible
+        // through the alias — proves the link actually points where we
+        // claimed, on both Windows junctions and POSIX symlinks.
+        $aliasPath = $this->tmp . '/alias';
+        $this->linker()->link(Path::create($aliasPath), $this->target());
+
+        \file_put_contents($this->tmp . '/target/marker.txt', 'hello');
+
+        Assert::true(\is_file($aliasPath . '/marker.txt'));
+        Assert::same(\file_get_contents($aliasPath . '/marker.txt'), 'hello');
+    }
+
+    public function existingLinkPointingAtTargetIsNoOp(): void
+    {
+        $aliasPath = $this->tmp . '/alias';
+        $linker = $this->linker();
+
+        $first = $linker->link(Path::create($aliasPath), $this->target());
+        $second = $linker->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($first->status, LinkStatus::Created);
+        Assert::same($second->status, LinkStatus::AlreadyCorrect);
+    }
+
+    public function existingLinkPointingElsewhereFails(): void
+    {
+        // Make the alias point at <tmp>/other first, then ask the linker
+        // to point it at <tmp>/target. The linker must refuse rather than
+        // silently retarget the user's existing alias.
+        \mkdir($this->tmp . '/other', 0o777, true);
+        $aliasPath = $this->tmp . '/alias';
+        $linker = $this->linker();
+
+        $linker->link(Path::create($aliasPath), Path::create($this->tmp . '/other'));
+        $result = $linker->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($result->status, LinkStatus::Failed);
+        Assert::true($result->isFailure());
+        Assert::true(
+            $result->reason !== null && \str_contains($result->reason, 'points elsewhere'),
+            'reason should mention "points elsewhere"; got: ' . ($result->reason ?? 'null'),
+        );
+    }
+
+    public function existingRealDirectoryFailsAndIsNotTouched(): void
+    {
+        $aliasPath = $this->tmp . '/alias';
+        \mkdir($aliasPath, 0o777, true);
+        \file_put_contents($aliasPath . '/user-file.txt', 'precious');
+
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($result->status, LinkStatus::Failed);
+        Assert::true(\is_dir($aliasPath));
+        Assert::true(\is_file($aliasPath . '/user-file.txt'));
+        Assert::same(\file_get_contents($aliasPath . '/user-file.txt'), 'precious');
+    }
+
+    public function existingRegularFileFails(): void
+    {
+        $aliasPath = $this->tmp . '/alias';
+        \file_put_contents($aliasPath, 'i am a file, not a directory');
+
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($result->status, LinkStatus::Failed);
+        Assert::true(\is_file($aliasPath), 'regular file must be left untouched');
+    }
+
+    public function missingTargetFails(): void
+    {
+        $result = $this->linker()->link(
+            Path::create($this->tmp . '/alias'),
+            Path::create($this->tmp . '/does-not-exist'),
+        );
+
+        Assert::same($result->status, LinkStatus::Failed);
+        Assert::true(
+            $result->reason !== null && \str_contains($result->reason, 'target directory does not exist'),
+            'reason should mention the missing target; got: ' . ($result->reason ?? 'null'),
+        );
+    }
+
+    public function dryRunReportsWouldCreateWithoutWriting(): void
+    {
+        $aliasPath = $this->tmp . '/alias';
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target(), dryRun: true);
+
+        Assert::same($result->status, LinkStatus::WouldCreate);
+        Assert::false(\file_exists($aliasPath), 'dry-run must not create the link');
+        Assert::false($this->resolvesToTarget($aliasPath));
+    }
+
+    public function dryRunStillReportsCollisionsWithExistingDirectory(): void
+    {
+        // The state-matrix collisions in §4.2 are reported the same way
+        // in dry-run and normal mode — the user can't tell from a dry-run
+        // alone whether the conflict has been resolved.
+        $aliasPath = $this->tmp . '/alias';
+        \mkdir($aliasPath, 0o777, true);
+
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target(), dryRun: true);
+
+        Assert::same($result->status, LinkStatus::Failed);
+    }
+
+    public function createsParentDirectoryWhenMissing(): void
+    {
+        // Aliases inside a not-yet-existing parent (e.g. first-time
+        // `.config/agents/skills`) should not require the user to mkdir
+        // the parent manually. SyncEngine does this for the target, the
+        // linker matches that behaviour for aliases.
+        $aliasPath = $this->tmp . '/nested/parent/alias';
+        $result = $this->linker()->link(Path::create($aliasPath), $this->target());
+
+        Assert::same($result->status, LinkStatus::Created);
+        Assert::true(\is_dir($this->tmp . '/nested/parent'));
+        Assert::true($this->resolvesToTarget($aliasPath));
+    }
+
+    private function linker(): SymlinkLinker
+    {
+        return new SymlinkLinker();
+    }
+
+    private function target(): Path
+    {
+        return Path::create($this->tmp . '/target');
+    }
+
+    /**
+     * Returns `true` when `$path` (a junction, symlink, or whatever the
+     * platform produced) resolves to the same canonical filesystem path
+     * as `<tmp>/target`. A behavioural check — independent of
+     * `is_link` / `readlink` quirks across PHP builds and platforms.
+     */
+    private function resolvesToTarget(string $path): bool
+    {
+        $resolved = \realpath($path);
+        $expectedTarget = \realpath($this->tmp . '/target');
+        if ($resolved === false || $expectedTarget === false) {
+            return false;
+        }
+
+        return \DIRECTORY_SEPARATOR === '\\'
+            ? \strcasecmp($resolved, $expectedTarget) === 0
+            : $resolved === $expectedTarget;
+    }
+}

--- a/tests/Unit/Sync/SyncPlannerTest.php
+++ b/tests/Unit/Sync/SyncPlannerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Tests\Unit\Sync;
 
 use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\SyncOptions;
 use LLM\Skills\Config\TrustedVendors;
@@ -12,6 +13,7 @@ use LLM\Skills\Config\VendorConfig;
 use LLM\Skills\Config\VendorPattern;
 use LLM\Skills\Sync\SyncPlanner;
 use Testo\Assert;
+use Testo\Expect;
 use Testo\Test;
 
 #[Test]
@@ -271,6 +273,131 @@ final class SyncPlannerTest
         Assert::same(
             $this->normalizePath((string) $plan->target),
             $this->normalizePath('/abs/skills'),
+        );
+    }
+
+    public function aliasesDefaultToEmptyListWhenNeitherConfigNorCliProvidesThem(): void
+    {
+        $plan = $this->planner()->plan(
+            donors: [],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same($plan->aliases, []);
+    }
+
+    public function aliasesFromProjectConfigAreResolvedAgainstProjectRoot(): void
+    {
+        $project = ProjectConfig::default()->withAliases(['.claude/skills', '.cursor/skills']);
+        $plan = $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->aliases), 2);
+        Assert::same(
+            $this->normalizePath((string) $plan->aliases[0]),
+            $this->normalizePath('/some/project/.claude/skills'),
+        );
+        Assert::same(
+            $this->normalizePath((string) $plan->aliases[1]),
+            $this->normalizePath('/some/project/.cursor/skills'),
+        );
+    }
+
+    public function absoluteAliasIsUsedAsIs(): void
+    {
+        // Absolute paths must not be joined to the project root, exactly
+        // like {@see SyncPlanner::resolveTarget()} treats them.
+        $project = ProjectConfig::default()->withAliases(['/abs/alias']);
+        $plan = $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(
+            $this->normalizePath((string) $plan->aliases[0]),
+            $this->normalizePath('/abs/alias'),
+        );
+    }
+
+    public function aliasOverrideReplacesProjectConfigEntirely(): void
+    {
+        // Passing `--alias` at all is an explicit takeover, never a merge —
+        // the planner must drop the project's aliases and use only the CLI list.
+        $project = ProjectConfig::default()->withAliases(['.claude/skills']);
+        $options = new SyncOptions(
+            packageFilters: [],
+            extraTrusted: [],
+            targetOverride: null,
+            interactive: false,
+            aliasOverrides: ['.cursor/skills'],
+        );
+        $plan = $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: $options,
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->aliases), 1);
+        Assert::same(
+            $this->normalizePath((string) $plan->aliases[0]),
+            $this->normalizePath('/some/project/.cursor/skills'),
+        );
+    }
+
+    public function aliasResolvingToTargetThrows(): void
+    {
+        // `./.claude/skills` and `.claude/skills` collapse to the same
+        // absolute path; the planner must catch the equality even though
+        // the raw strings differ from the configured target.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('alias');
+
+        $project = new ProjectConfig(
+            target: '.claude/skills',
+            trusted: TrustedVendors::empty(),
+            trustedReplace: false,
+            aliases: ['./.claude/skills'],
+        );
+        $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+    }
+
+    public function duplicateAliasesAfterResolutionThrow(): void
+    {
+        // `.claude/skills` and `./.claude/skills` are lexically distinct
+        // but collapse to the same absolute path. The mapper's lexical
+        // pass cannot tell — the planner's resolved-path pass must.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('duplicates');
+
+        $project = ProjectConfig::default()->withAliases([
+            '.claude/skills',
+            './.claude/skills',
+        ]);
+        $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
         );
     }
 

--- a/tests/Unit/Sync/SyncPlannerTest.php
+++ b/tests/Unit/Sync/SyncPlannerTest.php
@@ -254,12 +254,15 @@ final class SyncPlannerTest
         );
     }
 
-    public function absoluteTargetOverrideIsUsedAsIs(): void
+    public function absoluteTargetInsideProjectRootIsAccepted(): void
     {
+        // Absolute paths are honoured as-is, *but* they must still
+        // resolve inside the project root. A path that happens to be
+        // expressed absolutely yet lives under the project is fine.
         $options = new SyncOptions(
             packageFilters: [],
             extraTrusted: [],
-            targetOverride: '/abs/skills',
+            targetOverride: '/some/project/abs/skills',
             interactive: false,
         );
         $plan = $this->planner()->plan(
@@ -272,7 +275,54 @@ final class SyncPlannerTest
 
         Assert::same(
             $this->normalizePath((string) $plan->target),
-            $this->normalizePath('/abs/skills'),
+            $this->normalizePath('/some/project/abs/skills'),
+        );
+    }
+
+    public function absoluteTargetOutsideProjectRootIsRejected(): void
+    {
+        // Footgun guard: a CLI `--target=/etc/passwd` or a typo in
+        // composer.json must not be able to direct writes outside the
+        // project tree. Symmetric with the donor-side `source` escape
+        // check ({@see \LLM\Skills\Config\Mapper\VendorConfigMapper}).
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('outside the project root');
+
+        $options = new SyncOptions(
+            packageFilters: [],
+            extraTrusted: [],
+            targetOverride: '/etc/passwd',
+            interactive: false,
+        );
+        $this->planner()->plan(
+            donors: [],
+            project: ProjectConfig::default(),
+            options: $options,
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+    }
+
+    public function targetWithDotDotEscapeIsRejected(): void
+    {
+        // Relative paths that collapse to a location outside the
+        // project root are caught after Path normalises the `..`
+        // segments. The error names both the raw value and the
+        // resolved location so the user can find the entry.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('outside the project root');
+
+        $project = new ProjectConfig(
+            target: '../escape',
+            trusted: TrustedVendors::empty(),
+            trustedReplace: false,
+        );
+        $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
         );
     }
 
@@ -311,11 +361,12 @@ final class SyncPlannerTest
         );
     }
 
-    public function absoluteAliasIsUsedAsIs(): void
+    public function absoluteAliasInsideProjectRootIsAccepted(): void
     {
         // Absolute paths must not be joined to the project root, exactly
-        // like {@see SyncPlanner::resolveTarget()} treats them.
-        $project = ProjectConfig::default()->withAliases(['/abs/alias']);
+        // like {@see SyncPlanner::resolveTarget()} treats them — and
+        // they must still live inside the project tree.
+        $project = ProjectConfig::default()->withAliases(['/some/project/abs/alias']);
         $plan = $this->planner()->plan(
             donors: [],
             project: $project,
@@ -326,7 +377,41 @@ final class SyncPlannerTest
 
         Assert::same(
             $this->normalizePath((string) $plan->aliases[0]),
-            $this->normalizePath('/abs/alias'),
+            $this->normalizePath('/some/project/abs/alias'),
+        );
+    }
+
+    public function absoluteAliasOutsideProjectRootIsRejected(): void
+    {
+        // Same containment guard as for `target`. Aliases create
+        // junctions/symlinks, so a path outside the project tree
+        // would expose arbitrary filesystem locations through the
+        // project's own directory structure.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('outside the project root');
+
+        $project = ProjectConfig::default()->withAliases(['/tmp/escape']);
+        $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+    }
+
+    public function aliasWithDotDotEscapeIsRejected(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('outside the project root');
+
+        $project = ProjectConfig::default()->withAliases(['../escape']);
+        $this->planner()->plan(
+            donors: [],
+            project: $project,
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
         );
     }
 


### PR DESCRIPTION
Closes #3.

## What this PR does

Adds `aliases` to `extra.skills` and a matching `--alias=PATH` CLI flag.
Each alias is created as a junction (Windows) or symlink (POSIX) pointing
at the single real `target` directory:

```jsonc
{
  "extra": {
    "skills": {
      "target":  ".agents/skills",
      "aliases": [".claude/skills", ".cursor/skills"]
    }
  }
}
```

After `composer skills:update`:
- `.agents/skills/` — real directory, skills copied here.
- `.claude/skills`, `.cursor/skills` — OS-level mirrors of the real
  directory. Reads through any path see the same files.

CLI:
```bash
composer skills:update --alias=.claude/skills --alias=.cursor/skills
```
Passing `--alias` at all replaces project `aliases` entirely (symmetric
with `--target`'s takeover semantics — no merging).

## Why this shape, and not the issue's proposal

The issue proposed an `agents` object keyed by agent name, each entry
carrying its own `target` + `mode: copy|symlink`:

```jsonc
"agents": {
  "claude":  { "target": ".claude/skills", "mode": "symlink" },
  "cursor":  { "target": ".cursor/skills", "mode": "copy"    },
  "shared":  { "target": ".agents/skills", "mode": "copy"    }
}
```

That model is more general but, in practice, opens problems the issue
itself flagged as open questions:

1. **Multi-copy + symlinks is ambiguous.** "Symlink points to which
   copy?" The proposed shape allows arbitrary combinations but does not
   answer this — and per-skill routing (this donor → this target) is
   not in scope either, so the freedom buys nothing real.
2. **Per-agent conflict semantics get foggy.** With one target the
   current global conflict check is the right answer; with multiple
   copy targets you need to decide whether two donors with the same
   skill name colliding into different targets is "fine" or "still a
   conflict", and either choice surprises someone.
3. **The real, common case is "one canonical place + N aliases".** In
   that case the agent name is just a label — it adds nothing the path
   doesn't already carry. Naming each alias forces busywork on the
   user and adds no value the path itself doesn't already convey.

So the model here is intentionally narrower: **exactly one real copy
target + zero or more mirror paths**. It covers the issue's stated use
case ("expose the same skills to several agents at once") without
inventing routing, per-target conflict policies, or a parallel naming
layer. If a real multi-copy use case shows up later, this shape
extends cleanly — but we're not paying for it today.

## Surface changes

### `extra.skills` config

| Key       | Type     | Default | Notes                                    |
|-----------|----------|---------|------------------------------------------|
| `aliases` | string[] | `[]`    | Mirror paths pointing at `target`.       |

Validation rejects (fatal, like any malformed `extra.skills`):
- Not a list of non-empty strings.
- An alias lexically equal to `target` (`\\` vs `/`, trailing slash
  normalised) or to another alias.

The planner additionally rejects aliases that **collapse** to the same
absolute path as `target` (or each other) after resolution against
`getcwd()` — catches `./.claude/skills` vs `.claude/skills` style
mistakes.

### CLI

- `--alias=PATH` on `skills:update`, repeatable.
- Present at all → replaces `extra.skills.aliases` for that run.
  No merging.

### `skills:show`

Two-line header at the top; the `Aliases:` line is omitted when there
are none, so the common single-target output is unchanged:

```
Target:  D:/project/.agents/skills
Aliases: D:/project/.claude/skills, D:/project/.cursor/skills [drift: → /old/path]
```

`[drift: → X]` appears inline next to an alias that currently exists on
disk but resolves to a path other than `target`.

## Safety decisions (answering the issue's open questions)

The issue ended with three open questions. Our answers:

> Should `symlink` be allowed by default, or require an explicit opt-in?

Junctions/symlinks are the **whole feature**, so no opt-in switch. They
never leave the project root any more than `target` already could
(absolute paths are honoured today). On Windows we use **directory
junctions**, not symbolic links — junctions don't need
`SeCreateSymbolicLink`, so the feature works without admin/dev-mode.

> Should conflict detection run globally across all targets before
> writing anything?

Conflict detection is **unchanged**: global, runs once on the
enumerated skill list before any write. Because there is only one
target, there is no "across all targets" — the global check is the
right check.

> Should cleanup remove stale skills per target, or keep the current
> non-destructive merge?

**Non-destructive merge stays.** No cleanup. Removing an alias from
config leaves the existing junction/symlink on disk — documented as
manual cleanup. This matches every other "the plugin never deletes
user content" guarantee in the codebase.

## State matrix at the alias path

The linker applies this matrix per alias, before creating anything:

| Existing state                  | Action                                                |
|---------------------------------|-------------------------------------------------------|
| Does not exist                  | Create junction/symlink, status `Created`.            |
| Link/junction → target          | No-op, status `AlreadyCorrect`.                       |
| Link/junction → elsewhere       | `Failed` — never silently retarget the user's link.   |
| Real directory                  | `Failed` — never wipe user content.                   |
| Regular file                    | `Failed`.                                             |

Any `Failed` outcome: a one-line `[link-failed]` is printed to stderr
and the run exits non-zero. Other aliases in the same run are still
processed so the user sees the full failure list in one pass — this is
explicit policy, not a coincidence; CI would otherwise miss broken
mirrors silently. Skills already copied into `target` stay there
(non-destructive).

Cross-volume junctions on Windows are also `Failed` — we do not
silently degrade to a copy (would multiply bytes on disk without the
user asking).

## Backward compatibility

- `extra.skills.target` as a string — identical behaviour, no
  normalisation, no shim.
- `aliases` defaults to `[]` — every existing project keeps working
  unchanged.
- New CLI flag `--alias=PATH` is purely additive; `--target=PATH` is
  unchanged.

No 2.0 bump.

## Out of scope

- Multiple **real** copy targets. Not enough demand to justify the
  conflict/reporting complexity; `cp -r` in CI covers the rare case.
- Per-alias routing (subset of skills mirrored to a given alias).
- Pruning / cleanup mode for stale aliases or target.
- Migration helper to convert an existing real `.claude/skills` dir
  into an alias. Manual: rm, re-run.
- Pinning aliases inside the project root. `target` already accepts
  arbitrary paths; aliases inherit that.

## Tests

- Unit, mapper (`ProjectConfigMapperTest`): 10 cases — defaults,
  validation, lexical equality with target, duplicates.
- Unit, planner (`SyncPlannerTest`): 6 cases — relative/absolute path
  resolution, CLI override total replacement, post-resolution
  duplicate/equal-to-target detection.
- Unit, linker (`SymlinkLinkerTest`, new): 10 cases — every row of the
  §4.2 state matrix, dry-run, parent-dir auto-creation.
- Unit, formatter (`ReportFormatterTest`): 3 cases — header omission,
  comma-rendering, drift marker.
- Acceptance (`SkillsSyncTest`): 8 cases end-to-end via
  `composer skills:update` — link created, contents visible through
  alias, idempotence, CLI override, output line, pre-existing real
  directory aborts the run with content preserved, alias-equal-to-target
  rejected, dry-run does not touch disk.

242 tests total, psalm clean, code style clean.

## Notable production code fixes the tests forced

A few Windows-specific quirks surfaced while writing the linker tests
and are folded into this PR:

- **Forward-slash separators on Windows broke `is_dir`/`is_link` for
  NTFS junctions.** `Internal\Path` normalises to `/` but PHP's stat
  functions disagree with that on junctions specifically. The linker
  now converts to native separators once at entry and operates on a
  single form internally.
- **Stat cache stalls between two `link()` calls in the same process.**
  After `mklink /J` runs out-of-process, PHP's cache still reports
  "does not exist" on the alias path. `clearstatcache(true, $path)` at
  the top of each `link()` call.
- **`is_dir` returns false on NTFS junctions in some PHP builds.**
  Junction detection now goes through realpath (junction's realpath
  escapes the parent directory) before checking `is_dir`, so a
  junction-shaped alias is never misclassified as a "real directory"
  and rejected.
