### PR TITLE
External `skills.json` config, `skills:init` command, and donor-provider architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ composer skills:show
 composer skills:update
 ```
 
-Project-level settings (`extra.skills.target`, `trusted`, `discovery`) are still read from the
-**consumer project's** `composer.json`.
+Project-level settings (`target`, `trusted`, `discovery`, …) are read from the consumer
+project's `skills.json` when present, falling back to the legacy inline `extra.skills` block
+in `composer.json` otherwise. See [External config (`skills.json`)](#external-config-skillsjson)
+for the precedence rules and the auto-migration that moves inline blocks into the
+external file on the first write-mode command.
 
 
 ## Commands
@@ -88,8 +91,8 @@ bootstraps an external [`skills.json`](#external-config-skillsjson) at the proje
 | Option                | Where  | Description                                                                                                                                                        |
 |-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<package>...`        | both   | Restrict to matching donors. Exact (`acme/foo`) or wildcard (`acme/*`, `*`). Listed packages are treated as **trusted** for this run (see [Trust](#trust)).        |
-| `--target=PATH`, `-t` | both   | Override `extra.skills.target`.                                                                                                                                    |
-| `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces `extra.skills.aliases` entirely. See [Aliases](#aliases). |
+| `--target=PATH`, `-t` | both   | Override the configured target directory, regardless of whether it came from `skills.json` or inline `extra.skills.target`.                                        |
+| `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces the configured aliases entirely. See [Aliases](#aliases). |
 | `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                                  |
 | `--discovery`         | both   | Include packages that ship a `skills/` directory but do not declare `extra.skills`.                                                                                |
 | `--dry-run`           | update | Print actions; no files written.                                                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -39,18 +39,19 @@ Allow the plugin to run:
 { "config": { "allow-plugins": { "llm/skills": true } } }
 ```
 
-(Optional) auto-sync on every `composer install` / `update` — opt in once:
+Auto-sync after every `composer install` / `update` is **on by default** — you don't have to
+configure anything to get fresh skills after running Composer. To opt out:
 
 ```jsonc
 {
   "extra": {
-    "skills": { "auto-sync": true }
+    "skills": { "auto-sync": false }
   }
 }
 ```
 
-The plugin then runs `skills:update` for you after `composer install` / `update`.
-`composer install --no-scripts` still suppresses the auto-run.
+(or, in a `skills.json`, the same `"auto-sync": false`.) `composer install --no-scripts`
+also suppresses the auto-run for a single invocation without changing the config.
 
 ### Global installation
 
@@ -84,14 +85,14 @@ every donor, the per-skill sync status, and what is being skipped and why. `skil
 bootstraps an external [`skills.json`](#external-config-skillsjson) at the project root and
 (when `composer.json` carries inline project keys) migrates them out.
 
-| Option                | Where  | Description                                                                                                                                                 |
-|-----------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<package>...`        | both   | Restrict to matching donors. Exact (`acme/foo`) or wildcard (`acme/*`, `*`). Listed packages are treated as **trusted** for this run (see [Trust](#trust)). |
-| `--target=PATH`, `-t` | both   | Override `extra.skills.target`.                                                                                                                             |
+| Option                | Where  | Description                                                                                                                                                        |
+|-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<package>...`        | both   | Restrict to matching donors. Exact (`acme/foo`) or wildcard (`acme/*`, `*`). Listed packages are treated as **trusted** for this run (see [Trust](#trust)).        |
+| `--target=PATH`, `-t` | both   | Override `extra.skills.target`.                                                                                                                                    |
 | `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces `extra.skills.aliases` entirely. See [Aliases](#aliases). |
-| `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                           |
-| `--discovery`         | both   | Include packages that ship a `skills/` directory but do not declare `extra.skills`.                                                                         |
-| `--dry-run`           | update | Print actions; no files written.                                                                                                                            |
+| `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                                  |
+| `--discovery`         | both   | Include packages that ship a `skills/` directory but do not declare `extra.skills`.                                                                                |
+| `--dry-run`           | update | Print actions; no files written.                                                                                                                                   |
 
 Short flag `-d` for `--discovery` is registered only by the standalone `bin/skills` binary;
 inside Composer it is reserved for `--working-dir`.
@@ -160,20 +161,20 @@ All settings live under `extra.skills` in the consumer project's `composer.json`
       "trusted": ["acme/*", "myorg/skills-internal"],
       "trusted-replace": false,
       "discovery": false,
-      "auto-sync": false
+      "auto-sync": true
     }
   }
 }
 ```
 
-| Key               | Type     | Default          | Description                                                                              |
-|-------------------|----------|------------------|------------------------------------------------------------------------------------------|
-| `target`          | string   | `.agents/skills` | Destination directory, relative to the project root.                                     |
-| `aliases`         | string[] | `[]`             | Mirror paths (junction/symlink) pointing at `target`. See [Aliases](#aliases).           |
-| `trusted`         | string[] | `[]`             | Extra trust patterns (see [Trust](#trust)).                                              |
-| `trusted-replace` | bool     | `false`          | When `true`, the built-in trust list and direct-dependency auto-trust are both ignored.  |
-| `discovery`       | bool     | `false`          | When `true`, auto-discovery is on by default (CLI overrides).                            |
-| `auto-sync`       | bool     | `false`          | When `true`, run `skills:update` after `composer install` / `update`.                    |
+| Key               | Type     | Default          | Description                                                                             |
+|-------------------|----------|------------------|-----------------------------------------------------------------------------------------|
+| `target`          | string   | `.agents/skills` | Destination directory, relative to the project root.                                    |
+| `aliases`         | string[] | `[]`             | Mirror paths (junction/symlink) pointing at `target`. See [Aliases](#aliases).          |
+| `trusted`         | string[] | `[]`             | Extra trust patterns (see [Trust](#trust)).                                             |
+| `trusted-replace` | bool     | `false`          | When `true`, the built-in trust list and direct-dependency auto-trust are both ignored. |
+| `discovery`       | bool     | `false`          | When `true`, auto-discovery is on by default (CLI overrides).                           |
+| `auto-sync`       | bool     | `true`           | Run `skills:update` after `composer install` / `update`. Set to `false` to opt out.     |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
 directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent projects.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ Project-level settings (`extra.skills.target`, `trusted`, `discovery`) are still
 ```
 composer skills:update [<package>...] [options]   # alias: skills:u
 composer skills:show   [<package>...] [options]   # alias: skills:s
+composer skills:init   [options]                  # alias: skills:i
 ```
 
 `skills:update` copies skills into the target directory. `skills:show` is read-only — it lists
-every donor, the per-skill sync status, and what is being skipped and why.
+every donor, the per-skill sync status, and what is being skipped and why. `skills:init`
+bootstraps an external [`skills.json`](#external-config-skillsjson) at the project root and
+(when `composer.json` carries inline project keys) migrates them out.
 
 | Option                | Where  | Description                                                                                                                                                 |
 |-----------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -103,6 +106,7 @@ composer skills:update --discovery          # also include packages without extr
 composer skills:update --alias=.claude/skills   # mirror target via a junction/symlink
 composer skills:update --dry-run            # preview, write nothing
 composer skills:show                        # inspect: per-skill status, what is skipped
+composer skills:init                        # create skills.json (migrating inline keys)
 ```
 
 ## Shipping skills (vendor side)
@@ -176,6 +180,75 @@ directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent
 
 A malformed `extra.skills` in the project is **fatal**. The same block in a *donor* package is
 skipped with a `-v` warning — one bad vendor never blocks the rest.
+
+
+## External config (`skills.json`)
+
+Project-level configuration can also live in a dedicated **`skills.json`** at the project root,
+side-by-side with `composer.json`. Same fields as `extra.skills`, but free from the noise of
+Composer's own config and with first-class JSON-schema support in editors.
+
+```jsonc
+// <project-root>/skills.json
+{
+  "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+  "target": ".agents/skills",
+  "aliases": [".claude/skills", ".cursor/skills"],
+  "trusted": ["acme/*"],
+  "discovery": true,
+  "auto-sync": true
+}
+```
+
+### Precedence
+
+The plugin picks the project config from exactly one source:
+
+1. If `skills.json` exists at the project root → use it. Inline `extra.skills` project keys in
+   `composer.json` are ignored (a `-v` notice lists which ones were shadowed). Donor-side
+   `extra.skills.source` on the same package keeps working — it is not project config.
+2. Otherwise → fall back to `extra.skills` in `composer.json` (the 1.x contract, unchanged).
+
+There is no merging across the two sources. Once `skills.json` exists, it owns the project
+config in full. Donor discovery (the vendor walk through `composer.json`'s `require` /
+`require-dev`) is independent — `composer.json` keeps feeding the donor list either way.
+
+### Strict shape
+
+`skills.json` is **strict**:
+
+- Unknown top-level keys fail the run.
+- `$schema` is the only metadata key accepted (and silently stripped from the parsed config).
+- A nested `config-file` key is rejected — the file is the config, not a pointer to one.
+
+The PHP mapper is the authoritative validator at runtime; the
+[`resources/skills.schema.json`](resources/skills.schema.json) document mirrors it for IDE /
+editor support.
+
+### `skills:init` — bootstrap and migrate
+
+```bash
+composer skills:init                  # create skills.json (and migrate inline keys if any)
+composer skills:init --force          # overwrite an existing skills.json
+composer skills:init --path=PATH      # non-default location (won't be auto-discovered)
+```
+
+In a project with `composer.json`:
+
+- Reads the current `extra.skills` block (refusing if it is malformed — fix the bug, then init).
+- Writes the project-level keys into `skills.json` with a `$schema` pointer.
+- Removes the migrated keys from `extra.skills` via Composer's `JsonManipulator`, preserving
+  formatting, key order, and comments.
+- Leaves donor-side `extra.skills.source` (if any) untouched — a package can be both a donor
+  and a consumer.
+
+In a directory **without** `composer.json` (standalone mode), `skills:init` just writes a
+stub `skills.json` with the `$schema` pointer; nothing else is touched.
+
+`skills:init` refuses to overwrite an existing `skills.json` unless `--force` is passed. The
+canonical filename is `skills.json` at the project root — using `--path=PATH` to put the file
+elsewhere creates it, but subsequent `skills:update` / `skills:show` will not discover it (a
+notice is printed when this happens).
 
 
 ## Aliases

--- a/README.md
+++ b/README.md
@@ -40,18 +40,16 @@ Allow the plugin to run:
 ```
 
 Auto-sync after every `composer install` / `update` is **on by default** — you don't have to
-configure anything to get fresh skills after running Composer. To opt out:
+configure anything to get fresh skills after running Composer. To opt out, drop a
+`skills.json` at the project root:
 
 ```jsonc
-{
-  "extra": {
-    "skills": { "auto-sync": false }
-  }
-}
+// <project-root>/skills.json
+{ "auto-sync": false }
 ```
 
-(or, in a `skills.json`, the same `"auto-sync": false`.) `composer install --no-scripts`
-also suppresses the auto-run for a single invocation without changing the config.
+`composer install --no-scripts` also suppresses the auto-run for a single invocation without
+changing the config.
 
 ### Global installation
 
@@ -68,11 +66,9 @@ composer skills:show
 composer skills:update
 ```
 
-Project-level settings (`target`, `trusted`, `discovery`, …) are read from the consumer
-project's `skills.json` when present, falling back to the legacy inline `extra.skills` block
-in `composer.json` otherwise. See [External config (`skills.json`)](#external-config-skillsjson)
-for the precedence rules and the auto-migration that moves inline blocks into the
-external file on the first write-mode command.
+Project-level settings (`target`, `trusted`, `discovery`, …) live in the consumer project's
+`skills.json` at the project root. See [Project configuration](#project-configuration) for the
+full reference.
 
 
 ## Commands
@@ -85,13 +81,13 @@ composer skills:init   [options]                  # alias: skills:i
 
 `skills:update` copies skills into the target directory. `skills:show` is read-only — it lists
 every donor, the per-skill sync status, and what is being skipped and why. `skills:init`
-bootstraps an external [`skills.json`](#external-config-skillsjson) at the project root and
-(when `composer.json` carries inline project keys) migrates them out.
+bootstraps a [`skills.json`](#project-configuration) at the project root and (when
+`composer.json` carries legacy inline project keys) migrates them out.
 
 | Option                | Where  | Description                                                                                                                                                        |
 |-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<package>...`        | both   | Restrict to matching donors. Exact (`acme/foo`) or wildcard (`acme/*`, `*`). Listed packages are treated as **trusted** for this run (see [Trust](#trust)).        |
-| `--target=PATH`, `-t` | both   | Override the configured target directory, regardless of whether it came from `skills.json` or inline `extra.skills.target`.                                        |
+| `--target=PATH`, `-t` | both   | Override the configured target directory for this run.                                                                                                             |
 | `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces the configured aliases entirely. See [Aliases](#aliases). |
 | `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                                  |
 | `--discovery`         | both   | Include packages that ship a `skills/` directory but do not declare `extra.skills`.                                                                                |
@@ -153,20 +149,20 @@ After `skills:update`, the consumer project gets:
 
 ## Project configuration
 
-All settings live under `extra.skills` in the consumer project's `composer.json`:
+Project-level settings live in a dedicated **`skills.json`** at the project root. The file
+is the single source of truth for everything the plugin does in your project — what to copy,
+where to put it, who to trust, whether to auto-sync.
 
 ```jsonc
+// <project-root>/skills.json
 {
-  "extra": {
-    "skills": {
-      "target": ".agents/skills",
-      "aliases": [".claude/skills", ".cursor/skills"],
-      "trusted": ["acme/*", "myorg/skills-internal"],
-      "trusted-replace": false,
-      "discovery": false,
-      "auto-sync": true
-    }
-  }
+  "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+  "target": ".agents/skills",
+  "aliases": [".claude/skills", ".cursor/skills"],
+  "trusted": ["acme/*", "myorg/skills-internal"],
+  "trusted-replace": false,
+  "discovery": false,
+  "auto-sync": true
 }
 ```
 
@@ -182,58 +178,8 @@ All settings live under `extra.skills` in the consumer project's `composer.json`
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
 directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent projects.
 
-A malformed `extra.skills` in the project is **fatal**. The same block in a *donor* package is
-skipped with a `-v` warning — one bad vendor never blocks the rest.
-
-
-## External config (`skills.json`)
-
-Project-level configuration can also live in a dedicated **`skills.json`** at the project root,
-side-by-side with `composer.json`. Same fields as `extra.skills`, but free from the noise of
-Composer's own config and with first-class JSON-schema support in editors.
-
-```jsonc
-// <project-root>/skills.json
-{
-  "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
-  "target": ".agents/skills",
-  "aliases": [".claude/skills", ".cursor/skills"],
-  "trusted": ["acme/*"],
-  "discovery": true,
-  "auto-sync": true
-}
-```
-
-### Precedence and auto-migration
-
-`skills.json` is the **only** long-lived project-config artifact. Inline `extra.skills` is a
-transitional state: the first time a write-mode command (`skills:update`, `skills:init`, or
-the `post-update-cmd` auto-sync hook) runs in a project that still has the inline block, the
-plugin moves the project-level keys out of `composer.json` and into a fresh `skills.json`.
-After that, `composer.json` is left alone forever.
-
-**Write-mode commands** (`skills:update`, `skills:init`, `post-update-cmd`):
-
-1. If `skills.json` exists at the project root → use it. `composer.json` is not touched.
-2. Otherwise, if `extra.skills` has project keys → auto-migrate: write `skills.json`, strip
-   the keys from `composer.json` via `JsonManipulator` (formatting preserved, donor-side
-   `extra.skills.source` stays put), then proceed with the freshly-written config. A
-   `[migrate] moved extra.skills → skills.json (...)` line is printed.
-3. Otherwise → defaults.
-
-**Read-only commands** (`skills:show`, `post-install-cmd`):
-
-1. If `skills.json` exists → use it. `composer.json` is not touched.
-2. Otherwise, read inline `extra.skills` (legacy 1.x behaviour) and emit a one-line
-   `[notice]` telling the user to run `skills:update` for the migration.
-
-The asymmetry is deliberate. `composer install` is a fetch step; a silent `composer.json`
-rewrite there would be a surprise. The other surfaces (`skills:update` and explicit
-`skills:init` runs) are write-mode by nature, so cleaning up the legacy artifact along the
-way is in character.
-
-There is no `--no-migrate` flag. If you need the old read-only behaviour for one run, use
-`skills:show` or `composer install --no-scripts`.
+The fastest way to get a valid `skills.json` is `composer skills:init` (see below). Bootstrap
+it once and commit it alongside `composer.json`.
 
 ### Strict shape
 
@@ -245,9 +191,10 @@ There is no `--no-migrate` flag. If you need the old read-only behaviour for one
 
 The PHP mapper is the authoritative validator at runtime; the
 [`resources/skills.schema.json`](resources/skills.schema.json) document mirrors it for IDE /
-editor support.
+editor support. A malformed `skills.json` is **fatal**; a malformed `extra.skills` block in a
+*donor* package is skipped with a `-v` warning so one bad vendor never blocks the rest.
 
-### `skills:init` — explicit fast-path
+### `skills:init` — bootstrap and migrate
 
 ```bash
 composer skills:init                  # migrate eagerly (same effect as a future skills:update)
@@ -273,6 +220,14 @@ Refusal semantics:
 auto-discover `skills.json` at the project root, so a non-default `--path` also emits a
 notice telling the user to move the file.
 
+> [!NOTE]
+> **Upgrading from inline `extra.skills`?** Early versions of `llm/skills` kept project
+> settings under `extra.skills` in `composer.json`. That surface is deprecated. Starting with
+> **1.3.0**, the first write-mode run (`skills:update`, `skills:init`, or the
+> `post-update-cmd` auto-sync hook) moves the project keys into `skills.json` automatically
+> and prints a `[migrate]` line. `skills:show` and `post-install-cmd` stay read-only and just
+> emit a one-line notice. Donor-side `extra.skills.source` is never touched.
+
 
 ## Aliases
 
@@ -289,13 +244,10 @@ OS-level mirrors:
   refused with a non-zero exit; the plugin never silently degrades to a copy.
 
 ```jsonc
+// <project-root>/skills.json
 {
-  "extra": {
-    "skills": {
-      "target":  ".agents/skills",
-      "aliases": [".claude/skills", ".cursor/skills"]
-    }
-  }
+  "target":  ".agents/skills",
+  "aliases": [".claude/skills", ".cursor/skills"]
 }
 ```
 
@@ -310,7 +262,7 @@ through any path see the same files.
   directory manually and re-run — the plugin never destroys user content.
 - **Stale aliases not pruned.** Removing an entry from `aliases` does not delete the
   junction/symlink on disk. Clean it up manually if needed.
-- **CLI override is total.** `--alias=PATH` (repeatable) replaces `extra.skills.aliases`
+- **CLI override is total.** `--alias=PATH` (repeatable) replaces the configured `aliases`
   for that run — there is no merging.
 
 ```bash
@@ -339,11 +291,12 @@ prompt-injection payload, so the plugin does not copy skills from a donor unless
 Effective trust list:
 
 ```
-builtin ∪ project.extra.skills.trusted ∪ --trust=<pattern> ∪ direct-deps
+builtin ∪ project.trusted ∪ --trust=<pattern> ∪ direct-deps
 ```
 
-`direct-deps` is the set of packages declared under `require` and `require-dev` in the
-consumer's root `composer.json`. Setting `trusted-replace: true` drops both implicit sources
+`project.trusted` is the `trusted` array from `skills.json`. `direct-deps` is the set of
+packages declared under `require` and `require-dev` in the consumer's root `composer.json`.
+Setting `trusted-replace: true` drops both implicit sources
 (`builtin` and `direct-deps`) from the union, leaving only project trust and `--trust=` —
 the explicit-only mode.
 
@@ -379,7 +332,7 @@ When a package does not declare `extra.skills` but ships a `skills/` directory a
 root, `llm/skills` can still pick up the skills inside. Opt in one of three ways:
 
 - `--discovery` flag on the command line (for a single run);
-- `extra.skills.discovery: true` in the project (always on);
+- `"discovery": true` in `skills.json` (always on);
 - Name the package as a positional argument (implicit, per-package — see [Shortcuts](#shortcuts)).
 
 ```

--- a/README.md
+++ b/README.md
@@ -200,18 +200,36 @@ Composer's own config and with first-class JSON-schema support in editors.
 }
 ```
 
-### Precedence
+### Precedence and auto-migration
 
-The plugin picks the project config from exactly one source:
+`skills.json` is the **only** long-lived project-config artifact. Inline `extra.skills` is a
+transitional state: the first time a write-mode command (`skills:update`, `skills:init`, or
+the `post-update-cmd` auto-sync hook) runs in a project that still has the inline block, the
+plugin moves the project-level keys out of `composer.json` and into a fresh `skills.json`.
+After that, `composer.json` is left alone forever.
 
-1. If `skills.json` exists at the project root → use it. Inline `extra.skills` project keys in
-   `composer.json` are ignored (a `-v` notice lists which ones were shadowed). Donor-side
-   `extra.skills.source` on the same package keeps working — it is not project config.
-2. Otherwise → fall back to `extra.skills` in `composer.json` (the 1.x contract, unchanged).
+**Write-mode commands** (`skills:update`, `skills:init`, `post-update-cmd`):
 
-There is no merging across the two sources. Once `skills.json` exists, it owns the project
-config in full. Donor discovery (the vendor walk through `composer.json`'s `require` /
-`require-dev`) is independent — `composer.json` keeps feeding the donor list either way.
+1. If `skills.json` exists at the project root → use it. `composer.json` is not touched.
+2. Otherwise, if `extra.skills` has project keys → auto-migrate: write `skills.json`, strip
+   the keys from `composer.json` via `JsonManipulator` (formatting preserved, donor-side
+   `extra.skills.source` stays put), then proceed with the freshly-written config. A
+   `[migrate] moved extra.skills → skills.json (...)` line is printed.
+3. Otherwise → defaults.
+
+**Read-only commands** (`skills:show`, `post-install-cmd`):
+
+1. If `skills.json` exists → use it. `composer.json` is not touched.
+2. Otherwise, read inline `extra.skills` (legacy 1.x behaviour) and emit a one-line
+   `[notice]` telling the user to run `skills:update` for the migration.
+
+The asymmetry is deliberate. `composer install` is a fetch step; a silent `composer.json`
+rewrite there would be a surprise. The other surfaces (`skills:update` and explicit
+`skills:init` runs) are write-mode by nature, so cleaning up the legacy artifact along the
+way is in character.
+
+There is no `--no-migrate` flag. If you need the old read-only behaviour for one run, use
+`skills:show` or `composer install --no-scripts`.
 
 ### Strict shape
 
@@ -225,30 +243,31 @@ The PHP mapper is the authoritative validator at runtime; the
 [`resources/skills.schema.json`](resources/skills.schema.json) document mirrors it for IDE /
 editor support.
 
-### `skills:init` — bootstrap and migrate
+### `skills:init` — explicit fast-path
 
 ```bash
-composer skills:init                  # create skills.json (and migrate inline keys if any)
+composer skills:init                  # migrate eagerly (same effect as a future skills:update)
 composer skills:init --force          # overwrite an existing skills.json
 composer skills:init --path=PATH      # non-default location (won't be auto-discovered)
 ```
 
-In a project with `composer.json`:
+`skills:init` is the explicit version of the migration that `skills:update` runs implicitly.
+It exists for two cases:
 
-- Reads the current `extra.skills` block (refusing if it is malformed — fix the bug, then init).
-- Writes the project-level keys into `skills.json` with a `$schema` pointer.
-- Removes the migrated keys from `extra.skills` via Composer's `JsonManipulator`, preserving
-  formatting, key order, and comments.
-- Leaves donor-side `extra.skills.source` (if any) untouched — a package can be both a donor
-  and a consumer.
+- Pre-`skills:update` setup — bootstrap `skills.json` before the first sync.
+- Standalone projects (no `composer.json` at cwd) — write a stub `skills.json` with the
+  `$schema` pointer so editors can pick up the schema; nothing else is touched.
 
-In a directory **without** `composer.json` (standalone mode), `skills:init` just writes a
-stub `skills.json` with the `$schema` pointer; nothing else is touched.
+Refusal semantics:
 
-`skills:init` refuses to overwrite an existing `skills.json` unless `--force` is passed. The
-canonical filename is `skills.json` at the project root — using `--path=PATH` to put the file
-elsewhere creates it, but subsequent `skills:update` / `skills:show` will not discover it (a
-notice is printed when this happens).
+- Refuses to overwrite an existing `skills.json` without `--force`.
+- Refuses if the inline `extra.skills` block is malformed — fix `composer.json` first, then
+  rerun.
+- Refuses if `--path` points at an existing non-file (a directory etc.) with a clear error.
+
+`--path=PATH` honours the project-root containment rule. Subsequent commands only
+auto-discover `skills.json` at the project root, so a non-default `--path` also emits a
+notice telling the user to move the file.
 
 
 ## Aliases

--- a/bin/skills
+++ b/bin/skills
@@ -46,6 +46,7 @@ if ('cli' !== PHP_SAPI) {
         new FactoryCommandLoader([
             'update' => static fn() => new \LLM\Skills\Console\Command\Sync(),
             'show' => static fn() => new \LLM\Skills\Console\Command\Show(),
+            'init' => static fn() => new \LLM\Skills\Console\Command\Init(),
         ]),
     );
     $application->setDefaultCommand('update', false);

--- a/composer.json
+++ b/composer.json
@@ -66,12 +66,6 @@
     "extra": {
         "class": "LLM\\Skills\\Composer\\SkillsPlugin",
         "skills": {
-            "aliases": [
-                ".claude/skills",
-                ".cursor/skills"
-            ],
-            "discovery": true,
-            "auto-sync": true
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -64,9 +64,7 @@
         }
     },
     "extra": {
-        "class": "LLM\\Skills\\Composer\\SkillsPlugin",
-        "skills": {
-        }
+        "class": "LLM\\Skills\\Composer\\SkillsPlugin"
     },
     "config": {
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -5066,16 +5066,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "9c862df890f7c833b1101ac5578ec4dcf199efb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/9c862df890f7c833b1101ac5578ec4dcf199efb5",
+                "reference": "9c862df890f7c833b1101ac5578ec4dcf199efb5",
                 "shasum": ""
             },
             "require": {
@@ -5124,7 +5124,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5144,20 +5144,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-25T12:39:52+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -5209,7 +5209,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5229,20 +5229,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
+                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
                 "shasum": ""
             },
             "require": {
@@ -5294,7 +5294,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5314,20 +5314,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-25T14:08:27+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "a0e0aca0368801ec79f8791dea9a7c12af527c93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/a0e0aca0368801ec79f8791dea9a7c12af527c93",
+                "reference": "a0e0aca0368801ec79f8791dea9a7c12af527c93",
                 "shasum": ""
             },
             "require": {
@@ -5374,7 +5374,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5394,20 +5394,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-25T12:12:52+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "3e851ffb42624b64b3b9ec234a0e2074b0f880e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/3e851ffb42624b64b3b9ec234a0e2074b0f880e3",
+                "reference": "3e851ffb42624b64b3b9ec234a0e2074b0f880e3",
                 "shasum": ""
             },
             "require": {
@@ -5454,7 +5454,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5474,7 +5474,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-25T11:50:50+00:00"
         },
         {
             "name": "symfony/process",
@@ -5808,16 +5808,16 @@
         },
         {
             "name": "testo/assert",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-testo/assert.git",
-                "reference": "a7c8d721203a1bb57d0026fc5d3c980d98cbaf91"
+                "reference": "8d4a10a75239876bac5a8d06d81cbbca2373dff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-testo/assert/zipball/a7c8d721203a1bb57d0026fc5d3c980d98cbaf91",
-                "reference": "a7c8d721203a1bb57d0026fc5d3c980d98cbaf91",
+                "url": "https://api.github.com/repos/php-testo/assert/zipball/8d4a10a75239876bac5a8d06d81cbbca2373dff1",
+                "reference": "8d4a10a75239876bac5a8d06d81cbbca2373dff1",
                 "shasum": ""
             },
             "require": {
@@ -5855,7 +5855,7 @@
                 "testo"
             ],
             "support": {
-                "source": "https://github.com/php-testo/assert/tree/0.1.3"
+                "source": "https://github.com/php-testo/assert/tree/0.1.4"
             },
             "funding": [
                 {
@@ -5863,7 +5863,7 @@
                     "type": "boosty"
                 }
             ],
-            "time": "2026-05-15T07:06:23+00:00"
+            "time": "2026-05-20T16:58:48+00:00"
         },
         {
             "name": "testo/bench",
@@ -5987,16 +5987,16 @@
         },
         {
             "name": "testo/bridge-symfony-console",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-testo/bridge-symfony-console.git",
-                "reference": "acf77543b65c3e377d0831158081cd9d5444d5de"
+                "reference": "e4ca3ac433ad6e50807c01b7768f7bd1dfe1ff71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-testo/bridge-symfony-console/zipball/acf77543b65c3e377d0831158081cd9d5444d5de",
-                "reference": "acf77543b65c3e377d0831158081cd9d5444d5de",
+                "url": "https://api.github.com/repos/php-testo/bridge-symfony-console/zipball/e4ca3ac433ad6e50807c01b7768f7bd1dfe1ff71",
+                "reference": "e4ca3ac433ad6e50807c01b7768f7bd1dfe1ff71",
                 "shasum": ""
             },
             "require": {
@@ -6035,7 +6035,7 @@
                 "testo"
             ],
             "support": {
-                "source": "https://github.com/php-testo/bridge-symfony-console/tree/0.1.2"
+                "source": "https://github.com/php-testo/bridge-symfony-console/tree/0.1.3"
             },
             "funding": [
                 {
@@ -6043,7 +6043,7 @@
                     "type": "boosty"
                 }
             ],
-            "time": "2026-05-05T20:58:37+00:00"
+            "time": "2026-05-20T12:15:43+00:00"
         },
         {
             "name": "testo/codecov",
@@ -6561,16 +6561,16 @@
         },
         {
             "name": "testo/testo",
-            "version": "0.10.11",
+            "version": "0.10.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-testo/testo.git",
-                "reference": "de522a0d978d1c352a9b2a9dc6b8f38c9bb908cd"
+                "reference": "a8d2fcf0bda2feb91e3056670a7332f2e5e183f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-testo/testo/zipball/de522a0d978d1c352a9b2a9dc6b8f38c9bb908cd",
-                "reference": "de522a0d978d1c352a9b2a9dc6b8f38c9bb908cd",
+                "url": "https://api.github.com/repos/php-testo/testo/zipball/a8d2fcf0bda2feb91e3056670a7332f2e5e183f8",
+                "reference": "a8d2fcf0bda2feb91e3056670a7332f2e5e183f8",
                 "shasum": ""
             },
             "require": {
@@ -6656,7 +6656,7 @@
                     "type": "boosty"
                 }
             ],
-            "time": "2026-05-18T13:41:21+00:00"
+            "time": "2026-05-20T12:17:43+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -6922,16 +6922,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
@@ -6947,7 +6947,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -6978,9 +6982,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2026-04-11T10:33:05+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         },
         {
             "name": "yiisoft/injector",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ecf4fe8f1613b2313c5ea36285bdc09",
+    "content-hash": "f6037413afda1383a9a94d81cbbf443c",
     "packages": [
         {
             "name": "internal/path",

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -48,8 +48,8 @@
         },
         "auto-sync": {
             "type": "boolean",
-            "description": "When true, the plugin runs skills:update automatically after every composer install/update via post-install-cmd / post-update-cmd. Suppressed by --no-scripts.",
-            "default": false
+            "description": "When true (default), the plugin runs skills:update automatically after every composer install/update via post-install-cmd / post-update-cmd. Suppressed by --no-scripts.",
+            "default": true
         }
     }
 }

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+    "title": "llm/skills project configuration",
+    "description": "Project-level configuration for the llm/skills Composer plugin, stored at <project-root>/skills.json. When present, this file shadows the inline extra.skills block in composer.json. See https://github.com/roxblnfk/skills for full documentation.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "Optional pointer to this schema for IDE/editor support. Ignored by the mapper."
+        },
+        "target": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Destination directory for synced skills, relative to the project root. Default: .agents/skills.",
+            "default": ".agents/skills"
+        },
+        "aliases": {
+            "type": "array",
+            "description": "Additional paths created as symlinks (POSIX) or junctions (Windows) pointing at the target. Each entry must be a non-empty string. No entry may equal target or duplicate another entry (after lexical normalisation).",
+            "items": {
+                "type": "string",
+                "minLength": 1
+            },
+            "uniqueItems": true,
+            "default": []
+        },
+        "trusted": {
+            "type": "array",
+            "description": "Packages or vendor patterns allowed to ship skills into this project. Each pattern is either an exact name like \"vendor/package\" or a wildcard like \"vendor/*\". Bare vendor names (no slash) are rejected.",
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[^/]+/[^/]+$"
+            },
+            "default": []
+        },
+        "trusted-replace": {
+            "type": "boolean",
+            "description": "When true, the project's trusted list completely replaces both the built-in trusted vendors and the implicit direct-dependency trust. Default: false (project list extends the implicit sources).",
+            "default": false
+        },
+        "discovery": {
+            "type": "boolean",
+            "description": "When true, packages without an explicit extra.skills.source block are still considered as donors if they ship a top-level skills/ directory. CLI --discovery overrides this.",
+            "default": false
+        },
+        "auto-sync": {
+            "type": "boolean",
+            "description": "When true, the plugin runs skills:update automatically after every composer install/update via post-install-cmd / post-update-cmd. Suppressed by --no-scripts.",
+            "default": false
+        }
+    }
+}

--- a/skills.json
+++ b/skills.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+    "aliases": [
+        ".claude/skills",
+        ".cursor/skills"
+    ],
+    "discovery": true,
+    "auto-sync": true
+}

--- a/src/Composer/Command/Init.php
+++ b/src/Composer/Command/Init.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Composer\Command;
+
+use Composer\Command\BaseCommand;
+use Internal\Path;
+use LLM\Skills\Console\InitCliDefinition;
+use LLM\Skills\Init\InitRunner;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Composer plugin entrypoint for `skills:init` (alias `skills:i`).
+ * Registered by {@see \LLM\Skills\Composer\CommandProvider}.
+ *
+ * Creates a `skills.json` file at the project root and, when a
+ * `composer.json` is present, migrates the inline `extra.skills`
+ * project keys into it (donor `extra.skills.source` is left in place).
+ *
+ * For the PHAR/binary entrypoint that bootstraps Composer manually,
+ * see {@see \LLM\Skills\Console\Command\Init}.
+ *
+ * @internal
+ */
+final class Init extends BaseCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        InitCliDefinition::apply($this, 'skills:init', ['skills:i']);
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $options = InitCliDefinition::buildOptions($input);
+        } catch (\InvalidArgumentException $e) {
+            $this->getIO()->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
+            return self::INVALID;
+        }
+
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new InitRunner())->run($projectRoot, $this->getIO(), $options);
+    }
+}

--- a/src/Composer/Command/Show.php
+++ b/src/Composer/Command/Show.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace LLM\Skills\Composer\Command;
 
 use Composer\Command\BaseCommand;
+use Internal\Path;
 use LLM\Skills\Console\ShowCliDefinition;
+use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Show\ShowRunner;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,6 +44,16 @@ final class Show extends BaseCommand
             return self::INVALID;
         }
 
-        return (new ShowRunner())->run($this->requireComposer(), $this->getIO(), $options);
+        $composer = $this->requireComposer();
+        $provider = new ComposerProvider($composer);
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new ShowRunner())->run(
+            $projectRoot,
+            $provider,
+            $provider->rootExtras(),
+            $this->getIO(),
+            $options,
+        );
     }
 }

--- a/src/Composer/Command/Sync.php
+++ b/src/Composer/Command/Sync.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace LLM\Skills\Composer\Command;
 
 use Composer\Command\BaseCommand;
+use Internal\Path;
 use LLM\Skills\Console\SyncCliDefinition;
+use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Sync\SyncRunner;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,6 +44,16 @@ final class Sync extends BaseCommand
             return self::INVALID;
         }
 
-        return (new SyncRunner())->run($this->requireComposer(), $this->getIO(), $options);
+        $composer = $this->requireComposer();
+        $provider = new ComposerProvider($composer);
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new SyncRunner())->run(
+            $projectRoot,
+            $provider,
+            $provider->rootExtras(),
+            $this->getIO(),
+            $options,
+        );
     }
 }

--- a/src/Composer/CommandProvider.php
+++ b/src/Composer/CommandProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Composer;
 
 use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
+use LLM\Skills\Composer\Command\Init;
 use LLM\Skills\Composer\Command\Show;
 use LLM\Skills\Composer\Command\Sync;
 
@@ -19,6 +20,7 @@ final class CommandProvider implements CommandProviderCapability
         return [
             new Sync(),
             new Show(),
+            new Init(),
         ];
     }
 }

--- a/src/Composer/ComposerJsonExtraReader.php
+++ b/src/Composer/ComposerJsonExtraReader.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Composer;
+
+use Composer\IO\IOInterface;
+use Internal\Path;
+
+/**
+ * Best-effort reader for the `extra` field of a project's `composer.json`.
+ *
+ * Used by the standalone `bin/skills` entrypoints
+ * ({@see \LLM\Skills\Console\Command\Sync},
+ * {@see \LLM\Skills\Console\Command\Show}) as a fallback when
+ * {@see \Composer\Factory::create()} threw but `composer.json` is still
+ * parseable. Without this fallback, the legacy inline `extra.skills`
+ * config would silently disappear for any project where Composer
+ * bootstrap fails (locked vendor tree, schema mismatch, unreadable
+ * subfile, etc.) — leaving the runner with defaults even though the
+ * user's intent is one `file_get_contents` away.
+ *
+ * The reader is intentionally permissive: every error path is folded
+ * into a `null` return, because the caller has no recovery available.
+ * Diagnostic noise goes to the IO under `-v` so a curious user can
+ * see *why* the fallback came up empty.
+ *
+ * Composer-attached entrypoints (the plugin commands and the auto-sync
+ * hook) do NOT need this — they already hold a live `Composer` instance
+ * and pull extras directly from `$composer->getPackage()->getExtra()`.
+ */
+final readonly class ComposerJsonExtraReader
+{
+    /**
+     * Read `<projectRoot>/composer.json` and return its top-level `extra`
+     * value. Returns `null` when the file does not exist, is unreadable,
+     * is not valid JSON, decodes to something other than an object, or
+     * carries no `extra` field. Each non-trivial failure emits a `-v`
+     * notice on `$io`.
+     *
+     * @return mixed the raw `extra` value (typically `array<string, mixed>`)
+     *         or `null` when no extras are available
+     */
+    public function read(Path $projectRoot, IOInterface $io): mixed
+    {
+        $path = (string) $projectRoot->join('composer.json');
+        if (!\is_file($path)) {
+            return null;
+        }
+
+        $content = \file_get_contents($path);
+        if ($content === false) {
+            $io->writeError(
+                \sprintf(
+                    '<comment>[warn] composer.json present at %s but unreadable; '
+                    . 'inline extra.skills fallback disabled.</comment>',
+                    $path,
+                ),
+                verbosity: IOInterface::VERBOSE,
+            );
+            return null;
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $io->writeError(
+                '<comment>[warn] composer.json present but not valid JSON; '
+                . 'inline extra.skills fallback disabled: ' . $e->getMessage() . '</comment>',
+                verbosity: IOInterface::VERBOSE,
+            );
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        /** @var mixed $extra */
+        $extra = $decoded['extra'] ?? null;
+        return $extra;
+    }
+}

--- a/src/Composer/SkillsPlugin.php
+++ b/src/Composer/SkillsPlugin.php
@@ -12,9 +12,11 @@ use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
+use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\SyncOptions;
+use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Sync\SyncRunner;
 
 /**
@@ -102,17 +104,28 @@ final class SkillsPlugin implements PluginInterface, Capable, EventSubscriberInt
             return;
         }
 
+        $projectRoot = Path::create(\getcwd() ?: '.');
         try {
-            $project = (new ProjectConfigMapper())->fromExtra($this->composer->getPackage()->getExtra());
+            $resolution = (new ProjectConfigMapper())->forProject(
+                $projectRoot,
+                $this->composer->getPackage()->getExtra(),
+            );
         } catch (MalformedProjectConfig $e) {
             $this->io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
             return;
         }
 
-        if (!$project->autoSync) {
+        if (!$resolution->config->autoSync) {
             return;
         }
 
-        (new SyncRunner())->run($this->composer, $this->io, SyncOptions::default());
+        $provider = new ComposerProvider($this->composer);
+        (new SyncRunner())->run(
+            $projectRoot,
+            $provider,
+            $provider->rootExtras(),
+            $this->io,
+            SyncOptions::default(),
+        );
     }
 }

--- a/src/Composer/SkillsPlugin.php
+++ b/src/Composer/SkillsPlugin.php
@@ -93,10 +93,26 @@ final class SkillsPlugin implements PluginInterface, Capable, EventSubscriberInt
     }
 
     /**
-     * Auto-sync hook. Runs `skills:update` with default options when the
-     * project opts in via `extra.skills.auto-sync: true`. Any failure is
-     * surfaced through the {@see IOInterface} but never thrown — a broken
-     * sync must not abort the surrounding `composer install` / `update`.
+     * Auto-sync hook. Runs `skills:update` with default options when
+     * the project opts in via `extra.skills.auto-sync: true`. Any
+     * failure is surfaced through the {@see IOInterface} but never
+     * thrown — a broken sync must not abort the surrounding
+     * `composer install` / `update`.
+     *
+     * The two events are handled with slightly different policy:
+     *
+     * - **`post-install-cmd`** is a fetch-only step from the user's
+     *   point of view; an unexpected `composer.json` rewrite during
+     *   `composer install` would be a surprise. The hook therefore
+     *   passes `autoMigrate: false` so any legacy inline
+     *   `extra.skills` block is read but not relocated.
+     * - **`post-update-cmd`** runs when the user is actively
+     *   reshuffling dependencies. A `composer.json` write is in
+     *   character with that command, so the migration goes through.
+     *
+     * Either way, the explicit `composer skills:update` is the
+     * unambiguous trigger for the migration; the auto-sync hook
+     * just opportunistically takes the same code path on `update`.
      */
     public function onPostInstallOrUpdate(ScriptEvent $event): void
     {
@@ -119,13 +135,25 @@ final class SkillsPlugin implements PluginInterface, Capable, EventSubscriberInt
             return;
         }
 
+        $autoMigrate = $event->getName() === ScriptEvents::POST_UPDATE_CMD;
+        $options = new SyncOptions(
+            packageFilters: [],
+            extraTrusted: [],
+            targetOverride: null,
+            interactive: false,
+            dryRun: false,
+            discovery: null,
+            aliasOverrides: null,
+            autoMigrate: $autoMigrate,
+        );
+
         $provider = new ComposerProvider($this->composer);
         (new SyncRunner())->run(
             $projectRoot,
             $provider,
             $provider->rootExtras(),
             $this->io,
-            SyncOptions::default(),
+            $options,
         );
     }
 }

--- a/src/Composer/SkillsPlugin.php
+++ b/src/Composer/SkillsPlugin.php
@@ -93,10 +93,15 @@ final class SkillsPlugin implements PluginInterface, Capable, EventSubscriberInt
     }
 
     /**
-     * Auto-sync hook. Runs `skills:update` with default options when
-     * the project opts in via `extra.skills.auto-sync: true`. Any
-     * failure is surfaced through the {@see IOInterface} but never
-     * thrown — a broken sync must not abort the surrounding
+     * Auto-sync hook. Runs `skills:update` with default options on
+     * every `composer install` / `update` unless the project opts
+     * out via `auto-sync: false` (in `skills.json` or, for projects
+     * still on the inline config, in `extra.skills`). The default
+     * was flipped to on once it became clear most projects wanted
+     * it; opt-outs are now the exception.
+     *
+     * Any failure is surfaced through the {@see IOInterface} but
+     * never thrown — a broken sync must not abort the surrounding
      * `composer install` / `update`.
      *
      * The two events are handled with slightly different policy:

--- a/src/Config/InitOptions.php
+++ b/src/Config/InitOptions.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+/**
+ * Parameters for `skills:init`, built from the CLI surface.
+ *
+ * @psalm-immutable
+ */
+final readonly class InitOptions
+{
+    /**
+     * @param non-empty-string $path destination for the external config, relative to
+     *        the project root. Validated downstream by the runner (no `..`-escape,
+     *        not absolute).
+     * @param bool $force when true, overwrite an existing file at `$path` and an
+     *        already-rewritten `extra.skills`
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public string $path = 'skills.json',
+        public bool $force = false,
+    ) {}
+
+    /**
+     * @psalm-pure
+     */
+    public static function default(): self
+    {
+        return new self();
+    }
+}

--- a/src/Config/Mapper/ExternalProjectConfigLoader.php
+++ b/src/Config/Mapper/ExternalProjectConfigLoader.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
+
+/**
+ * Reads the external `skills.json` file at the project root and returns
+ * its contents as an array shaped like the inline `extra.skills` block,
+ * ready to be handed to the per-field validators in
+ * {@see ProjectConfigMapper}.
+ *
+ * The file is **strict**: any unknown top-level key fails the load.
+ * `$schema` is the single exception — it is allowed (for IDE/editor
+ * support) and silently stripped from the returned array so it does
+ * not look like an unrecognised field downstream.
+ *
+ * Errors are surfaced as {@see MalformedProjectConfig} with messages
+ * prefixed `skills.json:` so the origin of the failure is clear in
+ * combined output.
+ *
+ * Not annotated `@psalm-immutable`: {@see self::load()} reads the
+ * filesystem and is therefore impure. The class is otherwise
+ * stateless and safe to share.
+ */
+final readonly class ExternalProjectConfigLoader
+{
+    /**
+     * Canonical filename. The loader looks for exactly this name at the
+     * project root — there is no upward walk and no configurable
+     * location at read time (the `--path` flag of `skills:init` only
+     * affects file creation, not where subsequent commands look).
+     */
+    public const FILE_NAME = 'skills.json';
+
+    /**
+     * Top-level keys accepted inside `skills.json`. Mirrors the project
+     * keys understood under `extra.skills`, plus the editor-only
+     * `$schema` annotation.
+     *
+     * Kept in sync with the per-field mapping in
+     * {@see ProjectConfigMapper::mapSkillsBlock()} and with
+     * `resources/skills.schema.json`.
+     */
+    public const ALLOWED_KEYS = [
+        '$schema',
+        'target',
+        'aliases',
+        'trusted',
+        'trusted-replace',
+        'discovery',
+        'auto-sync',
+    ];
+
+    /**
+     * Load `skills.json` from the given project root.
+     *
+     * Returns the decoded array (with `$schema` already stripped) when
+     * the file exists, or `null` when it does not — the caller then
+     * falls back to the inline `extra.skills` block.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws MalformedProjectConfig when the file exists but cannot be read,
+     *         contains invalid JSON, has a non-object root, or carries an
+     *         unknown top-level key
+     */
+    public function load(Path $projectRoot): ?array
+    {
+        $filePath = (string) $projectRoot->join(self::FILE_NAME);
+        if (!\is_file($filePath)) {
+            return null;
+        }
+
+        $content = \file_get_contents($filePath);
+        if ($content === false) {
+            throw new MalformedProjectConfig(\sprintf(
+                'skills.json: failed to read "%s"',
+                $filePath,
+            ));
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new MalformedProjectConfig(\sprintf(
+                'skills.json: invalid JSON — %s',
+                $e->getMessage(),
+            ));
+        }
+
+        if (!\is_array($decoded)) {
+            throw new MalformedProjectConfig('skills.json: root must be a JSON object');
+        }
+
+        // A non-empty list (`[1, 2, 3]`) decodes to an array but is not
+        // an object — distinguish it from `{}` which decodes to `[]`.
+        if ($decoded !== [] && \array_is_list($decoded)) {
+            throw new MalformedProjectConfig('skills.json: root must be a JSON object, got a list');
+        }
+
+        foreach ($decoded as $key => $_unused) {
+            if (!\is_string($key) || !\in_array($key, self::ALLOWED_KEYS, true)) {
+                throw new MalformedProjectConfig(\sprintf(
+                    'skills.json: unknown top-level key "%s"; allowed keys: %s',
+                    \is_string($key) ? $key : '(non-string)',
+                    \implode(', ', \array_filter(self::ALLOWED_KEYS, static fn(string $k): bool => $k !== '$schema')),
+                ));
+            }
+        }
+
+        // `$schema` is metadata for editors only; strip it so downstream
+        // code never has to know about it.
+        unset($decoded['$schema']);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/src/Config/Mapper/ExternalProjectConfigLoader.php
+++ b/src/Config/Mapper/ExternalProjectConfigLoader.php
@@ -83,9 +83,15 @@ final readonly class ExternalProjectConfigLoader
             ));
         }
 
+        // Decode once with `assoc=false` so we can distinguish an
+        // empty JSON object `{}` (→ stdClass) from an empty JSON
+        // array `[]` (→ PHP array). With `assoc=true` both decode to
+        // `[]` and the `array_is_list` check accepts the array as a
+        // valid empty object — exactly the contract violation we're
+        // guarding against.
         try {
-            /** @var mixed $decoded */
-            $decoded = \json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+            /** @var mixed $typed */
+            $typed = \json_decode($content, false, flags: \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             throw new MalformedProjectConfig(\sprintf(
                 'skills.json: invalid JSON — %s',
@@ -93,21 +99,20 @@ final readonly class ExternalProjectConfigLoader
             ));
         }
 
-        if (!\is_array($decoded)) {
+        if (!$typed instanceof \stdClass) {
             throw new MalformedProjectConfig('skills.json: root must be a JSON object');
         }
 
-        // A non-empty list (`[1, 2, 3]`) decodes to an array but is not
-        // an object — distinguish it from `{}` which decodes to `[]`.
-        if ($decoded !== [] && \array_is_list($decoded)) {
-            throw new MalformedProjectConfig('skills.json: root must be a JSON object, got a list');
-        }
+        /** @var array<string, mixed> $decoded */
+        $decoded = (array) $typed;
 
+        // Casting a stdClass to array always yields string keys, so no
+        // runtime is_string guard is needed.
         foreach ($decoded as $key => $_unused) {
-            if (!\is_string($key) || !\in_array($key, self::ALLOWED_KEYS, true)) {
+            if (!\in_array($key, self::ALLOWED_KEYS, true)) {
                 throw new MalformedProjectConfig(\sprintf(
                     'skills.json: unknown top-level key "%s"; allowed keys: %s',
-                    \is_string($key) ? $key : '(non-string)',
+                    $key,
                     \implode(', ', \array_filter(self::ALLOWED_KEYS, static fn(string $k): bool => $k !== '$schema')),
                 ));
             }
@@ -117,7 +122,6 @@ final readonly class ExternalProjectConfigLoader
         // code never has to know about it.
         unset($decoded['$schema']);
 
-        /** @var array<string, mixed> $decoded */
         return $decoded;
     }
 }

--- a/src/Config/Mapper/MigrationResult.php
+++ b/src/Config/Mapper/MigrationResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+/**
+ * Outcome of {@see ProjectConfigMigrator::migrate()}.
+ *
+ * Distinguishes three states the caller cares about:
+ *
+ * - **Migrated** — `skills.json` was written and (when applicable)
+ *   `composer.json` had its inline project keys stripped. The caller
+ *   should reload project config from the fresh file.
+ * - **Skipped** — nothing to migrate (already done, or no inline
+ *   block to begin with). Not an error.
+ * - **Failed** — migration was eligible but a step (read, parse,
+ *   write) errored out. The error message has already been emitted
+ *   on `IOInterface`; the caller turns this into a non-zero exit
+ *   code.
+ *
+ * @psalm-immutable
+ */
+final readonly class MigrationResult
+{
+    /**
+     * @param list<non-empty-string> $migratedKeys names of project keys that moved
+     *        out of `extra.skills` into `skills.json`. Empty when status is
+     *        {@see MigrationStatus::Skipped} or {@see MigrationStatus::Failed}.
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public MigrationStatus $status,
+        public array $migratedKeys = [],
+    ) {}
+
+    /**
+     * @psalm-pure
+     */
+    public static function skipped(): self
+    {
+        return new self(MigrationStatus::Skipped);
+    }
+
+    /**
+     * @param list<non-empty-string> $keys
+     *
+     * @psalm-pure
+     */
+    public static function migrated(array $keys): self
+    {
+        return new self(MigrationStatus::Migrated, $keys);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function failed(): self
+    {
+        return new self(MigrationStatus::Failed);
+    }
+}

--- a/src/Config/Mapper/MigrationStatus.php
+++ b/src/Config/Mapper/MigrationStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+enum MigrationStatus
+{
+    /**
+     * Files were written; project config now lives in skills.json.
+     */
+    case Migrated;
+
+    /**
+     * No-op — skills.json already there, or no inline block to migrate.
+     */
+    case Skipped;
+
+    /**
+     * Migration was eligible but failed mid-flight; IO already informed.
+     */
+    case Failed;
+}

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -194,7 +194,7 @@ final readonly class ProjectConfigMapper
             );
         }
 
-        $autoSync = $skills['auto-sync'] ?? false;
+        $autoSync = $skills['auto-sync'] ?? true;
         if (!\is_bool($autoSync)) {
             throw new MalformedProjectConfig(
                 self::field($prefix, 'auto-sync') . ' must be a boolean',

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -4,26 +4,98 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Config\Mapper;
 
+use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\ProjectConfig;
+use LLM\Skills\Config\ProjectConfigResolution;
 use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorPattern;
 
 /**
- * Maps the root package's `extra` array (from the consumer project's
- * `composer.json`) into a typed {@see ProjectConfig}.
+ * Maps the consumer project's configuration into a typed
+ * {@see ProjectConfig}.
  *
- * A missing `extra.skills` block is treated as "all defaults" — that is the
- * expected state for a project freshly adopting `llm/skills`. Anything
- * else that is malformed throws {@see MalformedProjectConfig}, which is
- * not** caught by the sync command: the user owns this file, so loud
+ * Two sources feed this mapper:
+ *
+ * - **`skills.json`** at the project root, when present. Strict mapping,
+ *   loaded via {@see ExternalProjectConfigLoader}; this is the modern
+ *   surface the project owns explicitly.
+ * - **`extra.skills`** inside `composer.json`. Legacy / fallback
+ *   behaviour; lenient (Composer's own `extra` is a free-form area,
+ *   so unknown keys are silently ignored).
+ *
+ * The two are mutually exclusive — see {@see self::forProject()}. When
+ * both are present, `skills.json` wins and the inline project keys are
+ * collected into {@see ProjectConfigResolution::$ignoredInlineKeys} so
+ * the caller can surface a `-v` warning.
+ *
+ * A broken root config is **fatal**: the user owns this file, so loud
  * failure is preferable to silent defaults.
  *
- * @psalm-immutable
+ * Not annotated `@psalm-immutable` because {@see self::forProject()}
+ * reads the filesystem via {@see ExternalProjectConfigLoader}. The
+ * other methods stay `@psalm-mutation-free` / `@psalm-pure` and are
+ * safe to call from inside pure contexts.
  */
 final readonly class ProjectConfigMapper
 {
     /**
+     * Project-level keys understood under `extra.skills`. Donor-side
+     * keys (`source`) are deliberately excluded — they describe the
+     * package as a donor, not as a consumer, and must not be flagged
+     * as "shadowed" when `skills.json` is in effect.
+     *
+     * @var list<non-empty-string>
+     */
+    public const PROJECT_KEYS = [
+        'target',
+        'aliases',
+        'trusted',
+        'trusted-replace',
+        'discovery',
+        'auto-sync',
+    ];
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private ExternalProjectConfigLoader $externalLoader = new ExternalProjectConfigLoader(),
+    ) {}
+
+    /**
+     * Resolve the project config, choosing between `skills.json` (when
+     * it exists at `$projectRoot`) and the inline `extra.skills` block.
+     *
+     * The returned {@see ProjectConfigResolution} bundles the config
+     * with the list of inline project keys that were shadowed by
+     * `skills.json` (empty unless `skills.json` won and the inline
+     * block also carried project keys). Callers emit a `-v` warning
+     * from that list — no IO happens here.
+     *
+     * @param mixed $extra raw value of the root package's `extra` field
+     *
+     * @throws MalformedProjectConfig when either source is malformed
+     */
+    public function forProject(Path $projectRoot, mixed $extra): ProjectConfigResolution
+    {
+        $external = $this->externalLoader->load($projectRoot);
+        if ($external !== null) {
+            $config = $this->mapSkillsBlock($external, 'skills.json');
+            $ignored = $this->collectIgnoredInlineKeys($extra);
+
+            return new ProjectConfigResolution($config, $ignored);
+        }
+
+        return new ProjectConfigResolution($this->fromExtra($extra));
+    }
+
+    /**
+     * Legacy entry point: map an inline `extra` array directly. Kept
+     * for the auto-sync hook (which has no convenient project-root
+     * handle) and for unit tests that exercise the inline branch in
+     * isolation.
+     *
      * @param mixed $extra raw value of root `composer.json` `extra` field
      *
      * @throws MalformedProjectConfig when `extra.skills` is present but invalid
@@ -48,38 +120,7 @@ final readonly class ProjectConfigMapper
             throw new MalformedProjectConfig('extra.skills must be an object');
         }
 
-        $target = $skills['target'] ?? ProjectConfig::DEFAULT_TARGET;
-        if (!\is_string($target) || $target === '') {
-            throw new MalformedProjectConfig('extra.skills.target must be a non-empty string');
-        }
-
-        $aliases = $this->mapAliases($skills['aliases'] ?? [], $target);
-
-        $trusted = $this->mapTrusted($skills['trusted'] ?? []);
-
-        $replace = $skills['trusted-replace'] ?? false;
-        if (!\is_bool($replace)) {
-            throw new MalformedProjectConfig('extra.skills.trusted-replace must be a boolean');
-        }
-
-        $discovery = $skills['discovery'] ?? false;
-        if (!\is_bool($discovery)) {
-            throw new MalformedProjectConfig('extra.skills.discovery must be a boolean');
-        }
-
-        $autoSync = $skills['auto-sync'] ?? false;
-        if (!\is_bool($autoSync)) {
-            throw new MalformedProjectConfig('extra.skills.auto-sync must be a boolean');
-        }
-
-        return new ProjectConfig(
-            target: $target,
-            trusted: $trusted,
-            trustedReplace: $replace,
-            discovery: $discovery,
-            aliases: $aliases,
-            autoSync: $autoSync,
-        );
+        return $this->mapSkillsBlock($skills, 'extra.skills');
     }
 
     /**
@@ -95,19 +136,96 @@ final readonly class ProjectConfigMapper
     }
 
     /**
+     * Render a per-field path for error messages: `extra.skills.target`
+     * for the inline source, `skills.json: target` for the external one
+     * (the latter uses a colon to keep the file name distinct from a
+     * dotted JSON pointer).
+     *
+     * @param non-empty-string $prefix
+     * @param non-empty-string $name
+     *
+     * @return non-empty-string
+     *
+     * @psalm-pure
+     */
+    private static function field(string $prefix, string $name): string
+    {
+        return $prefix === 'skills.json'
+            ? "skills.json: {$name}"
+            : "{$prefix}.{$name}";
+    }
+
+    /**
+     * Per-field validator shared by both inline and external sources.
+     * `$prefix` is woven into error messages so the user knows where
+     * to look (`extra.skills.target` vs `skills.json: target`).
+     *
+     * @param array<array-key, mixed> $skills
+     * @param non-empty-string $prefix human-readable origin of the block, e.g. `extra.skills` or `skills.json`
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-mutation-free
+     */
+    private function mapSkillsBlock(array $skills, string $prefix): ProjectConfig
+    {
+        $target = $skills['target'] ?? ProjectConfig::DEFAULT_TARGET;
+        if (!\is_string($target) || $target === '') {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'target') . ' must be a non-empty string',
+            );
+        }
+
+        $aliases = $this->mapAliases($skills['aliases'] ?? [], $target, $prefix);
+
+        $trusted = $this->mapTrusted($skills['trusted'] ?? [], $prefix);
+
+        $replace = $skills['trusted-replace'] ?? false;
+        if (!\is_bool($replace)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'trusted-replace') . ' must be a boolean',
+            );
+        }
+
+        $discovery = $skills['discovery'] ?? false;
+        if (!\is_bool($discovery)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'discovery') . ' must be a boolean',
+            );
+        }
+
+        $autoSync = $skills['auto-sync'] ?? false;
+        if (!\is_bool($autoSync)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'auto-sync') . ' must be a boolean',
+            );
+        }
+
+        return new ProjectConfig(
+            target: $target,
+            trusted: $trusted,
+            trustedReplace: $replace,
+            discovery: $discovery,
+            aliases: $aliases,
+            autoSync: $autoSync,
+        );
+    }
+
+    /**
      * Validate and return the `aliases` list. Each entry must be a non-empty
      * string. After light lexical normalisation (separator unification,
      * trailing-slash strip) no alias may equal `$target`, and no two aliases
      * may collide.
      *
-     * Resolution against the project root happens later in {@see \LLM\Skills\Sync\SyncPlanner};
-     * this method only catches the obvious raw-string mistakes. The planner
-     * runs a second pass against fully resolved absolute paths, which catches
-     * cases like `./.claude/skills` vs `.claude/skills` after both join the
-     * project root.
+     * Resolution against the project root happens later in
+     * {@see \LLM\Skills\Sync\SyncPlanner}; this method only catches the
+     * obvious raw-string mistakes. The planner runs a second pass against
+     * fully resolved absolute paths, which catches cases like
+     * `./.claude/skills` vs `.claude/skills` after both join the project root.
      *
      * @param non-empty-string $target the already-validated target path; used to forbid
      *         `target == alias` configurations up front
+     * @param non-empty-string $prefix
      *
      * @return list<non-empty-string>
      *
@@ -115,13 +233,15 @@ final readonly class ProjectConfigMapper
      *
      * @psalm-pure
      */
-    private function mapAliases(mixed $raw, string $target): array
+    private function mapAliases(mixed $raw, string $target, string $prefix): array
     {
         if ($raw === []) {
             return [];
         }
         if (!\is_array($raw) || !\array_is_list($raw)) {
-            throw new MalformedProjectConfig('extra.skills.aliases must be a list of non-empty strings');
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'aliases') . ' must be a list of non-empty strings',
+            );
         }
 
         $normalisedTarget = self::lexicalNormalise($target);
@@ -132,7 +252,8 @@ final readonly class ProjectConfigMapper
         foreach ($raw as $index => $value) {
             if (!\is_string($value) || $value === '') {
                 throw new MalformedProjectConfig(\sprintf(
-                    'extra.skills.aliases[%d] must be a non-empty string',
+                    '%s[%d] must be a non-empty string',
+                    self::field($prefix, 'aliases'),
                     $index,
                 ));
             }
@@ -140,14 +261,17 @@ final readonly class ProjectConfigMapper
             $normalised = self::lexicalNormalise($value);
             if ($normalised === $normalisedTarget) {
                 throw new MalformedProjectConfig(\sprintf(
-                    'extra.skills.aliases[%d] (%s) cannot equal extra.skills.target',
+                    '%s[%d] (%s) cannot equal %s',
+                    self::field($prefix, 'aliases'),
                     $index,
                     $value,
+                    self::field($prefix, 'target'),
                 ));
             }
             if (isset($seen[$normalised])) {
                 throw new MalformedProjectConfig(\sprintf(
-                    'extra.skills.aliases[%d] (%s) duplicates an earlier entry',
+                    '%s[%d] (%s) duplicates an earlier entry',
+                    self::field($prefix, 'aliases'),
                     $index,
                     $value,
                 ));
@@ -160,14 +284,18 @@ final readonly class ProjectConfigMapper
     }
 
     /**
+     * @param non-empty-string $prefix
+     *
      * @throws MalformedProjectConfig
      *
      * @psalm-mutation-free
      */
-    private function mapTrusted(mixed $raw): TrustedVendors
+    private function mapTrusted(mixed $raw, string $prefix): TrustedVendors
     {
         if (!\is_array($raw)) {
-            throw new MalformedProjectConfig('extra.skills.trusted must be a list of patterns');
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'trusted') . ' must be a list of patterns',
+            );
         }
 
         $patterns = [];
@@ -175,7 +303,8 @@ final readonly class ProjectConfigMapper
         foreach ($raw as $index => $value) {
             if (!\is_string($value) || $value === '') {
                 throw new MalformedProjectConfig(\sprintf(
-                    'extra.skills.trusted[%s] must be a non-empty string',
+                    '%s[%s] must be a non-empty string',
+                    self::field($prefix, 'trusted'),
                     $index,
                 ));
             }
@@ -184,7 +313,8 @@ final readonly class ProjectConfigMapper
                 $patterns[] = VendorPattern::fromString($value);
             } catch (\InvalidArgumentException $e) {
                 throw new MalformedProjectConfig(\sprintf(
-                    'extra.skills.trusted[%s]: %s',
+                    '%s[%s]: %s',
+                    self::field($prefix, 'trusted'),
                     $index,
                     $e->getMessage(),
                 ));
@@ -192,5 +322,36 @@ final readonly class ProjectConfigMapper
         }
 
         return new TrustedVendors($patterns);
+    }
+
+    /**
+     * Pick the project-level keys that exist under `extra.skills` so the
+     * caller can warn about them being shadowed by `skills.json`.
+     * Donor-side keys (`source`) are deliberately not included — they
+     * remain meaningful even when `skills.json` drives the project
+     * config, because the same package may also be a donor.
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-pure
+     */
+    private function collectIgnoredInlineKeys(mixed $extra): array
+    {
+        if (!\is_array($extra)) {
+            return [];
+        }
+        $skills = $extra['skills'] ?? null;
+        if (!\is_array($skills)) {
+            return [];
+        }
+
+        $present = [];
+        foreach (self::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                $present[] = $key;
+            }
+        }
+
+        return $present;
     }
 }

--- a/src/Config/Mapper/ProjectConfigMigrator.php
+++ b/src/Config/Mapper/ProjectConfigMigrator.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+use Composer\IO\IOInterface;
+use Composer\Json\JsonManipulator;
+use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
+
+/**
+ * Moves a project's legacy inline `extra.skills` block out of
+ * `composer.json` and into the canonical `skills.json` file.
+ *
+ * Triggered automatically by write-mode entrypoints
+ * ({@see \LLM\Skills\Sync\SyncRunner},
+ * {@see \LLM\Skills\Init\InitRunner}, and the `post-update-cmd`
+ * auto-sync hook in {@see \LLM\Skills\Composer\SkillsPlugin}). Read-only
+ * surfaces ({@see \LLM\Skills\Show\ShowRunner},
+ * {@see \LLM\Skills\Composer\SkillsPlugin}'s `post-install-cmd` hook)
+ * never call into this class — they emit a notice instead, leaving
+ * the user in control of when their `composer.json` gets rewritten.
+ *
+ * The migration is **atomic in spirit**: validation happens before
+ * any filesystem write, and the two writes (skills.json, then
+ * composer.json) run in fixed order. If composer.json rewrite then
+ * fails, the freshly-written skills.json plus an unmodified
+ * composer.json is a recoverable state — a subsequent run sees
+ * skills.json and skips migration entirely.
+ *
+ * Idempotent: when `skills.json` already exists, or no inline
+ * project keys are present, the migrator returns
+ * {@see MigrationStatus::Skipped} without touching anything.
+ */
+final readonly class ProjectConfigMigrator
+{
+    /**
+     * URL of the published JSON schema. Emitted into the generated
+     * file's `$schema` field so editors that follow the link can
+     * offer validation / autocompletion.
+     */
+    public const SCHEMA_URL = 'https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json';
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
+    ) {}
+
+    /**
+     * Render the file content for a new `skills.json`. Defaults are
+     * NOT written — only the keys the user actually customised.
+     * Always starts with a `$schema` pointer so editors can validate.
+     *
+     * @param array<non-empty-string, mixed> $migrated project keys in {@see ProjectConfigMapper::PROJECT_KEYS} order
+     *
+     * @psalm-pure
+     */
+    public static function renderSkillsJson(array $migrated): string
+    {
+        $payload = ['$schema' => self::SCHEMA_URL] + $migrated;
+
+        $json = \json_encode(
+            $payload,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+        );
+        if ($json === false) {
+            throw new \RuntimeException('Failed to encode skills.json payload');
+        }
+
+        return $json . "\n";
+    }
+
+    /**
+     * Pull the project-level keys out of an inline `extra.skills`
+     * block, in canonical order. Donor `source` and any unrelated
+     * keys are deliberately dropped.
+     *
+     * @param array<array-key, mixed> $skills the inline `extra.skills` value
+     *
+     * @return array<non-empty-string, mixed>
+     *
+     * @psalm-pure
+     */
+    public static function extractProjectKeys(array $skills): array
+    {
+        $out = [];
+        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
+                $out[$key] = $skills[$key];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Detect-and-migrate. Returns:
+     *
+     * - {@see MigrationStatus::Skipped} when `skills.json` already
+     *   exists, when there is no `composer.json` at all (standalone
+     *   project — nothing to migrate from), or when `extra.skills`
+     *   has no project-level keys.
+     * - {@see MigrationStatus::Migrated} after writing `skills.json`
+     *   and stripping the migrated keys from `composer.json`.
+     * - {@see MigrationStatus::Failed} when migration was eligible
+     *   but a step errored out; the caller surfaces this as a
+     *   non-zero exit code (error already emitted on `$io`).
+     */
+    public function migrate(Path $projectRoot, IOInterface $io): MigrationResult
+    {
+        $skillsJsonPath = (string) $projectRoot->join('skills.json');
+        if (\is_file($skillsJsonPath)) {
+            return MigrationResult::skipped();
+        }
+
+        $composerJsonPath = (string) $projectRoot->join('composer.json');
+        if (!\is_file($composerJsonPath)) {
+            return MigrationResult::skipped();
+        }
+
+        $original = \file_get_contents($composerJsonPath);
+        if ($original === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to read composer.json at %s</error>',
+                $composerJsonPath,
+            ));
+            return MigrationResult::failed();
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($original, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] composer.json is not valid JSON: %s</error>',
+                $e->getMessage(),
+            ));
+            return MigrationResult::failed();
+        }
+
+        if (!\is_array($decoded)) {
+            $io->writeError('<error>[llm/skills] composer.json must be a JSON object</error>');
+            return MigrationResult::failed();
+        }
+
+        /** @var array<string, mixed> $extra */
+        $extra = \is_array($decoded['extra'] ?? null) ? $decoded['extra'] : [];
+        /** @var array<string, mixed> $skills */
+        $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
+
+        $migrated = self::extractProjectKeys($skills);
+        if ($migrated === []) {
+            // composer.json exists but carries no inline project keys
+            // (maybe just a donor `source`, or no skills block at all).
+            // Nothing to migrate — and we deliberately do NOT auto-create
+            // a stub skills.json here, because we'd be writing a file
+            // the user never asked for.
+            return MigrationResult::skipped();
+        }
+
+        // Pre-flight validation: refuse to relocate a malformed config.
+        try {
+            $this->projectMapper->fromExtra($extra);
+        } catch (MalformedProjectConfig $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] cannot auto-migrate: inline extra.skills is malformed — %s. '
+                . 'Fix composer.json or remove the inline block, then re-run.</error>',
+                $e->getMessage(),
+            ));
+            return MigrationResult::failed();
+        }
+
+        // Write skills.json first. If composer.json rewrite fails, the
+        // next run sees skills.json and skips migration entirely — the
+        // user just has to clean up their composer.json by hand.
+        $content = self::renderSkillsJson($migrated);
+        if (\file_put_contents($skillsJsonPath, $content) === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to write %s</error>',
+                $skillsJsonPath,
+            ));
+            return MigrationResult::failed();
+        }
+
+        $manipulator = new JsonManipulator($original);
+        foreach (\array_keys($migrated) as $key) {
+            if (!$manipulator->removeSubNode('extra', 'skills.' . $key)) {
+                $io->writeError(\sprintf(
+                    '<error>[llm/skills] failed to remove extra.skills.%s from composer.json '
+                    . '(skills.json was written; clean up composer.json by hand).</error>',
+                    $key,
+                ));
+                return MigrationResult::failed();
+            }
+        }
+
+        if (\file_put_contents($composerJsonPath, $manipulator->getContents()) === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to write composer.json at %s</error>',
+                $composerJsonPath,
+            ));
+            return MigrationResult::failed();
+        }
+
+        return MigrationResult::migrated(\array_keys($migrated));
+    }
+}

--- a/src/Config/Mapper/ProjectConfigMigrator.php
+++ b/src/Config/Mapper/ProjectConfigMigrator.php
@@ -198,6 +198,18 @@ final readonly class ProjectConfigMigrator
             }
         }
 
+        // If `extra.skills` had nothing but the migrated project keys,
+        // it is now an empty object — strip it so composer.json doesn't
+        // accumulate dead `"skills": {}` debris. Same hygiene for
+        // `extra` itself when it becomes empty (the user might not have
+        // anything else under it). Donor-side `source` and any other
+        // unrelated `extra.skills` keys keep both nodes alive.
+        $remaining = \array_diff(\array_keys($skills), \array_keys($migrated));
+        if ($remaining === []) {
+            $manipulator->removeSubNode('extra', 'skills');
+            $manipulator->removeMainKeyIfEmpty('extra');
+        }
+
         if (\file_put_contents($composerJsonPath, $manipulator->getContents()) === false) {
             $io->writeError(\sprintf(
                 '<error>[llm/skills] failed to write composer.json at %s</error>',

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -46,7 +46,7 @@ final readonly class ProjectConfig
         public bool $trustedReplace,
         public bool $discovery = false,
         public array $aliases = [],
-        public bool $autoSync = false,
+        public bool $autoSync = true,
     ) {}
 
     /**
@@ -63,7 +63,7 @@ final readonly class ProjectConfig
             trustedReplace: false,
             discovery: false,
             aliases: [],
-            autoSync: false,
+            autoSync: true,
         );
     }
 

--- a/src/Config/ProjectConfigResolution.php
+++ b/src/Config/ProjectConfigResolution.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+/**
+ * Result of {@see \LLM\Skills\Config\Mapper\ProjectConfigMapper::forProject()}.
+ *
+ * Bundles the resolved {@see ProjectConfig} with the list of inline
+ * `extra.skills` keys that were shadowed because a `skills.json` file
+ * exists at the project root. Callers emit a `-v`-only warning naming
+ * those keys so a confused user sees why their inline `target` (or
+ * other key) had no effect.
+ *
+ * @psalm-immutable
+ */
+final readonly class ProjectConfigResolution
+{
+    /**
+     * @param list<non-empty-string> $ignoredInlineKeys names of project-level keys
+     *        present under `extra.skills` in `composer.json` that were shadowed
+     *        by a `skills.json` at the project root. Always empty when the
+     *        inline block was used as the source of truth.
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public ProjectConfig $config,
+        public array $ignoredInlineKeys = [],
+    ) {}
+}

--- a/src/Config/SyncOptions.php
+++ b/src/Config/SyncOptions.php
@@ -27,6 +27,10 @@ final readonly class SyncOptions
      *         configured aliases", a list (including the empty one) means "the CLI list replaces project
      *         config entirely". Symmetric with {@see $targetOverride}: passing `--alias` at all is an
      *         explicit takeover, never a merge.
+     * @param bool $autoMigrate when `true` (default), the runner will move a legacy inline
+     *         `extra.skills` block into `skills.json` before doing the sync. Set to `false` by
+     *         read-mode-adjacent callers (today: the `post-install-cmd` auto-sync hook) that
+     *         must not rewrite the user's `composer.json` mid-install.
      *
      * @psalm-mutation-free
      */
@@ -38,6 +42,7 @@ final readonly class SyncOptions
         public bool $dryRun = false,
         public ?bool $discovery = null,
         public ?array $aliasOverrides = null,
+        public bool $autoMigrate = true,
     ) {}
 
     /**

--- a/src/Config/VendorPattern.php
+++ b/src/Config/VendorPattern.php
@@ -50,6 +50,19 @@ final readonly class VendorPattern
             ));
         }
 
+        // Composer package names contain exactly one slash; treat anything
+        // with more as malformed instead of silently letting the extra
+        // segments become part of the package name. This also keeps the
+        // mapper in sync with `resources/skills.schema.json`, whose
+        // `^[^/]+/[^/]+$` regex rejects multi-slash entries.
+        if (\strpos($pattern, '/', $slash + 1) !== false) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Invalid vendor pattern "%s": expected exactly one "/" '
+                . '(e.g. "vendor/package" or "vendor/*").',
+                $pattern,
+            ));
+        }
+
         /** @var non-empty-string $vendor */
         $vendor = \substr($pattern, 0, $slash);
         /** @var non-empty-string $package */

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Console\Command;
+
+use Composer\IO\ConsoleIO;
+use Internal\Path;
+use LLM\Skills\Console\InitCliDefinition;
+use LLM\Skills\Init\InitRunner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Standalone `init` (alias `i`) for the `bin/skills` binary.
+ *
+ * Unlike {@see \LLM\Skills\Composer\Command\Init}, this entrypoint is
+ * *not* invoked through `composer` and does not require a Composer
+ * instance — `init` only reads `composer.json` if it exists at the
+ * current working directory, and writes plain JSON. Bootstrapping
+ * Composer here would be unnecessary overhead.
+ *
+ * @internal
+ */
+final class Init extends Command
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        InitCliDefinition::apply($this, 'init', ['i']);
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ConsoleIO($input, $output, new HelperSet([
+            new QuestionHelper(),
+        ]));
+
+        try {
+            $options = InitCliDefinition::buildOptions($input);
+        } catch (\InvalidArgumentException $e) {
+            $io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
+            return self::INVALID;
+        }
+
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new InitRunner())->run($projectRoot, $io, $options);
+    }
+}

--- a/src/Console/Command/Show.php
+++ b/src/Console/Command/Show.php
@@ -26,8 +26,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Composer itself via {@see Factory::create()} on a best-effort
  * basis. When the current working directory has no `composer.json`
  * the {@see ComposerProvider} reports itself inactive and the runner
- * emits the standalone `[no donors available]` notice instead of
- * dying with a bootstrap error.
+ * emits the `no donor providers are active` notice instead of dying
+ * with a bootstrap error.
  *
  * @internal
  */

--- a/src/Console/Command/Show.php
+++ b/src/Console/Command/Show.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Console\Command;
 
+use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
+use Composer\IO\IOInterface;
+use Internal\Path;
 use LLM\Skills\Console\ShowCliDefinition;
+use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Show\ShowRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -18,10 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Standalone `show` (alias `s`) for the `bin/skills` binary.
  *
  * Mirrors {@see \LLM\Skills\Composer\Command\Show} but bootstraps
- * Composer itself via {@see Factory::create()} because there is no
- * Composer process around to inject one. Plugins are disabled during
- * bootstrap for the same reason as the standalone `update`: we never
- * want this binary to wake up another `llm/skills` plugin instance.
+ * Composer itself via {@see Factory::create()} on a best-effort
+ * basis. When the current working directory has no `composer.json`
+ * the {@see ComposerProvider} reports itself inactive and the runner
+ * emits the standalone `[no donors available]` notice instead of
+ * dying with a bootstrap error.
  *
  * @internal
  */
@@ -47,13 +52,38 @@ final class Show extends Command
             return self::INVALID;
         }
 
-        try {
-            $composer = Factory::create($io, null, disablePlugins: true, disableScripts: true);
-        } catch (\Throwable $e) {
-            $io->writeError('<error>[llm/skills] Failed to bootstrap Composer: ' . $e->getMessage() . '</error>');
-            return self::FAILURE;
+        $composer = self::tryBootstrapComposer($io);
+        $provider = new ComposerProvider($composer);
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new ShowRunner())->run(
+            $projectRoot,
+            $provider,
+            $provider->rootExtras(),
+            $io,
+            $options,
+        );
+    }
+
+    /**
+     * Best-effort {@see Factory::create()}. See the twin in
+     * {@see \LLM\Skills\Console\Command\Sync} for the rationale.
+     */
+    private static function tryBootstrapComposer(ConsoleIO $io): ?Composer
+    {
+        if (!\is_file((\getcwd() ?: '.') . '/composer.json')) {
+            return null;
         }
 
-        return (new ShowRunner())->run($composer, $io, $options);
+        try {
+            return Factory::create($io, null, disablePlugins: true, disableScripts: true);
+        } catch (\Throwable $e) {
+            $io->writeError(
+                '<comment>[warn] Composer bootstrap failed, continuing without it: '
+                . $e->getMessage() . '</comment>',
+                verbosity: IOInterface::VERBOSE,
+            );
+            return null;
+        }
     }
 }

--- a/src/Console/Command/Show.php
+++ b/src/Console/Command/Show.php
@@ -9,6 +9,7 @@ use Composer\Factory;
 use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
 use Internal\Path;
+use LLM\Skills\Composer\ComposerJsonExtraReader;
 use LLM\Skills\Console\ShowCliDefinition;
 use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Show\ShowRunner;
@@ -52,14 +53,21 @@ final class Show extends Command
             return self::INVALID;
         }
 
+        $projectRoot = Path::create(\getcwd() ?: '.');
         $composer = self::tryBootstrapComposer($io);
         $provider = new ComposerProvider($composer);
-        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        // See the twin in Console\Command\Sync — keeps the inline
+        // `extra.skills` fallback usable when Composer bootstrap fails.
+        /** @var mixed $extra */
+        $extra = $composer !== null
+            ? $composer->getPackage()->getExtra()
+            : (new ComposerJsonExtraReader())->read($projectRoot, $io);
 
         return (new ShowRunner())->run(
             $projectRoot,
             $provider,
-            $provider->rootExtras(),
+            $extra,
             $io,
             $options,
         );

--- a/src/Console/Command/Show.php
+++ b/src/Console/Command/Show.php
@@ -71,7 +71,15 @@ final class Show extends Command
      */
     private static function tryBootstrapComposer(ConsoleIO $io): ?Composer
     {
-        if (!\is_file((\getcwd() ?: '.') . '/composer.json')) {
+        $cwd = \getcwd() ?: '.';
+        if (!\is_file($cwd . '/composer.json')) {
+            $io->writeError(
+                \sprintf(
+                    '<comment>[warn] no composer.json at %s — Composer donor provider is inactive.</comment>',
+                    $cwd,
+                ),
+                verbosity: IOInterface::VERBOSE,
+            );
             return null;
         }
 

--- a/src/Console/Command/Sync.php
+++ b/src/Console/Command/Sync.php
@@ -8,6 +8,7 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
 use Internal\Path;
+use LLM\Skills\Composer\ComposerJsonExtraReader;
 use LLM\Skills\Console\SyncCliDefinition;
 use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Sync\SyncRunner;
@@ -60,14 +61,24 @@ final class Sync extends Command
             return self::INVALID;
         }
 
+        $projectRoot = Path::create(\getcwd() ?: '.');
         $composer = self::tryBootstrapComposer($io);
         $provider = new ComposerProvider($composer);
-        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        // When Composer bootstrap succeeded, the root package's getExtra()
+        // is the canonical source. When it failed but composer.json is
+        // present, we still want the legacy inline `extra.skills` fallback
+        // to work — read the file directly so the runner sees the same
+        // payload it would have under Composer.
+        /** @var mixed $extra */
+        $extra = $composer !== null
+            ? $composer->getPackage()->getExtra()
+            : (new ComposerJsonExtraReader())->read($projectRoot, $io);
 
         return (new SyncRunner())->run(
             $projectRoot,
             $provider,
-            $provider->rootExtras(),
+            $extra,
             $io,
             $options,
         );

--- a/src/Console/Command/Sync.php
+++ b/src/Console/Command/Sync.php
@@ -86,7 +86,15 @@ final class Sync extends Command
      */
     private static function tryBootstrapComposer(ConsoleIO $io): ?Composer
     {
-        if (!\is_file((\getcwd() ?: '.') . '/composer.json')) {
+        $cwd = \getcwd() ?: '.';
+        if (!\is_file($cwd . '/composer.json')) {
+            $io->writeError(
+                \sprintf(
+                    '<comment>[warn] no composer.json at %s — Composer donor provider is inactive.</comment>',
+                    $cwd,
+                ),
+                verbosity: \Composer\IO\IOInterface::VERBOSE,
+            );
             return null;
         }
 

--- a/src/Console/Command/Sync.php
+++ b/src/Console/Command/Sync.php
@@ -26,8 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * The bootstrap is **best-effort**: if no `composer.json` is found at the
  * current working directory, the {@see ComposerProvider} simply reports
- * itself inactive and the runner emits the `[no donors available]`
- * notice. Future providers (GitHub, npm, skills.sh, …) will plug into
+ * itself inactive and the runner emits the
+ * `no donor providers are active` notice. Future providers
+ * (GitHub, npm, skills.sh, …) will plug into
  * the same provider chain, so a Composer-less project will still have
  * actionable behaviour once those land. For now standalone mode is a
  * benign no-op rather than a crash.

--- a/src/Console/Command/Sync.php
+++ b/src/Console/Command/Sync.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Console\Command;
 
+use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
+use Internal\Path;
 use LLM\Skills\Console\SyncCliDefinition;
+use LLM\Skills\Discovery\Provider\ComposerProvider;
 use LLM\Skills\Sync\SyncRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -18,10 +21,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Unlike {@see \LLM\Skills\Composer\Command\Sync}, this entrypoint is *not*
  * invoked through `composer` and has no implicit Composer instance — we
- * bootstrap one ourselves via {@see Factory::create()}. The bootstrap reads
- * the current working directory's `composer.json`/`composer.lock`, so the
- * binary must be invoked from inside a Composer project (the same place
- * `composer install` would work).
+ * try to bootstrap one ourselves via {@see Factory::create()}.
+ *
+ * The bootstrap is **best-effort**: if no `composer.json` is found at the
+ * current working directory, the {@see ComposerProvider} simply reports
+ * itself inactive and the runner emits the `[no donors available]`
+ * notice. Future providers (GitHub, npm, skills.sh, …) will plug into
+ * the same provider chain, so a Composer-less project will still have
+ * actionable behaviour once those land. For now standalone mode is a
+ * benign no-op rather than a crash.
  *
  * `--disable-plugins` is set: when run from a global PHAR we have no reason
  * to load and execute third-party plugins, and we never want this binary to
@@ -52,13 +60,45 @@ final class Sync extends Command
             return self::INVALID;
         }
 
-        try {
-            $composer = Factory::create($io, null, disablePlugins: true, disableScripts: true);
-        } catch (\Throwable $e) {
-            $io->writeError('<error>[llm/skills] Failed to bootstrap Composer: ' . $e->getMessage() . '</error>');
-            return self::FAILURE;
+        $composer = self::tryBootstrapComposer($io);
+        $provider = new ComposerProvider($composer);
+        $projectRoot = Path::create(\getcwd() ?: '.');
+
+        return (new SyncRunner())->run(
+            $projectRoot,
+            $provider,
+            $provider->rootExtras(),
+            $io,
+            $options,
+        );
+    }
+
+    /**
+     * Best-effort {@see Factory::create()}. Returns `null` when the
+     * working directory has no `composer.json` (so the runner takes the
+     * standalone path) or when bootstrap fails for any other reason.
+     *
+     * Diagnostic output for non-trivial failures is intentionally
+     * limited to a `-v` line: a missing `composer.json` is the
+     * documented standalone case, not an error, so a noisy banner
+     * would just confuse users running `skills` outside any Composer
+     * project.
+     */
+    private static function tryBootstrapComposer(ConsoleIO $io): ?Composer
+    {
+        if (!\is_file((\getcwd() ?: '.') . '/composer.json')) {
+            return null;
         }
 
-        return (new SyncRunner())->run($composer, $io, $options);
+        try {
+            return Factory::create($io, null, disablePlugins: true, disableScripts: true);
+        } catch (\Throwable $e) {
+            $io->writeError(
+                '<comment>[warn] Composer bootstrap failed, continuing without it: '
+                . $e->getMessage() . '</comment>',
+                verbosity: \Composer\IO\IOInterface::VERBOSE,
+            );
+            return null;
+        }
     }
 }

--- a/src/Console/InitCliDefinition.php
+++ b/src/Console/InitCliDefinition.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Console;
+
+use LLM\Skills\Config\InitOptions;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Shared CLI surface for `skills:init` — used by both the Composer plugin
+ * entrypoint ({@see \LLM\Skills\Composer\Command\Init}) and the standalone
+ * binary ({@see \LLM\Skills\Console\Command\Init}).
+ *
+ * Centralising `configure()` and `buildOptions()` here guarantees that
+ * both entrypoints accept the same flags.
+ */
+final class InitCliDefinition
+{
+    private const DESCRIPTION = 'Bootstrap a skills.json file and (when applicable) migrate project '
+        . 'keys out of composer.json';
+
+    /**
+     * @param non-empty-string $name
+     * @param list<non-empty-string> $aliases
+     */
+    public static function apply(Command $command, string $name, array $aliases = []): void
+    {
+        $command
+            ->setName($name)
+            ->setAliases($aliases)
+            ->setDescription(self::DESCRIPTION)
+            ->addOption(
+                'path',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Where to create the external config, relative to the project root. '
+                . 'Default "skills.json". Must be inside the project root.',
+                'skills.json',
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Overwrite an existing file at the target path.',
+            );
+    }
+
+    /**
+     * @throws \InvalidArgumentException when `--path` is empty
+     */
+    public static function buildOptions(InputInterface $input): InitOptions
+    {
+        /** @var mixed $rawPath */
+        $rawPath = $input->getOption('path');
+        if (!\is_string($rawPath) || $rawPath === '') {
+            throw new \InvalidArgumentException('--path must be a non-empty string');
+        }
+
+        return new InitOptions(
+            path: $rawPath,
+            force: (bool) $input->getOption('force'),
+        );
+    }
+}

--- a/src/Discovery/Provider/ComposerProvider.php
+++ b/src/Discovery/Provider/ComposerProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider;
+
+use Composer\Composer;
+use Internal\Path;
+use LLM\Skills\Discovery\DonorDiscovery;
+use LLM\Skills\Discovery\DonorDiscoveryResult;
+
+/**
+ * Composer/Packagist {@see DonorProvider}.
+ *
+ * Wraps the existing {@see DonorDiscovery} that walks
+ * `Composer::getRepositoryManager()->getLocalRepository()->getPackages()`
+ * to enumerate donors. When no `Composer` instance is supplied (the
+ * standalone `bin/skills` ran outside any Composer project) the
+ * provider reports `isActive() === false` and contributes nothing —
+ * the runner falls through to the `[no donors available]` notice.
+ *
+ * Bootstrap concerns (how to obtain a `Composer` instance, what to
+ * do when `Factory::create()` throws) belong to the entrypoints
+ * ({@see \LLM\Skills\Composer\Command\Sync},
+ * {@see \LLM\Skills\Console\Command\Sync}); this provider just
+ * accepts whatever they pass in.
+ */
+final readonly class ComposerProvider implements DonorProvider
+{
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private ?Composer $composer = null,
+        private DonorDiscovery $discovery = new DonorDiscovery(),
+    ) {}
+
+    /**
+     * Composer's root-package extras — the `extra` field of the
+     * project's own `composer.json`. Used by the runner to map the
+     * legacy inline `extra.skills` block when no `skills.json` exists.
+     *
+     * Returns `null` when the provider has no Composer instance
+     * (standalone-mode run with no `composer.json`); the runner then
+     * lets the {@see \LLM\Skills\Config\Mapper\ProjectConfigMapper}
+     * fall back to defaults.
+     */
+    public function rootExtras(): mixed
+    {
+        return $this->composer?->getPackage()->getExtra();
+    }
+
+    /**
+     * @psalm-suppress MissingPureAnnotation
+     *         the inferred-pure body is incidental; the interface contract is impure
+     */
+    #[\Override]
+    public function isActive(Path $projectRoot): bool
+    {
+        return $this->composer !== null;
+    }
+
+    #[\Override]
+    public function discover(Path $projectRoot): DonorDiscoveryResult
+    {
+        if ($this->composer === null) {
+            return new DonorDiscoveryResult(donors: [], warnings: []);
+        }
+
+        return $this->discovery->discover($this->composer);
+    }
+
+    #[\Override]
+    public function directDependencies(Path $projectRoot): array
+    {
+        if ($this->composer === null) {
+            return [];
+        }
+
+        $root = $this->composer->getPackage();
+        $names = [];
+        foreach ([...$root->getRequires(), ...$root->getDevRequires()] as $name => $_link) {
+            if ($name === '' || !\str_contains($name, '/')) {
+                // Platform requirements like `php` or `ext-json` and
+                // metapackage placeholders never carry skills.
+                continue;
+            }
+            /** @var non-empty-string $name */
+            $names[] = $name;
+        }
+
+        return $names;
+    }
+}

--- a/src/Discovery/Provider/ComposerProvider.php
+++ b/src/Discovery/Provider/ComposerProvider.php
@@ -17,7 +17,8 @@ use LLM\Skills\Discovery\DonorDiscoveryResult;
  * to enumerate donors. When no `Composer` instance is supplied (the
  * standalone `bin/skills` ran outside any Composer project) the
  * provider reports `isActive() === false` and contributes nothing —
- * the runner falls through to the `[no donors available]` notice.
+ * the runner falls through to the `no donor providers are active`
+ * notice.
  *
  * Bootstrap concerns (how to obtain a `Composer` instance, what to
  * do when `Factory::create()` throws) belong to the entrypoints

--- a/src/Discovery/Provider/DonorProvider.php
+++ b/src/Discovery/Provider/DonorProvider.php
@@ -48,7 +48,7 @@ interface DonorProvider
      * Whether this provider has anything to contribute in the
      * current project. The runner uses the aggregate of all providers'
      * `isActive()` to decide whether to emit the
-     * `[no donors available]` notice (true when every provider
+     * `no donor providers are active` notice (true when every provider
      * reports inactive — typically "no donor ecosystem detected").
      *
      * @psalm-suppress MissingAbstractPureAnnotation

--- a/src/Discovery/Provider/DonorProvider.php
+++ b/src/Discovery/Provider/DonorProvider.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider;
+
+use Internal\Path;
+use LLM\Skills\Discovery\DonorDiscoveryResult;
+
+/**
+ * Source of donor packages for the sync pipeline.
+ *
+ * A provider knows how to enumerate donor packages from a specific
+ * ecosystem (Composer/Packagist, GitHub, npm, a flat `skills.sh`
+ * registry, …). The runner is agnostic — it gets a `DonorProvider`
+ * and asks it for donors, regardless of where they came from.
+ *
+ * Today only {@see ComposerProvider} exists. The interface exists so
+ * adding a `GithubProvider`, `NodeModulesProvider`, etc. is purely
+ * additive: implement this interface, register the new provider in
+ * the entrypoint, done.
+ *
+ * Implementations MUST be:
+ *
+ * - **Silent when inactive.** A provider that cannot contribute to
+ *   the current project ({@see ComposerProvider} in a directory
+ *   without `composer.json`, a hypothetical `NodeModulesProvider`
+ *   when no `node_modules/` exists, etc.) returns an empty
+ *   {@see DonorDiscoveryResult} from {@see self::discover()} and
+ *   `false` from {@see self::isActive()}. They do NOT throw.
+ * - **Idempotent.** Repeated calls produce the same output for
+ *   identical inputs. The runner may call {@see self::discover()}
+ *   more than once for a single run.
+ *
+ * Implementations read external state (filesystem, Composer's
+ * repository manager, future network clients) so the interface is
+ * intentionally NOT annotated `@psalm-immutable` — that would force
+ * every implementation to be pure, ruling out Composer (whose
+ * methods are not pure) as a dependency.
+ *
+ * @psalm-suppress MissingInterfaceImmutableAnnotation
+ *         the interface is deliberately NOT immutable — implementations may carry impure
+ *         dependencies like Composer
+ */
+interface DonorProvider
+{
+    /**
+     * Whether this provider has anything to contribute in the
+     * current project. The runner uses the aggregate of all providers'
+     * `isActive()` to decide whether to emit the
+     * `[no donors available]` notice (true when every provider
+     * reports inactive — typically "no donor ecosystem detected").
+     *
+     * @psalm-suppress MissingAbstractPureAnnotation
+     *         not all implementations are pure (the Composer one reads from a mutable repo)
+     */
+    public function isActive(Path $projectRoot): bool;
+
+    /**
+     * Walk the provider's source of truth and return every donor
+     * package it can find at `$projectRoot`. Returns an empty result
+     * (not `null`) when the provider is inactive or has nothing to
+     * offer.
+     *
+     * @psalm-suppress MissingAbstractPureAnnotation
+     *         implementations talk to Composer / network / filesystem and are not pure
+     */
+    public function discover(Path $projectRoot): DonorDiscoveryResult;
+
+    /**
+     * Names of packages this provider considers "direct dependencies"
+     * of the consumer project — used for the implicit-trust rule
+     * (a package declared in the consumer's manifest is trusted
+     * without needing an explicit pattern).
+     *
+     * Providers without a notion of "direct dep" (e.g. a hypothetical
+     * GitHub provider reading a flat list of repo URLs) return an
+     * empty list. Composer is the only first-class case today.
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-suppress MissingAbstractPureAnnotation
+     *         the Composer implementation reads from the (mutable) root package metadata
+     */
+    public function directDependencies(Path $projectRoot): array;
+}

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -93,7 +93,20 @@ final readonly class InitRunner
             && $options->path === 'skills.json'
             && \is_file($target)
         ) {
+            // Suppress so we can report a friendlier message ourselves
+            // (permission denied / file lock on Windows surfaces as a
+            // PHP warning otherwise). The follow-up `is_file` check is
+            // what actually decides whether to fail the run — a
+            // successful unlink leaves no file, period.
             @\unlink($target);
+            if (\is_file($target)) {
+                $io->writeError(\sprintf(
+                    '<error>[llm/skills] --force could not remove existing %s (file locked or permission denied). '
+                    . 'Remove it manually and re-run.</error>',
+                    $target,
+                ));
+                return Command::FAILURE;
+            }
         }
 
         $composerJsonPath = (string) $projectRoot->join('composer.json');

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -198,6 +198,14 @@ final readonly class InitRunner
                 ));
                 return Command::FAILURE;
             }
+            // POSIX `rename()` overwrites an existing destination
+            // transparently, but Windows refuses to. When the user
+            // passed `--force` and a file at the target survived the
+            // earlier refusal check, unlink it explicitly so `--force`
+            // is honoured the same way on both platforms.
+            if ($options->force && \is_file($target)) {
+                @\unlink($target);
+            }
             if (!@\rename($canonical, $target)) {
                 $io->writeError(\sprintf(
                     '<error>[llm/skills] failed to relocate skills.json to %s</error>',

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -145,7 +145,14 @@ final readonly class InitRunner
 
         $io->write('<info>[init]</info> standalone mode (no composer.json detected)');
         $io->write(\sprintf('<info>[init]</info> created %s', $options->path));
-        $io->write('<info>[init]</info> note: subsequent skills commands will read this file directly');
+
+        // The "subsequent commands will read this file" promise only holds
+        // when the file lives at the canonical location. For a custom
+        // --path, the `maybeWarnNonDefaultPath()` notice below contradicts
+        // it — emit one or the other, never both.
+        if ($options->path === 'skills.json') {
+            $io->write('<info>[init]</info> note: subsequent skills commands will read this file directly');
+        }
 
         $this->maybeWarnNonDefaultPath($io, $options->path);
 

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -92,7 +92,7 @@ final readonly class InitRunner
 
         // Canonical migration path. Non-default `--path` requires
         // post-processing (rename) since the migrator always writes
-        // to <root>/skills.json — see {@see self::handleNonDefaultPath()}.
+        // to <root>/skills.json — see {@see self::runNonDefaultPath()}.
         if ($options->path !== 'skills.json') {
             return $this->runNonDefaultPath($projectRoot, $io, $options, $target);
         }

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LLM\Skills\Init;
 
 use Composer\IO\IOInterface;
+use Composer\Json\JsonManipulator;
 use Internal\Path;
 use LLM\Skills\Config\InitOptions;
 use LLM\Skills\Config\Mapper\MigrationStatus;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
 use Symfony\Component\Console\Command\Command;
 
@@ -47,6 +49,7 @@ final readonly class InitRunner
      */
     public function __construct(
         private ProjectConfigMigrator $migrator = new ProjectConfigMigrator(),
+        private InteractiveInitWizard $wizard = new InteractiveInitWizard(),
     ) {}
 
     public function run(Path $projectRoot, IOInterface $io, InitOptions $options): int
@@ -80,12 +83,35 @@ final readonly class InitRunner
         // `--force` re-runs in the canonical location are handled by
         // unlinking the existing file first so the migrator's
         // "skills.json already exists → skip" branch does not short-
-        // circuit the rewrite the user explicitly asked for.
-        if ($options->force && $options->path === 'skills.json' && \is_file($target)) {
+        // circuit the rewrite the user explicitly asked for. For the
+        // interactive path we hold off on the unlink so we can still
+        // read the existing skills.json values as defaults — handled
+        // inside runInteractive() instead.
+        if (
+            !$io->isInteractive()
+            && $options->force
+            && $options->path === 'skills.json'
+            && \is_file($target)
+        ) {
             @\unlink($target);
         }
 
         $composerJsonPath = (string) $projectRoot->join('composer.json');
+
+        // `skills:init` is the command users run on purpose — it exists
+        // precisely because they want to think about their config. In
+        // interactive mode, walk them through the wizard with sensible
+        // defaults. CI / `--no-interaction` keeps the silent flow.
+        if ($io->isInteractive() && $options->path === 'skills.json') {
+            return $this->runInteractive(
+                $projectRoot,
+                $io,
+                $options,
+                $target,
+                \is_file($composerJsonPath) ? $composerJsonPath : null,
+            );
+        }
+
         if (!\is_file($composerJsonPath)) {
             return $this->runStandalone($io, $options, $target);
         }
@@ -132,6 +158,187 @@ final readonly class InitRunner
                 $io->write('<info>[init]</info> note: skills:update will read project config from skills.json');
                 return Command::SUCCESS;
         }
+    }
+
+    /**
+     * Interactive flow. Resolves defaults from (priority order):
+     *
+     * 1. The existing `skills.json` when `--force` re-runs on top of
+     *    one — current values become the prompts' defaults so users
+     *    can tune knob-by-knob.
+     * 2. The inline `extra.skills` block in `composer.json` — only
+     *    when the user confirms "import current settings?" at the
+     *    top of the wizard.
+     * 3. {@see ProjectConfig::default()}.
+     *
+     * After the wizard returns: writes `skills.json` with the user's
+     * answers, then strips the inline keys from `composer.json` (if
+     * the file existed and carried project keys). Cancelling at the
+     * final confirmation aborts cleanly without writing anything.
+     *
+     * @param non-empty-string $target
+     * @param non-empty-string|null $composerJsonPath
+     */
+    private function runInteractive(
+        Path $projectRoot,
+        IOInterface $io,
+        InitOptions $options,
+        string $target,
+        ?string $composerJsonPath,
+    ): int {
+        $defaults = [];
+
+        // Existing skills.json (only under --force; the early refusal
+        // check would have failed otherwise).
+        if (\is_file($target)) {
+            $existing = $this->readJsonObject($target, $io, 'skills.json');
+            if ($existing === null) {
+                return Command::FAILURE;
+            }
+            unset($existing['$schema']);
+            $defaults = $existing;
+        }
+
+        $inlineKeys = [];
+        if ($composerJsonPath !== null && $defaults === []) {
+            $composerDecoded = $this->readJsonObject($composerJsonPath, $io, 'composer.json');
+            if ($composerDecoded === null) {
+                return Command::FAILURE;
+            }
+            /** @var array<string, mixed> $extra */
+            $extra = \is_array($composerDecoded['extra'] ?? null) ? $composerDecoded['extra'] : [];
+            /** @var array<string, mixed> $skills */
+            $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
+            $inlineKeys = ProjectConfigMigrator::extractProjectKeys($skills);
+
+            if ($inlineKeys !== []) {
+                $io->write(\sprintf(
+                    '<info>[init]</info> detected inline extra.skills in composer.json: %s',
+                    \implode(', ', \array_keys($inlineKeys)),
+                ));
+                if ($io->askConfirmation(
+                    '<info>Import these as defaults?</info> [<comment>Y/n</comment>]: ',
+                    true,
+                )) {
+                    $defaults = $inlineKeys;
+                }
+            }
+        }
+
+        $resolved = $this->wizard->run($io, $defaults);
+        if ($resolved === null) {
+            return Command::SUCCESS;
+        }
+
+        $content = ProjectConfigMigrator::renderSkillsJson($this->orderedProjectKeys($resolved));
+        if (\file_put_contents($target, $content) === false) {
+            $io->writeError(\sprintf('<error>[llm/skills] failed to write %s</error>', $target));
+            return Command::FAILURE;
+        }
+
+        // Strip inline keys from composer.json if any are present. We
+        // re-read composer.json here (instead of reusing the
+        // earlier decode) because JsonManipulator needs the raw bytes
+        // for in-place editing.
+        if ($composerJsonPath !== null && $inlineKeys !== []) {
+            if (!$this->stripInlineKeys($composerJsonPath, \array_keys($inlineKeys), $io)) {
+                $io->write(
+                    '<comment>[init] note: skills.json was written, but stripping '
+                    . 'composer.json failed. skills.json wins from now on regardless.</comment>',
+                );
+                return Command::FAILURE;
+            }
+            $io->write('<info>[init]</info> composer.json updated: removed inline project keys.');
+        }
+
+        $io->write(\sprintf('<info>[init]</info> wrote %s', $options->path));
+        $io->write('<info>[init]</info> done.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Re-order an arbitrary project-keys map to match
+     * {@see ProjectConfigMapper::PROJECT_KEYS} so generated files are
+     * diff-stable across runs.
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return array<non-empty-string, mixed>
+     *
+     * @psalm-pure
+     */
+    private function orderedProjectKeys(array $values): array
+    {
+        $out = [];
+        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $values)) {
+                /** @psalm-suppress MixedAssignment */
+                $out[$key] = $values[$key];
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param non-empty-string $path
+     * @param non-empty-string $label used in error messages
+     *
+     * @return array<string, mixed>|null
+     */
+    private function readJsonObject(string $path, IOInterface $io, string $label): ?array
+    {
+        $raw = \file_get_contents($path);
+        if ($raw === false) {
+            $io->writeError(\sprintf('<error>[llm/skills] failed to read %s</error>', $label));
+            return null;
+        }
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] %s is not valid JSON: %s</error>',
+                $label,
+                $e->getMessage(),
+            ));
+            return null;
+        }
+        if (!\is_array($decoded)) {
+            $io->writeError(\sprintf('<error>[llm/skills] %s must be a JSON object</error>', $label));
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param non-empty-string $composerJsonPath
+     * @param list<non-empty-string> $keys
+     */
+    private function stripInlineKeys(string $composerJsonPath, array $keys, IOInterface $io): bool
+    {
+        $raw = \file_get_contents($composerJsonPath);
+        if ($raw === false) {
+            $io->writeError('<error>[llm/skills] failed to re-read composer.json for cleanup</error>');
+            return false;
+        }
+        $manipulator = new JsonManipulator($raw);
+        foreach ($keys as $key) {
+            if (!$manipulator->removeSubNode('extra', 'skills.' . $key)) {
+                $io->writeError(\sprintf(
+                    '<error>[llm/skills] JsonManipulator failed on extra.skills.%s</error>',
+                    $key,
+                ));
+                return false;
+            }
+        }
+        if (\file_put_contents($composerJsonPath, $manipulator->getContents()) === false) {
+            $io->writeError('<error>[llm/skills] failed to write composer.json</error>');
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -5,48 +5,48 @@ declare(strict_types=1);
 namespace LLM\Skills\Init;
 
 use Composer\IO\IOInterface;
-use Composer\Json\JsonManipulator;
 use Internal\Path;
-use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\InitOptions;
-use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use LLM\Skills\Config\Mapper\MigrationStatus;
+use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * Body of the `skills:init` command — independent of which entrypoint
  * invoked it.
  *
- * Detects whether `composer.json` exists at the project root and runs
- * one of two flows:
+ * Composer-attached projects: delegate to {@see ProjectConfigMigrator}.
+ * Same code path the auto-migration in `skills:update` uses; running
+ * `skills:init` explicitly is just the fast way to perform the
+ * migration without doing a full sync.
  *
- * - **Composer-attached** — read the inline `extra.skills` block,
- *   partition its keys into project vs donor, write the project keys
- *   into a fresh `skills.json`, and rewrite `composer.json` to drop the
- *   migrated project keys (donor `source` and any unrelated `extra`
- *   keys are left in place).
- * - **Standalone** — write a stub `skills.json` (only `$schema`) and
- *   touch nothing else.
+ * Standalone projects (no `composer.json` at cwd): write a stub
+ * `skills.json` containing only the `$schema` pointer so the user has
+ * a starting point.
  *
- * The flow is **atomic on success**: validation happens before any
- * filesystem write, and the two writes (skills.json, composer.json)
- * run in fixed order — `skills.json` first, so a crash before the
- * second write leaves the new file plus the original `composer.json`
- * intact. A re-run with `--force` recovers from any partial state.
+ * The `--path` flag lets the user pick a non-canonical location for
+ * the generated file. Subsequent commands only look at the canonical
+ * `skills.json` at the project root, so a non-default `--path` also
+ * emits a notice — it's a "create, then move it yourself" affordance.
+ *
+ * The migrator handles the composer-attached refusal logic
+ * implicitly (skills.json already exists → no-op); InitRunner adds
+ * the user-facing refusal-without-force semantics on top.
  */
 final readonly class InitRunner
 {
     /**
-     * URL of the published JSON schema. Emitted into the generated file's
-     * `$schema` field so editors that follow the link can offer
-     * validation / autocompletion.
+     * URL of the published JSON schema. Kept as a class constant for
+     * the standalone-stub path (the migrator owns the same value for
+     * the migration path).
      */
-    public const SCHEMA_URL = 'https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json';
+    public const SCHEMA_URL = ProjectConfigMigrator::SCHEMA_URL;
 
     /**
      * @psalm-mutation-free
      */
     public function __construct(
-        private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
+        private ProjectConfigMigrator $migrator = new ProjectConfigMigrator(),
     ) {}
 
     public function run(Path $projectRoot, IOInterface $io, InitOptions $options): int
@@ -60,10 +60,6 @@ final readonly class InitRunner
             return Command::INVALID;
         }
 
-        // A pre-existing directory (or other non-file) at the target path
-        // cannot be overwritten by writing a file — let the user know
-        // explicitly rather than letting `file_put_contents` fail later
-        // with a generic message.
         if (\file_exists($target) && !\is_file($target)) {
             $io->writeError(\sprintf(
                 '<error>[llm/skills] %s exists but is not a regular file; '
@@ -81,21 +77,69 @@ final readonly class InitRunner
             return Command::FAILURE;
         }
 
+        // `--force` re-runs in the canonical location are handled by
+        // unlinking the existing file first so the migrator's
+        // "skills.json already exists → skip" branch does not short-
+        // circuit the rewrite the user explicitly asked for.
+        if ($options->force && $options->path === 'skills.json' && \is_file($target)) {
+            @\unlink($target);
+        }
+
         $composerJsonPath = (string) $projectRoot->join('composer.json');
         if (!\is_file($composerJsonPath)) {
             return $this->runStandalone($io, $options, $target);
         }
 
-        return $this->runComposerAttached($projectRoot, $composerJsonPath, $io, $options, $target);
+        // Canonical migration path. Non-default `--path` requires
+        // post-processing (rename) since the migrator always writes
+        // to <root>/skills.json — see {@see self::handleNonDefaultPath()}.
+        if ($options->path !== 'skills.json') {
+            return $this->runNonDefaultPath($projectRoot, $io, $options, $target);
+        }
+
+        $result = $this->migrator->migrate($projectRoot, $io);
+
+        switch ($result->status) {
+            case MigrationStatus::Failed:
+                return Command::FAILURE;
+
+            case MigrationStatus::Skipped:
+                // Either skills.json already exists (handled above when
+                // --force not set) or there are no inline keys to
+                // migrate. Either way, ensure a stub exists so the
+                // user can start adding things.
+                if (!\is_file($target)) {
+                    if (!$this->writeStub($target, $io)) {
+                        return Command::FAILURE;
+                    }
+                    $io->write(\sprintf(
+                        '<info>[init]</info> created %s (no project keys to migrate; stub created)',
+                        $options->path,
+                    ));
+                    $io->write('<info>[init]</info> note: skills:update will read project config from skills.json');
+                }
+                return Command::SUCCESS;
+
+            case MigrationStatus::Migrated:
+                $io->write(\sprintf(
+                    '<info>[init]</info> created %s (migrated: %s)',
+                    $options->path,
+                    \implode(', ', $result->migratedKeys),
+                ));
+                $io->write(
+                    '<info>[init]</info> composer.json updated: removed migrated project keys from extra.skills',
+                );
+                $io->write('<info>[init]</info> note: skills:update will read project config from skills.json');
+                return Command::SUCCESS;
+        }
     }
 
     /**
-     * @param non-empty-string $target absolute path to the skills.json being created
+     * @param non-empty-string $target
      */
     private function runStandalone(IOInterface $io, InitOptions $options, string $target): int
     {
-        $content = $this->renderSkillsJson([]);
-        if (!$this->writeFile($target, $content, $io)) {
+        if (!$this->writeStub($target, $io)) {
             return Command::FAILURE;
         }
 
@@ -109,117 +153,84 @@ final readonly class InitRunner
     }
 
     /**
-     * @param non-empty-string $composerJsonPath
-     * @param non-empty-string $target absolute path to the skills.json being created
+     * Composer-attached + non-canonical `--path`. The migrator always
+     * writes to `skills.json` at the project root, so we let it do
+     * its job and then move the file to the requested location.
+     * Always followed by the "won't be auto-discovered" notice.
+     *
+     * @param non-empty-string $target
      */
-    private function runComposerAttached(
+    private function runNonDefaultPath(
         Path $projectRoot,
-        string $composerJsonPath,
         IOInterface $io,
         InitOptions $options,
         string $target,
     ): int {
-        $original = \file_get_contents($composerJsonPath);
-        if ($original === false) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] failed to read composer.json at %s</error>',
-                $composerJsonPath,
-            ));
+        $canonical = (string) $projectRoot->join('skills.json');
+        $canonicalExisted = \is_file($canonical);
+
+        $result = $this->migrator->migrate($projectRoot, $io);
+
+        if ($result->status === MigrationStatus::Failed) {
             return Command::FAILURE;
         }
 
-        try {
-            /** @var mixed $decoded */
-            $decoded = \json_decode($original, true, flags: \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] composer.json is not valid JSON: %s</error>',
-                $e->getMessage(),
-            ));
-            return Command::FAILURE;
-        }
-
-        if (!\is_array($decoded)) {
-            $io->writeError('<error>[llm/skills] composer.json must be a JSON object</error>');
-            return Command::FAILURE;
-        }
-
-        /** @var array<string, mixed> $extra */
-        $extra = \is_array($decoded['extra'] ?? null) ? $decoded['extra'] : [];
-        /** @var array<string, mixed> $skills */
-        $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
-
-        // Pre-flight: confirm the inline block is well-formed. Migrating
-        // a malformed config silently would just relocate the bug into
-        // skills.json where it would surface on the next sync — fail loud
-        // up front instead.
-        try {
-            $this->projectMapper->fromExtra($extra);
-        } catch (MalformedProjectConfig $e) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] cannot migrate: inline extra.skills is malformed — %s</error>',
-                $e->getMessage(),
-            ));
-            return Command::FAILURE;
-        }
-
-        $migrated = $this->extractProjectKeys($skills);
-
-        // Validate that the future skills.json itself maps cleanly — a
-        // second safety net in case extractProjectKeys reshapes anything
-        // (it currently does not, but the cost of running it is trivial).
-        try {
-            $this->projectMapper->fromExtra(['skills' => $migrated]);
-        } catch (MalformedProjectConfig $e) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] migrated content is not a valid skills.json: %s</error>',
-                $e->getMessage(),
-            ));
-            return Command::FAILURE;
-        }
-
-        $content = $this->renderSkillsJson($migrated);
-
-        // Write skills.json first. If composer.json rewrite then fails,
-        // re-running with --force fixes the partial state.
-        if (!$this->writeFile($target, $content, $io)) {
-            return Command::FAILURE;
-        }
-
-        $migratedKeys = \array_keys($migrated);
-        if ($migratedKeys !== []) {
-            $manipulator = new JsonManipulator($original);
-            foreach ($migratedKeys as $key) {
-                if (!$manipulator->removeSubNode('extra', 'skills.' . $key)) {
-                    $io->writeError(\sprintf(
-                        '<error>[llm/skills] failed to remove extra.skills.%s from composer.json '
-                        . '(skills.json was written; re-run with --force after fixing composer.json)</error>',
-                        $key,
-                    ));
-                    return Command::FAILURE;
-                }
-            }
-
-            $newComposer = $manipulator->getContents();
-            if (\file_put_contents($composerJsonPath, $newComposer) === false) {
+        // Either the migrator wrote skills.json or it was already
+        // there. In the latter case we still need a file at $target;
+        // create a stub for it.
+        if ($result->status === MigrationStatus::Migrated) {
+            // The migrator always lands its output at the canonical
+            // path; ensure the parent of the user-chosen path exists
+            // before renaming, otherwise the rename will silently fail
+            // on a non-existent subdirectory.
+            $dir = \dirname($target);
+            if (!\is_dir($dir) && !@\mkdir($dir, 0o777, true) && !\is_dir($dir)) {
                 $io->writeError(\sprintf(
-                    '<error>[llm/skills] failed to write composer.json at %s</error>',
-                    $composerJsonPath,
+                    '<error>[llm/skills] failed to create directory %s</error>',
+                    $dir,
                 ));
                 return Command::FAILURE;
             }
+            if (!@\rename($canonical, $target)) {
+                $io->writeError(\sprintf(
+                    '<error>[llm/skills] failed to relocate skills.json to %s</error>',
+                    $options->path,
+                ));
+                return Command::FAILURE;
+            }
+            $io->write(\sprintf(
+                '<info>[init]</info> created %s (migrated: %s)',
+                $options->path,
+                \implode(', ', $result->migratedKeys),
+            ));
+            $io->write(
+                '<info>[init]</info> composer.json updated: removed migrated project keys from extra.skills',
+            );
+        } else {
+            // Skipped → stub at $target. If skills.json at the canonical
+            // location was created by an earlier explicit run we leave
+            // it; otherwise nothing else to clean up.
+            if (!$canonicalExisted && \is_file($canonical)) {
+                @\unlink($canonical);
+            }
+            if (!$this->writeStub($target, $io)) {
+                return Command::FAILURE;
+            }
+            $io->write(\sprintf(
+                '<info>[init]</info> created %s (no project keys to migrate; stub created)',
+                $options->path,
+            ));
         }
 
-        $this->emitComposerAttachedReport($io, $options->path, $migratedKeys);
         $this->maybeWarnNonDefaultPath($io, $options->path);
 
         return Command::SUCCESS;
     }
 
     /**
-     * @param non-empty-string $target absolute filesystem path
+     * @param non-empty-string $target
      */
-    private function writeFile(string $target, string $content, IOInterface $io): bool
+    private function writeStub(string $target, IOInterface $io): bool
     {
         $dir = \dirname($target);
         if (!\is_dir($dir) && !@\mkdir($dir, 0o777, true) && !\is_dir($dir)) {
@@ -230,6 +241,7 @@ final readonly class InitRunner
             return false;
         }
 
+        $content = ProjectConfigMigrator::renderSkillsJson([]);
         if (\file_put_contents($target, $content) === false) {
             $io->writeError(\sprintf(
                 '<error>[llm/skills] failed to write %s</error>',
@@ -242,15 +254,6 @@ final readonly class InitRunner
     }
 
     /**
-     * Resolve `$raw` against the project root and verify the result stays
-     * inside it.
-     *
-     * Reuses the {@see Path::match()} containment idiom that
-     * {@see \LLM\Skills\Sync\SyncPlanner::assertWithinProject()} uses so
-     * semantics stay aligned. `null` means the input is not acceptable
-     * (absolute path or `..`-escape) — caller turns that into a fatal
-     * error.
-     *
      * @return non-empty-string|null absolute filesystem path or `null` if input is invalid
      */
     private function resolveTargetPath(Path $projectRoot, string $raw): ?string
@@ -272,84 +275,9 @@ final readonly class InitRunner
     }
 
     /**
-     * Extract the project-level keys (the ones documented in
-     * {@see ProjectConfigMapper::PROJECT_KEYS}) from the inline
-     * `extra.skills` block. Donor `source` and any unrelated keys are
-     * deliberately dropped from the result.
-     *
-     * @param array<array-key, mixed> $skills the inline `extra.skills` value
-     *
-     * @return array<non-empty-string, mixed> ordered per {@see ProjectConfigMapper::PROJECT_KEYS}
-     *
-     * @psalm-pure
-     */
-    private function extractProjectKeys(array $skills): array
-    {
-        $out = [];
-        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
-            if (\array_key_exists($key, $skills)) {
-                /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
-                $out[$key] = $skills[$key];
-            }
-        }
-
-        return $out;
-    }
-
-    /**
-     * Emit the file content for a new `skills.json`. Defaults are NOT
-     * written — only the keys the user actually customised. Always
-     * starts with a `$schema` pointer so editors can validate the file.
-     *
-     * @param array<string, mixed> $migrated project keys in {@see ProjectConfigMapper::PROJECT_KEYS} order
-     *
-     * @psalm-pure
-     */
-    private function renderSkillsJson(array $migrated): string
-    {
-        $payload = ['$schema' => self::SCHEMA_URL] + $migrated;
-
-        $json = \json_encode(
-            $payload,
-            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
-        );
-        if ($json === false) {
-            throw new \RuntimeException('Failed to encode skills.json payload');
-        }
-
-        return $json . "\n";
-    }
-
-    /**
-     * @param list<non-empty-string> $migratedKeys
-     */
-    private function emitComposerAttachedReport(IOInterface $io, string $path, array $migratedKeys): void
-    {
-        if ($migratedKeys === []) {
-            $io->write(\sprintf(
-                '<info>[init]</info> created %s (no project keys to migrate; stub created)',
-                $path,
-            ));
-            $io->write('<info>[init]</info> note: skills:update will now read project config from skills.json');
-            return;
-        }
-
-        $io->write(\sprintf(
-            '<info>[init]</info> created %s (migrated: %s)',
-            $path,
-            \implode(', ', $migratedKeys),
-        ));
-        $io->write(
-            '<info>[init]</info> composer.json updated: removed migrated project keys from extra.skills',
-        );
-        $io->write('<info>[init]</info> note: skills:update will now read project config from skills.json');
-    }
-
-    /**
-     * Warn the user when `--path` is anything other than the canonical
-     * `skills.json`. The loader only looks at that exact filename at the
-     * project root, so a custom location is created but won't be picked
-     * up by subsequent commands.
+     * The loader only auto-discovers `skills.json` at the project root.
+     * A custom location is created but won't be picked up by subsequent
+     * commands — surface that explicitly so the user is not surprised.
      */
     private function maybeWarnNonDefaultPath(IOInterface $io, string $path): void
     {

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -239,9 +239,12 @@ final readonly class InitRunner
         // Strip inline keys from composer.json if any are present. We
         // re-read composer.json here (instead of reusing the
         // earlier decode) because JsonManipulator needs the raw bytes
-        // for in-place editing.
+        // for in-place editing. We also pass the full original `$skills`
+        // block so the helper can collapse an empty `"skills": {}`
+        // residue (and an empty `"extra": {}`) after the strip.
         if ($composerJsonPath !== null && $inlineKeys !== []) {
-            if (!$this->stripInlineKeys($composerJsonPath, \array_keys($inlineKeys), $io)) {
+            /** @var array<string, mixed> $skills */
+            if (!$this->stripInlineKeys($composerJsonPath, $skills, \array_keys($inlineKeys), $io)) {
                 $io->write(
                     '<comment>[init] note: skills.json was written, but stripping '
                     . 'composer.json failed. skills.json wins from now on regardless.</comment>',
@@ -315,10 +318,17 @@ final readonly class InitRunner
 
     /**
      * @param non-empty-string $composerJsonPath
+     * @param array<string, mixed> $originalSkills the inline `extra.skills` block as it
+     *        existed before the strip; used to decide whether to collapse an
+     *        empty `"skills": {}` residue (and a now-empty `"extra": {}`)
      * @param list<non-empty-string> $keys
      */
-    private function stripInlineKeys(string $composerJsonPath, array $keys, IOInterface $io): bool
-    {
+    private function stripInlineKeys(
+        string $composerJsonPath,
+        array $originalSkills,
+        array $keys,
+        IOInterface $io,
+    ): bool {
         $raw = \file_get_contents($composerJsonPath);
         if ($raw === false) {
             $io->writeError('<error>[llm/skills] failed to re-read composer.json for cleanup</error>');
@@ -334,6 +344,16 @@ final readonly class InitRunner
                 return false;
             }
         }
+
+        // If the `extra.skills` block had nothing but the keys we just
+        // stripped, the leftover `"skills": {}` is dead weight — strip
+        // it too. Same hygiene for `"extra": {}`.
+        $remaining = \array_diff(\array_keys($originalSkills), $keys);
+        if ($remaining === []) {
+            $manipulator->removeSubNode('extra', 'skills');
+            $manipulator->removeMainKeyIfEmpty('extra');
+        }
+
         if (\file_put_contents($composerJsonPath, $manipulator->getContents()) === false) {
             $io->writeError('<error>[llm/skills] failed to write composer.json</error>');
             return false;

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Init;
+
+use Composer\IO\IOInterface;
+use Composer\Json\JsonManipulator;
+use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Config\InitOptions;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Body of the `skills:init` command — independent of which entrypoint
+ * invoked it.
+ *
+ * Detects whether `composer.json` exists at the project root and runs
+ * one of two flows:
+ *
+ * - **Composer-attached** — read the inline `extra.skills` block,
+ *   partition its keys into project vs donor, write the project keys
+ *   into a fresh `skills.json`, and rewrite `composer.json` to drop the
+ *   migrated project keys (donor `source` and any unrelated `extra`
+ *   keys are left in place).
+ * - **Standalone** — write a stub `skills.json` (only `$schema`) and
+ *   touch nothing else.
+ *
+ * The flow is **atomic on success**: validation happens before any
+ * filesystem write, and the two writes (skills.json, composer.json)
+ * run in fixed order — `skills.json` first, so a crash before the
+ * second write leaves the new file plus the original `composer.json`
+ * intact. A re-run with `--force` recovers from any partial state.
+ */
+final readonly class InitRunner
+{
+    /**
+     * URL of the published JSON schema. Emitted into the generated file's
+     * `$schema` field so editors that follow the link can offer
+     * validation / autocompletion.
+     */
+    public const SCHEMA_URL = 'https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json';
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
+    ) {}
+
+    public function run(Path $projectRoot, IOInterface $io, InitOptions $options): int
+    {
+        $target = $this->resolveTargetPath($projectRoot, $options->path);
+        if ($target === null) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] --path "%s" must be a relative path inside the project root</error>',
+                $options->path,
+            ));
+            return Command::INVALID;
+        }
+
+        if (\is_file($target) && !$options->force) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] %s already exists; pass --force to overwrite</error>',
+                $options->path,
+            ));
+            return Command::FAILURE;
+        }
+
+        $composerJsonPath = (string) $projectRoot->join('composer.json');
+        if (!\is_file($composerJsonPath)) {
+            return $this->runStandalone($io, $options, $target);
+        }
+
+        return $this->runComposerAttached($projectRoot, $composerJsonPath, $io, $options, $target);
+    }
+
+    /**
+     * @param non-empty-string $target absolute path to the skills.json being created
+     */
+    private function runStandalone(IOInterface $io, InitOptions $options, string $target): int
+    {
+        $content = $this->renderSkillsJson([]);
+        if (!$this->writeFile($target, $content, $io)) {
+            return Command::FAILURE;
+        }
+
+        $io->write('<info>[init]</info> standalone mode (no composer.json detected)');
+        $io->write(\sprintf('<info>[init]</info> created %s', $options->path));
+        $io->write('<info>[init]</info> note: subsequent skills commands will read this file directly');
+
+        $this->maybeWarnNonDefaultPath($io, $options->path);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param non-empty-string $composerJsonPath
+     * @param non-empty-string $target absolute path to the skills.json being created
+     */
+    private function runComposerAttached(
+        Path $projectRoot,
+        string $composerJsonPath,
+        IOInterface $io,
+        InitOptions $options,
+        string $target,
+    ): int {
+        $original = \file_get_contents($composerJsonPath);
+        if ($original === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to read composer.json at %s</error>',
+                $composerJsonPath,
+            ));
+            return Command::FAILURE;
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($original, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] composer.json is not valid JSON: %s</error>',
+                $e->getMessage(),
+            ));
+            return Command::FAILURE;
+        }
+
+        if (!\is_array($decoded)) {
+            $io->writeError('<error>[llm/skills] composer.json must be a JSON object</error>');
+            return Command::FAILURE;
+        }
+
+        /** @var array<string, mixed> $extra */
+        $extra = \is_array($decoded['extra'] ?? null) ? $decoded['extra'] : [];
+        /** @var array<string, mixed> $skills */
+        $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
+
+        // Pre-flight: confirm the inline block is well-formed. Migrating
+        // a malformed config silently would just relocate the bug into
+        // skills.json where it would surface on the next sync — fail loud
+        // up front instead.
+        try {
+            $this->projectMapper->fromExtra($extra);
+        } catch (MalformedProjectConfig $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] cannot migrate: inline extra.skills is malformed — %s</error>',
+                $e->getMessage(),
+            ));
+            return Command::FAILURE;
+        }
+
+        $migrated = $this->extractProjectKeys($skills);
+
+        // Validate that the future skills.json itself maps cleanly — a
+        // second safety net in case extractProjectKeys reshapes anything
+        // (it currently does not, but the cost of running it is trivial).
+        try {
+            $this->projectMapper->fromExtra(['skills' => $migrated]);
+        } catch (MalformedProjectConfig $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] migrated content is not a valid skills.json: %s</error>',
+                $e->getMessage(),
+            ));
+            return Command::FAILURE;
+        }
+
+        $content = $this->renderSkillsJson($migrated);
+
+        // Write skills.json first. If composer.json rewrite then fails,
+        // re-running with --force fixes the partial state.
+        if (!$this->writeFile($target, $content, $io)) {
+            return Command::FAILURE;
+        }
+
+        $migratedKeys = \array_keys($migrated);
+        if ($migratedKeys !== []) {
+            $manipulator = new JsonManipulator($original);
+            foreach ($migratedKeys as $key) {
+                if (!$manipulator->removeSubNode('extra', 'skills.' . $key)) {
+                    $io->writeError(\sprintf(
+                        '<error>[llm/skills] failed to remove extra.skills.%s from composer.json '
+                        . '(skills.json was written; re-run with --force after fixing composer.json)</error>',
+                        $key,
+                    ));
+                    return Command::FAILURE;
+                }
+            }
+
+            $newComposer = $manipulator->getContents();
+            if (\file_put_contents($composerJsonPath, $newComposer) === false) {
+                $io->writeError(\sprintf(
+                    '<error>[llm/skills] failed to write composer.json at %s</error>',
+                    $composerJsonPath,
+                ));
+                return Command::FAILURE;
+            }
+        }
+
+        $this->emitComposerAttachedReport($io, $options->path, $migratedKeys);
+        $this->maybeWarnNonDefaultPath($io, $options->path);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param non-empty-string $target absolute filesystem path
+     */
+    private function writeFile(string $target, string $content, IOInterface $io): bool
+    {
+        $dir = \dirname($target);
+        if (!\is_dir($dir) && !@\mkdir($dir, 0o777, true) && !\is_dir($dir)) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to create directory %s</error>',
+                $dir,
+            ));
+            return false;
+        }
+
+        if (\file_put_contents($target, $content) === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to write %s</error>',
+                $target,
+            ));
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve `$raw` against the project root and verify the result stays
+     * inside it.
+     *
+     * Reuses the {@see Path::match()} containment idiom that
+     * {@see \LLM\Skills\Sync\SyncPlanner::assertWithinProject()} uses so
+     * semantics stay aligned. `null` means the input is not acceptable
+     * (absolute path or `..`-escape) — caller turns that into a fatal
+     * error.
+     *
+     * @return non-empty-string|null absolute filesystem path or `null` if input is invalid
+     */
+    private function resolveTargetPath(Path $projectRoot, string $raw): ?string
+    {
+        if ($raw === '') {
+            return null;
+        }
+        $rawPath = Path::create($raw);
+        if ($rawPath->isAbsolute()) {
+            return null;
+        }
+
+        $resolved = $projectRoot->join($rawPath);
+        if (!$resolved->match($projectRoot->join('*'))) {
+            return null;
+        }
+
+        return (string) $resolved;
+    }
+
+    /**
+     * Extract the project-level keys (the ones documented in
+     * {@see ProjectConfigMapper::PROJECT_KEYS}) from the inline
+     * `extra.skills` block. Donor `source` and any unrelated keys are
+     * deliberately dropped from the result.
+     *
+     * @param array<array-key, mixed> $skills the inline `extra.skills` value
+     *
+     * @return array<non-empty-string, mixed> ordered per {@see ProjectConfigMapper::PROJECT_KEYS}
+     *
+     * @psalm-pure
+     */
+    private function extractProjectKeys(array $skills): array
+    {
+        $out = [];
+        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
+                $out[$key] = $skills[$key];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Emit the file content for a new `skills.json`. Defaults are NOT
+     * written — only the keys the user actually customised. Always
+     * starts with a `$schema` pointer so editors can validate the file.
+     *
+     * @param array<string, mixed> $migrated project keys in {@see ProjectConfigMapper::PROJECT_KEYS} order
+     *
+     * @psalm-pure
+     */
+    private function renderSkillsJson(array $migrated): string
+    {
+        $payload = ['$schema' => self::SCHEMA_URL] + $migrated;
+
+        $json = \json_encode(
+            $payload,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+        );
+        if ($json === false) {
+            throw new \RuntimeException('Failed to encode skills.json payload');
+        }
+
+        return $json . "\n";
+    }
+
+    /**
+     * @param list<non-empty-string> $migratedKeys
+     */
+    private function emitComposerAttachedReport(IOInterface $io, string $path, array $migratedKeys): void
+    {
+        if ($migratedKeys === []) {
+            $io->write(\sprintf(
+                '<info>[init]</info> created %s (no project keys to migrate; stub created)',
+                $path,
+            ));
+            $io->write('<info>[init]</info> note: skills:update will now read project config from skills.json');
+            return;
+        }
+
+        $io->write(\sprintf(
+            '<info>[init]</info> created %s (migrated: %s)',
+            $path,
+            \implode(', ', $migratedKeys),
+        ));
+        $io->write(
+            '<info>[init]</info> composer.json updated: removed migrated project keys from extra.skills',
+        );
+        $io->write('<info>[init]</info> note: skills:update will now read project config from skills.json');
+    }
+
+    /**
+     * Warn the user when `--path` is anything other than the canonical
+     * `skills.json`. The loader only looks at that exact filename at the
+     * project root, so a custom location is created but won't be picked
+     * up by subsequent commands.
+     */
+    private function maybeWarnNonDefaultPath(IOInterface $io, string $path): void
+    {
+        if ($path === 'skills.json') {
+            return;
+        }
+
+        $io->writeError(\sprintf(
+            '<comment>[init] note: only "skills.json" at the project root is auto-loaded by '
+            . 'subsequent commands; "%s" was written but will not be discovered. '
+            . 'Move or rename it to skills.json to activate.</comment>',
+            $path,
+        ));
+    }
+}

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -60,6 +60,19 @@ final readonly class InitRunner
             return Command::INVALID;
         }
 
+        // A pre-existing directory (or other non-file) at the target path
+        // cannot be overwritten by writing a file — let the user know
+        // explicitly rather than letting `file_put_contents` fail later
+        // with a generic message.
+        if (\file_exists($target) && !\is_file($target)) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] %s exists but is not a regular file; '
+                . 'cannot write skills.json there. Choose a different --path or remove it.</error>',
+                $options->path,
+            ));
+            return Command::FAILURE;
+        }
+
         if (\is_file($target) && !$options->force) {
             $io->writeError(\sprintf(
                 '<error>[llm/skills] %s already exists; pass --force to overwrite</error>',

--- a/src/Init/InteractiveInitWizard.php
+++ b/src/Init/InteractiveInitWizard.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Init;
+
+use Composer\IO\IOInterface;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+
+/**
+ * Interactive setup helper for `skills:init`.
+ *
+ * `skills:init` is the command the user runs deliberately — it
+ * exists exactly because they want to think about their configuration.
+ * Walking them through the available knobs one at a time, with
+ * descriptions and sensible defaults, is the natural shape for the
+ * command. Non-interactive callers (CI, `--no-interaction`) bypass
+ * this class and use the silent migrate/stub flow in
+ * {@see InitRunner}.
+ *
+ * Defaults come from one of three sources, in order:
+ *
+ * 1. Existing `skills.json` (`--force` re-runs surface current
+ *    values).
+ * 2. Inline `extra.skills` in `composer.json`, when the user
+ *    confirms "import current settings" at the first prompt.
+ * 3. Built-in defaults from {@see ProjectConfig::default()}.
+ *
+ * The wizard returns the resolved set of project keys ready to be
+ * written as `skills.json`; the caller (InitRunner) handles the
+ * actual file writes and the composer.json strip.
+ */
+final readonly class InteractiveInitWizard
+{
+    /**
+     * Well-known alias paths offered as numbered options. Keeps the
+     * user from typing the same boring strings every time. Custom
+     * paths are still allowed via the follow-up free-form prompt.
+     *
+     * @var list<non-empty-string>
+     */
+    public const COMMON_ALIASES = [
+        '.claude/skills',
+        '.cursor/skills',
+        '.agents/skills',
+    ];
+
+    /**
+     * Walk the user through the wizard. Returns the resolved
+     * project-keys array (suitable for `json_encode` into
+     * `skills.json`) or `null` if the user aborted at the final
+     * confirmation.
+     *
+     * @param array<string, mixed> $defaults pre-resolved defaults per
+     *        {@see ProjectConfigMapper::PROJECT_KEYS}. Keys not in
+     *        the array default to {@see ProjectConfig::default()}.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function run(IOInterface $io, array $defaults): ?array
+    {
+        $io->write('');
+        $io->write('<info>=====================================</info>');
+        $io->write('<info>  skills.json — interactive setup    </info>');
+        $io->write('<info>=====================================</info>');
+        $io->write('');
+        $io->write(
+            'Press <comment>Enter</comment> to accept the default in [brackets]. '
+            . 'Ctrl+C aborts.',
+        );
+        $io->write('');
+
+        $target = $this->askTarget($io, $defaults);
+        $aliases = $this->askAliases($io, $defaults, $target);
+        $trusted = $this->askTrusted($io, $defaults);
+        $trustedReplace = $this->askTrustedReplace($io, $defaults);
+        $discovery = $this->askDiscovery($io, $defaults);
+        $autoSync = $this->askAutoSync($io, $defaults);
+
+        $result = [];
+        // Order matches ProjectConfigMapper::PROJECT_KEYS so generated
+        // skills.json files are diff-stable.
+        if ($target !== '.agents/skills') {
+            $result['target'] = $target;
+        }
+        if ($aliases !== []) {
+            $result['aliases'] = $aliases;
+        }
+        if ($trusted !== []) {
+            $result['trusted'] = $trusted;
+        }
+        if ($trustedReplace) {
+            $result['trusted-replace'] = true;
+        }
+        if ($discovery) {
+            $result['discovery'] = true;
+        }
+        // auto-sync's default is `true`; only emit the key when the
+        // user opted out, otherwise let the default carry it.
+        if (!$autoSync) {
+            $result['auto-sync'] = false;
+        }
+
+        $this->renderSummary($io, $result);
+
+        if (!$io->askConfirmation('<info>Write skills.json? [Y/n]:</info> ', true)) {
+            $io->write('<comment>[init] aborted by user.</comment>');
+            return null;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<non-empty-string> $current
+     *
+     * @psalm-pure
+     */
+    private static function encodeAliasDefault(array $current): string
+    {
+        $tokens = [];
+        foreach ($current as $alias) {
+            $idx = \array_search($alias, self::COMMON_ALIASES, true);
+            $tokens[] = $idx === false ? $alias : (string) ($idx + 1);
+        }
+
+        return \implode(',', $tokens);
+    }
+
+    /**
+     * Parse the freeform alias input. Empty / "none" yields `[]`.
+     * Numbers map to {@see COMMON_ALIASES}; ranges (`1-3`) expand;
+     * anything that isn't a number is taken as a literal path.
+     *
+     * @param list<non-empty-string> $defaultsForLiteral when the user accepted
+     *        the prompt verbatim, keep the original list of paths verbatim
+     *        rather than round-tripping through the number encoding
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-pure
+     */
+    private static function parseAliasInput(string $raw, array $defaultsForLiteral): array
+    {
+        $raw = \trim($raw);
+        if ($raw === '' || \strtolower($raw) === 'none') {
+            return [];
+        }
+
+        // If the input is byte-identical to the encoded default, keep
+        // the original list rather than re-decoding (preserves any
+        // custom literal paths that lived alongside numbered defaults).
+        if ($defaultsForLiteral !== [] && $raw === self::encodeAliasDefault($defaultsForLiteral)) {
+            return $defaultsForLiteral;
+        }
+
+        $out = [];
+        foreach (\explode(',', $raw) as $token) {
+            $token = \trim($token);
+            if ($token === '') {
+                continue;
+            }
+
+            // Range: "1-3" → 1, 2, 3
+            if (\preg_match('/^(\d+)-(\d+)$/', $token, $m) === 1) {
+                $start = (int) $m[1];
+                $end = (int) $m[2];
+                if ($start > $end) {
+                    [$start, $end] = [$end, $start];
+                }
+                for ($i = $start; $i <= $end; $i++) {
+                    $path = self::COMMON_ALIASES[$i - 1] ?? null;
+                    if ($path !== null) {
+                        $out[] = $path;
+                    }
+                }
+                continue;
+            }
+
+            // Single number
+            if (\ctype_digit($token)) {
+                $path = self::COMMON_ALIASES[((int) $token) - 1] ?? null;
+                if ($path !== null) {
+                    $out[] = $path;
+                }
+                continue;
+            }
+
+            // Anything else: literal path
+            /** @var non-empty-string $token */
+            $out[] = $token;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @return non-empty-string
+     */
+    private function askTarget(IOInterface $io, array $defaults): string
+    {
+        /** @var mixed $rawDefault */
+        $rawDefault = $defaults['target'] ?? null;
+        $default = \is_string($rawDefault) && $rawDefault !== '' ? $rawDefault : '.agents/skills';
+
+        $io->write('<info>1/6  target</info> — destination directory for synced skills,');
+        $io->write('     relative to the project root. Tool-agnostic by default so');
+        $io->write('     multiple agents can share it; redirect to .claude/skills,');
+        $io->write('     .cursor/skills, etc. for single-agent projects.');
+
+        /** @var mixed $answer */
+        $answer = $io->ask(\sprintf('  <info>target</info> [<comment>%s</comment>]: ', $default), $default);
+        $value = \is_string($answer) && $answer !== '' ? $answer : $default;
+        $io->write('');
+
+        return $value;
+    }
+
+    /**
+     * Numbered selection plus free-form CSV. Accepts mixed input like
+     * `1,3` or `1-3` or `2,custom/path`.
+     *
+     * @param array<string, mixed> $defaults
+     * @param non-empty-string $target used to reject alias == target up front
+     *
+     * @return list<non-empty-string>
+     */
+    private function askAliases(IOInterface $io, array $defaults, string $target): array
+    {
+        $currentAliases = [];
+        /** @var mixed $rawAliases */
+        $rawAliases = $defaults['aliases'] ?? null;
+        if (\is_array($rawAliases)) {
+            /** @var mixed $value */
+            foreach ($rawAliases as $value) {
+                if (\is_string($value) && $value !== '') {
+                    /** @var non-empty-string $value */
+                    $currentAliases[] = $value;
+                }
+            }
+        }
+
+        $io->write('<info>2/6  aliases</info> — extra paths that mirror the target via');
+        $io->write('     symlink (POSIX) or junction (Windows). Reads through any alias');
+        $io->write('     see the same files; only the target is physically written.');
+        $io->write('     Pick by number, range (1-3), and/or type custom paths.');
+        $io->write('');
+        foreach (self::COMMON_ALIASES as $i => $path) {
+            $marker = \in_array($path, $currentAliases, true) ? '<info>*</info>' : ' ';
+            $io->write(\sprintf('     %s %d) %s', $marker, $i + 1, $path));
+        }
+        $io->write('');
+
+        $defaultPrompt = $currentAliases === []
+            ? 'none'
+            : self::encodeAliasDefault($currentAliases);
+
+        /** @var mixed $answer */
+        $answer = $io->ask(
+            \sprintf('  <info>aliases</info> [<comment>%s</comment>]: ', $defaultPrompt),
+            $defaultPrompt,
+        );
+
+        $parsed = self::parseAliasInput(\is_string($answer) ? $answer : $defaultPrompt, $currentAliases);
+
+        // Validate against target. Re-prompt would be nicer; for now,
+        // drop the offending entry with a notice and continue.
+        $clean = [];
+        $seen = [];
+        $targetNorm = \rtrim(\str_replace('\\', '/', $target), '/');
+        foreach ($parsed as $alias) {
+            $norm = \rtrim(\str_replace('\\', '/', $alias), '/');
+            if ($norm === $targetNorm) {
+                $io->write(\sprintf(
+                    '  <comment>(dropped: %s equals target)</comment>',
+                    $alias,
+                ));
+                continue;
+            }
+            if (isset($seen[$norm])) {
+                continue;
+            }
+            $seen[$norm] = true;
+            $clean[] = $alias;
+        }
+
+        $io->write('');
+
+        return $clean;
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @return list<non-empty-string>
+     */
+    private function askTrusted(IOInterface $io, array $defaults): array
+    {
+        $current = [];
+        /** @var mixed $rawTrusted */
+        $rawTrusted = $defaults['trusted'] ?? null;
+        if (\is_array($rawTrusted)) {
+            /** @var mixed $value */
+            foreach ($rawTrusted as $value) {
+                if (\is_string($value) && $value !== '') {
+                    /** @var non-empty-string $value */
+                    $current[] = $value;
+                }
+            }
+        }
+
+        $io->write('<info>3/6  trusted</info> — packages allowed to ship skills into this');
+        $io->write('     project. Patterns: <comment>vendor/package</comment> (exact) or');
+        $io->write('     <comment>vendor/*</comment> (whole vendor). Built-in trust and direct');
+        $io->write('     dependencies are implicitly trusted — only list what those');
+        $io->write('     two sources do not already cover.');
+
+        $defaultStr = $current === [] ? '<none>' : \implode(',', $current);
+        /** @var mixed $answer */
+        $answer = $io->ask(
+            \sprintf('  <info>trusted</info> (comma-separated) [<comment>%s</comment>]: ', $defaultStr),
+            $defaultStr,
+        );
+        $answer = \is_string($answer) ? \trim($answer) : '';
+        if ($answer === '' || $answer === '<none>') {
+            $io->write('');
+            return $current;
+        }
+
+        $out = [];
+        foreach (\explode(',', $answer) as $token) {
+            $token = \trim($token);
+            if ($token !== '') {
+                /** @var non-empty-string $token */
+                $out[] = $token;
+            }
+        }
+        $io->write('');
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     */
+    private function askTrustedReplace(IOInterface $io, array $defaults): bool
+    {
+        $default = (bool) ($defaults['trusted-replace'] ?? false);
+
+        $io->write('<info>4/6  trusted-replace</info> — when <comment>true</comment>, the project trust');
+        $io->write('     list <comment>replaces</comment> both the built-in trusted vendors and the');
+        $io->write('     implicit direct-dependency trust. Use this for "explicit trust');
+        $io->write('     only" mode.');
+        $bool = $io->askConfirmation(
+            \sprintf(
+                '  <info>trusted-replace</info> [<comment>%s</comment>]: ',
+                $default ? 'Y/n' : 'y/N',
+            ),
+            $default,
+        );
+        $io->write('');
+
+        return $bool;
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     */
+    private function askDiscovery(IOInterface $io, array $defaults): bool
+    {
+        $default = (bool) ($defaults['discovery'] ?? false);
+
+        $io->write('<info>5/6  discovery</info> — when <comment>true</comment>, packages without an');
+        $io->write('     <comment>extra.skills</comment> block are still considered as donors if');
+        $io->write('     they ship a top-level <comment>skills/</comment> directory. Useful for');
+        $io->write('     ecosystems where shipping skills is conventional but not yet');
+        $io->write('     declared.');
+        $bool = $io->askConfirmation(
+            \sprintf(
+                '  <info>discovery</info> [<comment>%s</comment>]: ',
+                $default ? 'Y/n' : 'y/N',
+            ),
+            $default,
+        );
+        $io->write('');
+
+        return $bool;
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     */
+    private function askAutoSync(IOInterface $io, array $defaults): bool
+    {
+        // Default `true`: most projects want the post-install/update
+        // hook to keep skills fresh without ceremony. Users with
+        // sensitive CI policies can flip it off here.
+        $default = (bool) ($defaults['auto-sync'] ?? true);
+
+        $io->write('<info>6/6  auto-sync</info> — when <comment>true</comment> (default), <comment>skills:update</comment> runs');
+        $io->write('     automatically after every <comment>composer install</comment> /');
+        $io->write('     <comment>composer update</comment>. Suppressed by <comment>--no-scripts</comment>.');
+        $bool = $io->askConfirmation(
+            \sprintf(
+                '  <info>auto-sync</info> [<comment>%s</comment>]: ',
+                $default ? 'Y/n' : 'y/N',
+            ),
+            $default,
+        );
+        $io->write('');
+
+        return $bool;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function renderSummary(IOInterface $io, array $result): void
+    {
+        $io->write('<info>=====================================</info>');
+        $io->write('<info>  Summary                            </info>');
+        $io->write('<info>=====================================</info>');
+
+        if ($result === []) {
+            $io->write('  (defaults across the board — empty skills.json will be written)');
+            $io->write('');
+            return;
+        }
+
+        /** @var mixed $value */
+        foreach ($result as $key => $value) {
+            $rendered = match (true) {
+                \is_bool($value) => $value ? 'true' : 'false',
+                \is_array($value) => '[' . \implode(', ', \array_map(
+                    static fn(mixed $v): string => \is_string($v) ? $v : (string) \json_encode($v),
+                    $value,
+                )) . ']',
+                default => \is_scalar($value) ? (string) $value : (string) \json_encode($value),
+            };
+            $io->write(\sprintf('  <comment>%-18s</comment> %s', $key, $rendered));
+        }
+
+        $io->write('');
+    }
+}

--- a/src/Init/InteractiveInitWizard.php
+++ b/src/Init/InteractiveInitWizard.php
@@ -6,6 +6,7 @@ namespace LLM\Skills\Init;
 
 use Composer\IO\IOInterface;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use LLM\Skills\Config\ProjectConfig;
 
 /**
  * Interactive setup helper for `skills:init`.
@@ -79,8 +80,10 @@ final readonly class InteractiveInitWizard
 
         $result = [];
         // Order matches ProjectConfigMapper::PROJECT_KEYS so generated
-        // skills.json files are diff-stable.
-        if ($target !== '.agents/skills') {
+        // skills.json files are diff-stable. We compare against the
+        // canonical default rather than the literal string so this
+        // wizard tracks any future change to DEFAULT_TARGET in one place.
+        if ($target !== ProjectConfig::DEFAULT_TARGET) {
             $result['target'] = $target;
         }
         if ($aliases !== []) {
@@ -203,7 +206,9 @@ final readonly class InteractiveInitWizard
     {
         /** @var mixed $rawDefault */
         $rawDefault = $defaults['target'] ?? null;
-        $default = \is_string($rawDefault) && $rawDefault !== '' ? $rawDefault : '.agents/skills';
+        $default = \is_string($rawDefault) && $rawDefault !== ''
+            ? $rawDefault
+            : ProjectConfig::DEFAULT_TARGET;
 
         $io->write('<info>1/6  target</info> — destination directory for synced skills,');
         $io->write('     relative to the project root. Tool-agnostic by default so');

--- a/src/Init/InteractiveInitWizard.php
+++ b/src/Init/InteractiveInitWizard.php
@@ -320,7 +320,8 @@ final readonly class InteractiveInitWizard
         $io->write('     project. Patterns: <comment>vendor/package</comment> (exact) or');
         $io->write('     <comment>vendor/*</comment> (whole vendor). Built-in trust and direct');
         $io->write('     dependencies are implicitly trusted — only list what those');
-        $io->write('     two sources do not already cover.');
+        $io->write('     two sources do not already cover. Type <comment>&lt;none&gt;</comment>');
+        $io->write('     to clear the list.');
 
         $defaultStr = $current === [] ? '<none>' : \implode(',', $current);
         /** @var mixed $answer */
@@ -329,9 +330,20 @@ final readonly class InteractiveInitWizard
             $defaultStr,
         );
         $answer = \is_string($answer) ? \trim($answer) : '';
-        if ($answer === '' || $answer === '<none>') {
+
+        // Three branches:
+        // - empty answer       → user pressed Enter; keep current list as-is.
+        // - literal "<none>"   → user explicitly cleared. When the default was
+        //                       already "<none>" (empty current), this collapses
+        //                       to the same empty result naturally.
+        // - everything else    → parse comma-separated tokens.
+        if ($answer === '') {
             $io->write('');
             return $current;
+        }
+        if ($answer === '<none>') {
+            $io->write('');
+            return [];
         }
 
         $out = [];

--- a/src/Show/InspectionBuilder.php
+++ b/src/Show/InspectionBuilder.php
@@ -62,9 +62,9 @@ final readonly class InspectionBuilder
      *        GitHub / npm / skills.sh providers plug in here
      * @param ProjectConfig $project pre-resolved project config. The caller
      *        ({@see \LLM\Skills\Show\ShowRunner}) loads it via
-     *        {@see ProjectConfigMapper::forProject()} so it can surface the
-     *        `skills.json` shadowing warning through IO; the builder itself
-     *        stays pure (no IO).
+     *        {@see \LLM\Skills\Config\Mapper\ProjectConfigMapper::forProject()}
+     *        so it can surface the `skills.json` shadowing warning through IO;
+     *        the builder itself stays pure (no IO).
      *
      * @throws MalformedProjectConfig when planner-level path validation fails.
      */

--- a/src/Show/InspectionBuilder.php
+++ b/src/Show/InspectionBuilder.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Show;
 
-use Composer\Composer;
 use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
-use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\SyncOptions;
 use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorConfig;
 use LLM\Skills\Discovery\DiscoveryResolver;
-use LLM\Skills\Discovery\DonorDiscovery;
 use LLM\Skills\Discovery\InstalledSkill;
 use LLM\Skills\Discovery\InstalledSkillScanner;
+use LLM\Skills\Discovery\Provider\DonorProvider;
 use LLM\Skills\Discovery\Skill;
 use LLM\Skills\Discovery\SkillEnumerator;
 use LLM\Skills\Discovery\SkillFrontmatterReader;
@@ -49,26 +47,36 @@ final readonly class InspectionBuilder
      */
     public function __construct(
         private SyncPlanner $planner = new SyncPlanner(),
-        private DonorDiscovery $donorDiscovery = new DonorDiscovery(),
         private SkillEnumerator $skillEnumerator = new SkillEnumerator(),
         private InstalledSkillScanner $installedScanner = new InstalledSkillScanner(),
         private SyncEngine $engine = new SyncEngine(),
         private DriftDetector $drift = new DriftDetector(),
         private SkillFrontmatterReader $frontmatter = new SkillFrontmatterReader(),
-        private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
         private DiscoveryResolver $discoveryResolver = new DiscoveryResolver(),
     ) {}
 
     /**
-     * @throws MalformedProjectConfig when the root `extra.skills` block is invalid —
-     *         a project-level error is fatal, the caller surfaces it.
+     * @param Path $projectRoot consumer project root, supplied by the caller
+     * @param DonorProvider $provider source of donors (today
+     *        {@see \LLM\Skills\Discovery\Provider\ComposerProvider}); future
+     *        GitHub / npm / skills.sh providers plug in here
+     * @param ProjectConfig $project pre-resolved project config. The caller
+     *        ({@see \LLM\Skills\Show\ShowRunner}) loads it via
+     *        {@see ProjectConfigMapper::forProject()} so it can surface the
+     *        `skills.json` shadowing warning through IO; the builder itself
+     *        stays pure (no IO).
+     *
+     * @throws MalformedProjectConfig when planner-level path validation fails.
      */
-    public function build(Composer $composer, SyncOptions $options): InspectionReport
-    {
-        $project = $this->projectMapper->fromExtra($composer->getPackage()->getExtra());
+    public function build(
+        Path $projectRoot,
+        DonorProvider $provider,
+        ProjectConfig $project,
+        SyncOptions $options,
+    ): InspectionReport {
         $builtin = $this->loadBuiltinTrustedVendors();
 
-        $discovery = $this->donorDiscovery->discover($composer);
+        $discovery = $provider->discover($projectRoot);
 
         $discoveryActive = $options->discovery ?? $project->discovery;
         $resolution = $this->discoveryResolver->resolve(
@@ -78,8 +86,7 @@ final readonly class InspectionBuilder
         );
         $donors = [...$discovery->donors, ...$resolution->included];
 
-        $projectRoot = Path::create(\getcwd() ?: '.');
-        $directDeps = $this->collectDirectDependencies($composer);
+        $directDeps = $provider->directDependencies($projectRoot);
         $plan = $this->planner->plan(
             $donors,
             $project,
@@ -215,28 +222,6 @@ final readonly class InspectionBuilder
             // actually contribute to the approval decision.
             directDeps: $project->trustedReplace ? null : $directDeps,
         );
-    }
-
-    /**
-     * Names declared under `require` and `require-dev` of the consumer's
-     * root `composer.json`. Used to attribute trust to the "direct dep"
-     * source in the `show` output.
-     *
-     * @return list<non-empty-string>
-     */
-    private function collectDirectDependencies(Composer $composer): array
-    {
-        $root = $composer->getPackage();
-        $names = [];
-        foreach ([...$root->getRequires(), ...$root->getDevRequires()] as $name => $_link) {
-            if ($name === '' || !\str_contains($name, '/')) {
-                continue;
-            }
-            /** @var non-empty-string $name */
-            $names[] = $name;
-        }
-
-        return $names;
     }
 
     /**

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -20,8 +20,8 @@ use Symfony\Component\Console\Command\Command;
  * returns a Symfony exit code.
  *
  * Project-config IO concerns (the `skills.json` shadowing warning,
- * and the standalone "no donors available" notice) stay here so the
- * builder remains IO-free.
+ * and the standalone `no donor providers are active` notice) stay
+ * here so the builder remains IO-free.
  */
 final readonly class ShowRunner
 {

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -144,9 +144,15 @@ final readonly class ShowRunner
             return;
         }
 
+        // Show is invoked from two entrypoints with different command
+        // names — `composer skills:update` / `composer skills:init`
+        // through the plugin, and `skills update` / `skills init`
+        // through the standalone bin. Mention both rather than
+        // hard-coding the Composer flavour.
         $io->write(\sprintf(
             '<comment>[notice] legacy inline config detected (extra.skills: %s). '
-            . 'Run `composer skills:update` (or `skills:init`) to migrate it into skills.json.</comment>',
+            . 'Run `composer skills:update` (or `skills update` from the standalone '
+            . 'binary) to migrate it into skills.json.</comment>',
             \implode(', ', $present),
         ));
     }

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -63,10 +63,12 @@ final readonly class ShowRunner
             );
         }
 
+        // See SyncRunner: notice is provider-neutral, specifics flow
+        // through `-v` warnings emitted at the entrypoint.
         if (!$provider->isActive($projectRoot)) {
             $io->write(
-                '<comment>[llm/skills] no donors available — no composer.json detected and no other '
-                . 'donor providers are configured.</comment>',
+                '<comment>[llm/skills] no donor providers are active — nothing to show. '
+                . 'Run with -v for details.</comment>',
             );
             return Command::SUCCESS;
         }

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Show;
 
-use Composer\Composer;
 use Composer\IO\IOInterface;
+use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\SyncOptions;
+use LLM\Skills\Discovery\Provider\DonorProvider;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * Shared body of `skills:show` — independent of which entrypoint invoked it.
  *
  * Mirrors the role {@see \LLM\Skills\Sync\SyncRunner} plays for the
- * update command: built once, fed the same `(Composer, IOInterface,
- * SyncOptions)` triple, returns a Symfony exit code.
+ * update command: built once, fed the same project/provider context,
+ * returns a Symfony exit code.
  *
- * The runner is intentionally tiny — it composes
- * {@see InspectionBuilder} and {@see ReportFormatter} and routes the
- * resulting lines to IO. No business logic lives here.
+ * Project-config IO concerns (the `skills.json` shadowing warning,
+ * and the standalone "no donors available" notice) stay here so the
+ * builder remains IO-free.
  */
 final readonly class ShowRunner
 {
@@ -29,12 +31,48 @@ final readonly class ShowRunner
     public function __construct(
         private InspectionBuilder $builder = new InspectionBuilder(),
         private ReportFormatter $formatter = new ReportFormatter(),
+        private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
     ) {}
 
-    public function run(Composer $composer, IOInterface $io, SyncOptions $options): int
-    {
+    /**
+     * @param Path $projectRoot consumer project root (the entrypoint's cwd)
+     * @param DonorProvider $provider source of donors (today
+     *        {@see \LLM\Skills\Discovery\Provider\ComposerProvider})
+     * @param mixed $extra raw `composer.json` `extra`, or `null` when no
+     *        `composer.json` is around (standalone bin run)
+     */
+    public function run(
+        Path $projectRoot,
+        DonorProvider $provider,
+        mixed $extra,
+        IOInterface $io,
+        SyncOptions $options,
+    ): int {
         try {
-            $report = $this->builder->build($composer, $options);
+            $resolution = $this->projectMapper->forProject($projectRoot, $extra);
+        } catch (MalformedProjectConfig $e) {
+            $io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        if ($resolution->ignoredInlineKeys !== []) {
+            $io->writeError(
+                '<comment>[warn] skills.json present; the following extra.skills keys in '
+                . 'composer.json are ignored: ' . \implode(', ', $resolution->ignoredInlineKeys) . '</comment>',
+                verbosity: IOInterface::VERBOSE,
+            );
+        }
+
+        if (!$provider->isActive($projectRoot)) {
+            $io->write(
+                '<comment>[llm/skills] no donors available — no composer.json detected and no other '
+                . 'donor providers are configured.</comment>',
+            );
+            return Command::SUCCESS;
+        }
+
+        try {
+            $report = $this->builder->build($projectRoot, $provider, $resolution->config, $options);
         } catch (MalformedProjectConfig $e) {
             $io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
             return Command::FAILURE;

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -70,6 +70,10 @@ final readonly class ShowRunner
                 '<comment>[llm/skills] no donor providers are active — nothing to show. '
                 . 'Run with -v for details.</comment>',
             );
+            // Read-only command: never rewrites composer.json. If the
+            // user is still on the legacy inline config, point them at
+            // the command that will migrate it.
+            $this->maybeNotifyLegacyConfig($projectRoot, $io);
             return Command::SUCCESS;
         }
 
@@ -84,6 +88,66 @@ final readonly class ShowRunner
             $io->write($line);
         }
 
+        // Trailing diagnostic — same channel as the existing `[hint]`
+        // line emitted by ReportFormatter. Belongs after the report so
+        // the user sees the data first and the meta-notice after.
+        $this->maybeNotifyLegacyConfig($projectRoot, $io);
+
         return Command::SUCCESS;
+    }
+
+    /**
+     * When `skills.json` is absent but inline `extra.skills` carries
+     * project keys, emit a one-line hint pointing the user at
+     * `skills:update` (which would migrate the block). Quiet on
+     * projects that already migrated, or that never had inline
+     * config in the first place.
+     */
+    private function maybeNotifyLegacyConfig(Path $projectRoot, IOInterface $io): void
+    {
+        $skillsJsonPath = (string) $projectRoot->join('skills.json');
+        if (\is_file($skillsJsonPath)) {
+            return;
+        }
+
+        $composerJsonPath = (string) $projectRoot->join('composer.json');
+        if (!\is_file($composerJsonPath)) {
+            return;
+        }
+
+        $content = \file_get_contents($composerJsonPath);
+        if ($content === false) {
+            return;
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return;
+        }
+        if (!\is_array($decoded)) {
+            return;
+        }
+        /** @var array<string, mixed> $extra */
+        $extra = \is_array($decoded['extra'] ?? null) ? $decoded['extra'] : [];
+        /** @var array<string, mixed> $skills */
+        $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
+
+        $present = [];
+        foreach (\LLM\Skills\Config\Mapper\ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                $present[] = $key;
+            }
+        }
+        if ($present === []) {
+            return;
+        }
+
+        $io->write(\sprintf(
+            '<comment>[notice] legacy inline config detected (extra.skills: %s). '
+            . 'Run `composer skills:update` (or `skills:init`) to migrate it into skills.json.</comment>',
+            \implode(', ', $present),
+        ));
     }
 }

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -150,14 +150,22 @@ final readonly class SyncRunner
         $donors = [...$discovery->donors, ...$discoveryResolution->included];
 
         $directDeps = $provider->directDependencies($projectRoot);
-        $plan = $this->planner->plan(
-            $donors,
-            $project,
-            $options,
-            $builtin,
-            $projectRoot,
-            $directDeps,
-        );
+        try {
+            $plan = $this->planner->plan(
+                $donors,
+                $project,
+                $options,
+                $builtin,
+                $projectRoot,
+                $directDeps,
+            );
+        } catch (MalformedProjectConfig $e) {
+            // Containment-check failures (target / alias escapes the
+            // project root) surface here. Same UX as inline / skills.json
+            // shape errors caught by the mapper above.
+            $io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
 
         if ($options->hasPackageFilters() && $plan->approvedDonors === []) {
             $patterns = \implode(

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -34,7 +34,9 @@ use Symfony\Component\Console\Command\Command;
  *   shipped as `bin/skills`; the Composer instance is bootstrapped
  *   manually via {@see \Composer\Factory::create()}. When that fails
  *   (e.g. no `composer.json` at cwd) the provider becomes inactive
- *   and the runner emits the `[no donors available]` notice.
+ *   and the runner emits the
+ *   `[llm/skills] no donor providers are active — nothing to sync.`
+ *   notice and exits 0.
  *
  * Whatever the source, the runner orchestrates the pipeline:
  *

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -7,7 +7,9 @@ namespace LLM\Skills\Sync;
 use Composer\IO\IOInterface;
 use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Config\Mapper\MigrationStatus;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
 use LLM\Skills\Config\SyncOptions;
 use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorConfig;
@@ -62,6 +64,7 @@ final readonly class SyncRunner
         private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
         private DiscoveryResolver $discoveryResolver = new DiscoveryResolver(),
         private SymlinkLinker $symlinkLinker = new SymlinkLinker(),
+        private ProjectConfigMigrator $migrator = new ProjectConfigMigrator(),
     ) {}
 
     /**
@@ -79,6 +82,33 @@ final readonly class SyncRunner
         IOInterface $io,
         SyncOptions $options,
     ): int {
+        // Auto-migration is part of the write-mode contract: any
+        // `skills:update` (or `post-update-cmd` auto-sync invocation)
+        // moves a legacy inline extra.skills block into the canonical
+        // skills.json before doing anything else. Skipped silently
+        // when there is no migration to do (skills.json exists, or no
+        // inline keys, or no composer.json at all). The
+        // `$options->autoMigrate=false` opt-out is used by the
+        // `post-install-cmd` hook, which must not rewrite
+        // `composer.json` mid-install.
+        if ($options->autoMigrate) {
+            $migration = $this->migrator->migrate($projectRoot, $io);
+            if ($migration->status === MigrationStatus::Failed) {
+                return Command::FAILURE;
+            }
+            if ($migration->status === MigrationStatus::Migrated) {
+                $io->write(\sprintf(
+                    '<info>[migrate]</info> moved extra.skills → skills.json (%s)',
+                    \implode(', ', $migration->migratedKeys),
+                ));
+                // The fresh skills.json is now the source of truth;
+                // the stale in-memory $extra (still containing the
+                // migrated keys) must be discarded so forProject()
+                // reads from disk.
+                $extra = null;
+            }
+        }
+
         try {
             $configResolution = $this->projectMapper->forProject($projectRoot, $extra);
         } catch (MalformedProjectConfig $e) {

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Sync;
 
-use Composer\Composer;
 use Composer\IO\IOInterface;
 use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
@@ -14,7 +13,7 @@ use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorConfig;
 use LLM\Skills\Discovery\AutoDiscoveryProbe;
 use LLM\Skills\Discovery\DiscoveryResolver;
-use LLM\Skills\Discovery\DonorDiscovery;
+use LLM\Skills\Discovery\Provider\DonorProvider;
 use LLM\Skills\Discovery\Skill;
 use LLM\Skills\Discovery\SkillEnumerator;
 use LLM\Skills\Info;
@@ -27,15 +26,19 @@ use Symfony\Component\Console\Command\Command;
  *
  * - {@see \LLM\Skills\Composer\Command\Sync} — wired into Composer via the
  *   plugin's {@see \LLM\Skills\Composer\CommandProvider}; the Composer
- *   instance is provided by `BaseCommand::requireComposer()`.
+ *   instance flows into the {@see DonorProvider} (today
+ *   {@see \LLM\Skills\Discovery\Provider\ComposerProvider}).
  * - {@see \LLM\Skills\Console\Command\Sync} — the PHAR/binary entrypoint
- *   shipped as `bin/skills`; the Composer instance is bootstrapped manually
- *   via {@see \Composer\Factory::create()}.
+ *   shipped as `bin/skills`; the Composer instance is bootstrapped
+ *   manually via {@see \Composer\Factory::create()}. When that fails
+ *   (e.g. no `composer.json` at cwd) the provider becomes inactive
+ *   and the runner emits the `[no donors available]` notice.
  *
  * Whatever the source, the runner orchestrates the pipeline:
  *
- *   1. Map root `extra.skills` → {@see \LLM\Skills\Config\ProjectConfig}.
- *   2. {@see DonorDiscovery}: Composer → list of donor {@see VendorConfig}.
+ *   1. Map project config → {@see \LLM\Skills\Config\ProjectConfig}
+ *      via `skills.json` (when present) or inline `extra.skills`.
+ *   2. {@see DonorProvider::discover()}: enumerate donor packages.
  *   3. {@see DiscoveryResolver}: merge auto-discovered donors that the user
  *      asked for (via `--discovery` or a positional name) into the donor list.
  *   4. {@see SyncPlanner}: trust + filter partitioning → {@see SyncPlan}.
@@ -55,37 +58,62 @@ final readonly class SyncRunner
     public function __construct(
         private SyncPlanner $planner = new SyncPlanner(),
         private SyncEngine $engine = new SyncEngine(),
-        private DonorDiscovery $donorDiscovery = new DonorDiscovery(),
         private SkillEnumerator $skillEnumerator = new SkillEnumerator(),
         private ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
         private DiscoveryResolver $discoveryResolver = new DiscoveryResolver(),
         private SymlinkLinker $symlinkLinker = new SymlinkLinker(),
     ) {}
 
-    public function run(Composer $composer, IOInterface $io, SyncOptions $options): int
-    {
+    /**
+     * @param Path $projectRoot consumer project root, typically the entrypoint's cwd
+     * @param DonorProvider $provider source of donor packages (Composer today; in future,
+     *        also GitHub / npm / skills.sh — see {@see DonorProvider})
+     * @param mixed $extra raw `composer.json` `extra` field, or `null` when no
+     *        `composer.json` is around (standalone-mode bin run). Drives the legacy
+     *        inline `extra.skills` fallback when `skills.json` is absent.
+     */
+    public function run(
+        Path $projectRoot,
+        DonorProvider $provider,
+        mixed $extra,
+        IOInterface $io,
+        SyncOptions $options,
+    ): int {
         try {
-            $project = $this->projectMapper->fromExtra($composer->getPackage()->getExtra());
+            $configResolution = $this->projectMapper->forProject($projectRoot, $extra);
         } catch (MalformedProjectConfig $e) {
             $io->writeError('<error>[llm/skills] ' . $e->getMessage() . '</error>');
             return Command::FAILURE;
         }
 
+        $project = $configResolution->config;
+        $this->emitShadowedKeysWarning($io, $configResolution->ignoredInlineKeys);
+
+        // No donor provider can contribute (e.g. standalone bin/skills
+        // ran outside any Composer project). Future providers will plug
+        // in here — for now, Composer absence means "nothing to sync".
+        if (!$provider->isActive($projectRoot)) {
+            $io->write(
+                '<comment>[llm/skills] no donors available — no composer.json detected and no other '
+                . 'donor providers are configured.</comment>',
+            );
+            return Command::SUCCESS;
+        }
+
         $builtin = $this->loadBuiltinTrustedVendors();
 
-        $discovery = $this->donorDiscovery->discover($composer);
+        $discovery = $provider->discover($projectRoot);
         $this->emitWarnings($io, $discovery->warnings);
 
         $discoveryActive = $options->discovery ?? $project->discovery;
-        $resolution = $this->discoveryResolver->resolve(
+        $discoveryResolution = $this->discoveryResolver->resolve(
             $discovery->discoverable,
             $discoveryActive,
             $options,
         );
-        $donors = [...$discovery->donors, ...$resolution->included];
+        $donors = [...$discovery->donors, ...$discoveryResolution->included];
 
-        $projectRoot = Path::create(\getcwd() ?: '.');
-        $directDeps = $this->collectDirectDependencies($composer);
+        $directDeps = $provider->directDependencies($projectRoot);
         $plan = $this->planner->plan(
             $donors,
             $project,
@@ -125,7 +153,7 @@ final readonly class SyncRunner
                 ));
             }
             $io->writeError('<error>Sync aborted due to skill-name conflicts; nothing was written.</error>');
-            $this->emitTrailingDiagnostics($io, $plan, $resolution->excluded);
+            $this->emitTrailingDiagnostics($io, $plan, $discoveryResolution->excluded);
             return Command::FAILURE;
         }
 
@@ -141,7 +169,7 @@ final readonly class SyncRunner
 
         $aliasFailed = $this->processAliases($io, $plan, $options->dryRun);
 
-        $this->emitTrailingDiagnostics($io, $plan, $resolution->excluded);
+        $this->emitTrailingDiagnostics($io, $plan, $discoveryResolution->excluded);
 
         // Alias errors fail the run loudly — silent partial success would
         // mask broken `.claude/skills` / `.cursor/skills` aliases on CI,
@@ -278,31 +306,24 @@ final readonly class SyncRunner
     }
 
     /**
-     * Pull the consumer project's direct dependencies — every package
-     * named under `require` or `require-dev` in the root `composer.json`.
-     * These are implicitly trusted by the planner: depending on a
-     * package is already an act of trust, and asking the user to repeat
-     * it under `extra.skills.trusted` would be busywork. `trustedReplace`
-     * users opted out of implicit lists, so they pass the list through
-     * but the planner ignores it.
+     * `skills.json` won the precedence contest but `composer.json` still
+     * carries project-level keys under `extra.skills`. Surface their
+     * names under `-v` so a confused user can see why their inline
+     * `target` (or any other key) had no effect.
      *
-     * @return list<non-empty-string>
+     * @param list<non-empty-string> $ignored
      */
-    private function collectDirectDependencies(Composer $composer): array
+    private function emitShadowedKeysWarning(IOInterface $io, array $ignored): void
     {
-        $root = $composer->getPackage();
-        $names = [];
-        foreach ([...$root->getRequires(), ...$root->getDevRequires()] as $name => $_link) {
-            if ($name === '' || !\str_contains($name, '/')) {
-                // Platform requirements like `php` or `ext-json` and the
-                // odd metapackage placeholder don't carry skills.
-                continue;
-            }
-            /** @var non-empty-string $name */
-            $names[] = $name;
+        if ($ignored === []) {
+            return;
         }
 
-        return $names;
+        $io->writeError(
+            '<comment>[warn] skills.json present; the following extra.skills keys in '
+            . 'composer.json are ignored: ' . \implode(', ', $ignored) . '</comment>',
+            verbosity: IOInterface::VERBOSE,
+        );
     }
 
     /**

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -89,13 +89,17 @@ final readonly class SyncRunner
         $project = $configResolution->config;
         $this->emitShadowedKeysWarning($io, $configResolution->ignoredInlineKeys);
 
-        // No donor provider can contribute (e.g. standalone bin/skills
-        // ran outside any Composer project). Future providers will plug
-        // in here — for now, Composer absence means "nothing to sync".
+        // No donor provider can contribute. Reasons vary by provider —
+        // {@see \LLM\Skills\Discovery\Provider\ComposerProvider} is
+        // inactive when no Composer instance was supplied (no composer.json
+        // at cwd, or `Factory::create()` threw). The entrypoint emits a
+        // `-v` line naming the actual cause; this user-facing notice
+        // stays neutral so it stays accurate across all providers
+        // (today only Composer, eventually also GitHub / npm / skills.sh).
         if (!$provider->isActive($projectRoot)) {
             $io->write(
-                '<comment>[llm/skills] no donors available — no composer.json detected and no other '
-                . 'donor providers are configured.</comment>',
+                '<comment>[llm/skills] no donor providers are active — nothing to sync. '
+                . 'Run with -v for details.</comment>',
             );
             return Command::SUCCESS;
         }

--- a/tests/Acceptance/SkillsAutoMigrateTest.php
+++ b/tests/Acceptance/SkillsAutoMigrateTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSandboxExtras;
+use LLM\Skills\Tests\Testo\Filesystem;
+use LLM\Skills\Tests\Testo\SandboxStateGuard;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance coverage for the automatic migration of legacy inline
+ * `extra.skills` into `skills.json`.
+ *
+ * Contract (see `spec-config-file.md` §3):
+ *
+ * - Write-mode commands (`skills:update`, `post-update-cmd` autosync)
+ *   migrate on first contact.
+ * - Read-only paths (`skills:show`, `post-install-cmd` autosync) do
+ *   NOT migrate; show emits a notice pointing the user at update.
+ * - Once `skills.json` exists, `composer.json` is left alone forever.
+ */
+#[Test]
+final class SkillsAutoMigrateTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const SKILLS_JSON = Info::PROJECT_DIR . '/skills.json';
+    private const COMPOSER_JSON = Info::PROJECT_DIR . '/composer.json';
+
+    #[BeforeTest]
+    public function snapshotAndClear(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        SandboxStateGuard::snapshot();
+    }
+
+    #[AfterTest]
+    public function restore(): void
+    {
+        SandboxStateGuard::restore();
+    }
+
+    // ── update migrates ─────────────────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'target' => 'auto-migrate-target/skills',
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function updateMigratesInlineIntoSkillsJsonOnFirstRun(): void
+    {
+        // Before run: no skills.json, inline extra.skills has project keys.
+        Assert::false(\is_file(self::SKILLS_JSON), 'pre-condition: no skills.json yet');
+
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+
+        // After run: skills.json exists with migrated keys.
+        Assert::true(\is_file(self::SKILLS_JSON), 'skills.json must be created');
+        $skills = $this->readSkillsJson();
+        Assert::same($skills['target'] ?? null, 'auto-migrate-target/skills');
+        Assert::same($skills['trusted'] ?? null, ['acme/skills-basic', 'acme/skills-pro']);
+        Assert::true(\array_key_exists('$schema', $skills));
+
+        // composer.json no longer carries the migrated keys.
+        $composer = $this->readComposerJson();
+        $remaining = $composer['extra']['skills'] ?? [];
+        Assert::false(\array_key_exists('target', $remaining));
+        Assert::false(\array_key_exists('trusted', $remaining));
+
+        // [migrate] line announces what happened on stdout.
+        Assert::true(
+            \str_contains($process->getOutput(), '[migrate]'),
+            'output must announce the migration. Got: ' . $process->getOutput(),
+        );
+
+        // And the actual sync proceeded with the new config.
+        Assert::true(
+            \is_file(Info::PROJECT_DIR . '/auto-migrate-target/skills/greeting/SKILL.md'),
+            'skills must land at the migrated target',
+        );
+
+        // Cleanup of the new target dir before AfterTest restores composer.json.
+        Filesystem::removeRecursive(Info::PROJECT_DIR . '/auto-migrate-target');
+    }
+
+    public function updateIsNoOpForComposerJsonWhenSkillsJsonAlreadyExists(): void
+    {
+        // Pre-create skills.json so the precedence path picks it. The
+        // sandbox composer.json still has its inline `trusted` block;
+        // we should NOT touch it.
+        \file_put_contents(self::SKILLS_JSON, \json_encode([
+            'trusted' => ['acme/skills-basic'],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);
+
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0);
+        Assert::same(
+            \file_get_contents(self::COMPOSER_JSON),
+            $composerBefore,
+            'composer.json must be byte-for-byte unchanged when skills.json already exists',
+        );
+        // No [migrate] line on this run.
+        Assert::false(
+            \str_contains($process->getOutput(), '[migrate]'),
+            'no migration must happen when skills.json already exists',
+        );
+    }
+
+    public function updateIsNoOpForComposerJsonWhenNoInlineProjectKeys(): void
+    {
+        // composer.json has no inline `extra.skills` project keys
+        // (the WithSandboxExtras attribute is absent). The runner has
+        // nothing to migrate; composer.json stays untouched.
+        $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);
+
+        // Strip the default inline keys so this test really has "no
+        // inline project keys" precondition. We do this in-test (not
+        // via WithSandboxExtras) so the snapshot guard restores
+        // afterwards.
+        $decoded = \json_decode($composerBefore, true, flags: \JSON_THROW_ON_ERROR);
+        unset($decoded['extra']['skills']);
+        \file_put_contents(
+            self::COMPOSER_JSON,
+            \json_encode($decoded, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n",
+        );
+        $strippedComposer = (string) \file_get_contents(self::COMPOSER_JSON);
+
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0);
+        Assert::same(
+            \file_get_contents(self::COMPOSER_JSON),
+            $strippedComposer,
+            'composer.json must remain identical when nothing to migrate',
+        );
+        Assert::false(
+            \is_file(self::SKILLS_JSON),
+            'no stub skills.json must be auto-created on plain update',
+        );
+    }
+
+    // ── post-install vs post-update ─────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'target' => 'auto-migrate-target/skills',
+        'trusted' => ['acme/skills-basic'],
+        'auto-sync' => true,
+    ])]
+    public function postUpdateHookMigrates(): void
+    {
+        // The post-update-cmd hook handles the migration step because
+        // composer update is the right moment to rewrite composer.json.
+        Assert::false(\is_file(self::SKILLS_JSON));
+
+        $process = $this->runScript('post-update-cmd');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(\is_file(self::SKILLS_JSON), 'post-update-cmd should have migrated');
+        Filesystem::removeRecursive(Info::PROJECT_DIR . '/auto-migrate-target');
+    }
+
+    #[WithSandboxExtras([
+        'target' => 'auto-migrate-target/skills',
+        'trusted' => ['acme/skills-basic'],
+        'auto-sync' => true,
+    ])]
+    public function postInstallHookDoesNotMigrate(): void
+    {
+        // post-install is a fetch step; surprising the user with a
+        // composer.json rewrite mid-install is the wrong default.
+        // The hook still syncs (auto-sync is on), but composer.json
+        // stays as the interceptor left it.
+        $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);
+        Assert::false(\is_file(self::SKILLS_JSON));
+
+        $process = $this->runScript('post-install-cmd');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::same(
+            \file_get_contents(self::COMPOSER_JSON),
+            $composerBefore,
+            'post-install-cmd must NOT rewrite composer.json',
+        );
+        Assert::false(
+            \is_file(self::SKILLS_JSON),
+            'post-install-cmd must NOT create skills.json',
+        );
+
+        // But the sync did happen — skills are at the inline-configured
+        // target (we read inline as fallback when no skills.json exists).
+        Assert::true(
+            \is_file(Info::PROJECT_DIR . '/auto-migrate-target/skills/greeting/SKILL.md'),
+            'post-install-cmd should still sync, just without migrating',
+        );
+        Filesystem::removeRecursive(Info::PROJECT_DIR . '/auto-migrate-target');
+    }
+
+    // ── migration failure propagates ────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'target' => 'auto-migrate-target/skills',
+        'auto-sync' => 'yes',  // intentionally malformed
+    ])]
+    public function updateFailsLoudlyWhenInlineIsMalformed(): void
+    {
+        // The migrator refuses to relocate broken config; the runner
+        // turns Failed into a non-zero exit code instead of papering
+        // over the problem.
+        $process = $this->runUpdate();
+
+        Assert::notSame(
+            $process->getExitCode(),
+            0,
+            'malformed inline must fail the run; stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'cannot auto-migrate'),
+            'stderr must explain the migration refusal. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \is_file(self::SKILLS_JSON),
+            'no skills.json must be written when migration fails pre-flight',
+        );
+    }
+
+    // ── show is read-only ───────────────────────────────────────────────
+
+    public function showDoesNotMigrate(): void
+    {
+        // Default sandbox composer.json has inline `trusted`. show is
+        // read-only and must not migrate it.
+        $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);
+        Assert::false(\is_file(self::SKILLS_JSON));
+
+        $process = ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:show',
+            timeout: 60,
+            mustSucceed: false,
+        );
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::same(
+            \file_get_contents(self::COMPOSER_JSON),
+            $composerBefore,
+            'show must not mutate composer.json',
+        );
+        Assert::false(\is_file(self::SKILLS_JSON), 'show must not create skills.json');
+    }
+
+    public function showEmitsLegacyNoticeWhenInlineDetected(): void
+    {
+        // The notice exists so a user staring at "still works on inline
+        // config" output knows there's a one-command migration available.
+        $process = ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:show',
+            timeout: 60,
+            mustSucceed: false,
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, 'legacy inline config'),
+            'show should hint at migration when inline keys exist. Got: ' . $combined,
+        );
+        Assert::true(
+            \str_contains($combined, 'skills:update'),
+            'hint should name the command to run. Got: ' . $combined,
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private function runUpdate(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:update',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    private function runScript(string $event): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'run-script ' . $event,
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(self::SKILLS_JSON),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readComposerJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(self::COMPOSER_JSON),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+}

--- a/tests/Acceptance/SkillsAutoMigrateTest.php
+++ b/tests/Acceptance/SkillsAutoMigrateTest.php
@@ -236,10 +236,17 @@ final class SkillsAutoMigrateTest
 
     // ── show is read-only ───────────────────────────────────────────────
 
+    #[WithSandboxExtras([
+        'target' => '.agents/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
     public function showDoesNotMigrate(): void
     {
-        // Default sandbox composer.json has inline `trusted`. show is
-        // read-only and must not migrate it.
+        // Inject inline project keys explicitly via the attribute so
+        // this test does not depend on whatever the sandbox happens
+        // to ship with — particularly important on CI where tests
+        // across classes might run in an order that leaves the
+        // sandbox in a different state than local runs do.
         $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);
         Assert::false(\is_file(self::SKILLS_JSON));
 
@@ -259,10 +266,17 @@ final class SkillsAutoMigrateTest
         Assert::false(\is_file(self::SKILLS_JSON), 'show must not create skills.json');
     }
 
+    #[WithSandboxExtras([
+        'target' => '.agents/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
     public function showEmitsLegacyNoticeWhenInlineDetected(): void
     {
         // The notice exists so a user staring at "still works on inline
         // config" output knows there's a one-command migration available.
+        // We inject inline project keys via WithSandboxExtras so the
+        // notice fires deterministically regardless of cross-class
+        // test ordering on CI.
         $process = ComposerRunner::run(
             Path::create(Info::PROJECT_DIR),
             'skills:show',

--- a/tests/Acceptance/SkillsAutoSyncTest.php
+++ b/tests/Acceptance/SkillsAutoSyncTest.php
@@ -82,17 +82,37 @@ final class SkillsAutoSyncTest
         Assert::true(\is_file(self::TARGET_DIR . '/greeting/SKILL.md'));
     }
 
-    public function autoSyncDefaultsToOffAndDoesNotWriteAnything(): void
+    public function autoSyncDefaultsToOnAndRunsOnPostInstall(): void
     {
-        // Sandbox's default `extra.skills` has no `auto-sync` key. Firing
-        // the install event must be a no-op for our plugin — the user
-        // hasn't opted in, so the filesystem stays untouched.
+        // The sandbox's default extra.skills carries no `auto-sync`
+        // key, so the new default (`true`) takes effect: firing the
+        // post-install event should sync the trusted donors without
+        // any explicit opt-in. This is the "just install the plugin
+        // and it works" path users get out of the box.
+        $process = $this->runScript('post-install-cmd');
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/greeting/SKILL.md'),
+            'auto-sync defaults to on, so the trusted donor must have synced',
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic'],
+        'auto-sync' => false,
+    ])]
+    public function explicitAutoSyncFalseOptsOut(): void
+    {
+        // Users who explicitly opt out keep the old "nothing happens
+        // until skills:update" behaviour. Set `auto-sync: false` in
+        // skills.json or composer.json's extra.skills.
         $process = $this->runScript('post-install-cmd');
 
         Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
         Assert::false(
             \is_dir(self::TARGET_DIR),
-            'auto-sync must stay off by default; nothing should appear under target',
+            'explicit auto-sync=false must keep the filesystem untouched',
         );
     }
 

--- a/tests/Acceptance/SkillsAutoSyncTest.php
+++ b/tests/Acceptance/SkillsAutoSyncTest.php
@@ -8,8 +8,10 @@ use Internal\Path;
 use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
 use LLM\Skills\Tests\Testo\Composer\WithSandboxExtras;
 use LLM\Skills\Tests\Testo\Filesystem;
+use LLM\Skills\Tests\Testo\SandboxStateGuard;
 use Symfony\Component\Process\Process;
 use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
 use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
 
@@ -32,6 +34,13 @@ final class SkillsAutoSyncTest
     public function clearTargetDir(): void
     {
         Filesystem::removeRecursive(self::TARGET_DIR);
+        SandboxStateGuard::snapshot();
+    }
+
+    #[AfterTest]
+    public function restoreSandbox(): void
+    {
+        SandboxStateGuard::restore();
     }
 
     #[WithSandboxExtras([

--- a/tests/Acceptance/SkillsJsonConfigTest.php
+++ b/tests/Acceptance/SkillsJsonConfigTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSandboxExtras;
+use LLM\Skills\Tests\Testo\Composer\WithSkillsJson;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance tests for the external `skills.json` config file:
+ *
+ * - precedence over the inline `extra.skills` block in `composer.json`;
+ * - the warning emitted under `-v` when both sources coexist;
+ * - the `composer skills:init` migration flow (project keys move out of
+ *   `composer.json` into `skills.json`, donor `source` stays behind);
+ * - refusal semantics for `init` (no `--force`).
+ *
+ * These all run against the standard sandbox at `tests/Sandbox/project`,
+ * exercising the full pipeline: Composer plugin → runner → mapper →
+ * filesystem writes.
+ */
+#[Test]
+final class SkillsJsonConfigTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const EXTERNAL_TARGET = Info::PROJECT_DIR . '/external-target/skills';
+    private const INLINE_TARGET = Info::PROJECT_DIR . '/inline-target/skills';
+    private const SKILLS_JSON = Info::PROJECT_DIR . '/skills.json';
+    private const COMPOSER_JSON = Info::PROJECT_DIR . '/composer.json';
+
+    private ?string $originalComposerJson = null;
+
+    /**
+     * Snapshot the sandbox `composer.json` so we can restore it
+     * verbatim after the `skills:init` tests, which rewrite the file
+     * in place. Tests that already use {@see WithSandboxExtras} do
+     * not strictly need this (the interceptor restores too), but a
+     * second guard is cheap and makes the init tests independent.
+     *
+     * NOTE: skills.json deletion happens in {@see restoreComposerJson()}
+     * only, not here — the {@see WithSkillsJson} interceptor runs
+     * *outside* the BeforeTest hook, so a delete here would erase
+     * the file the interceptor just wrote.
+     */
+    #[BeforeTest]
+    public function snapshotAndClear(): void
+    {
+        $raw = \file_get_contents(self::COMPOSER_JSON);
+        $this->originalComposerJson = $raw === false ? null : $raw;
+
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        Filesystem::removeRecursive(Info::PROJECT_DIR . '/external-target');
+        Filesystem::removeRecursive(Info::PROJECT_DIR . '/inline-target');
+    }
+
+    #[AfterTest]
+    public function restoreComposerJson(): void
+    {
+        if ($this->originalComposerJson !== null) {
+            \file_put_contents(self::COMPOSER_JSON, $this->originalComposerJson);
+        }
+        if (\is_file(self::SKILLS_JSON)) {
+            @\unlink(self::SKILLS_JSON);
+        }
+    }
+
+    // ── precedence ──────────────────────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'target' => 'inline-target/skills',
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function skillsJsonOverridesInlineExtraSkills(): void
+    {
+        // Inline says "inline-target/skills"; external says
+        // "external-target/skills". The mapper must pick external —
+        // the file is the new source of truth.
+        $process = $this->runSync();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \is_file(self::EXTERNAL_TARGET . '/greeting/SKILL.md'),
+            'skills.json target must win over inline target',
+        );
+        Assert::false(
+            \is_dir(self::INLINE_TARGET),
+            'inline target must be ignored entirely',
+        );
+    }
+
+    #[WithSandboxExtras([
+        'target' => 'inline-target/skills',
+        'trusted' => ['acme/skills-basic'],
+        'auto-sync' => true,
+    ])]
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function shadowedInlineKeysAreReportedUnderVerbose(): void
+    {
+        // The warning is under -v so day-to-day output stays quiet;
+        // when the user passes -v they get an explanation of which
+        // inline keys their skills.json shadowed.
+        $process = $this->runSync('-v');
+
+        Assert::same($process->getExitCode(), 0);
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, 'skills.json present'),
+            '-v output must announce the skills.json shadowing. Got: ' . $combined,
+        );
+        Assert::true(
+            \str_contains($combined, 'target'),
+            'shadowed key list should name the colliding inline keys. Got: ' . $combined,
+        );
+    }
+
+    #[WithSandboxExtras([
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function inlineKeysNotInProjectListAreNotReportedAsShadowed(): void
+    {
+        // Inline has only `trusted` (a project key). External shadows
+        // it. The donor-side key `source` is absent, so the shadowed
+        // list should contain just `trusted` — no false positives.
+        $process = $this->runSync('-v');
+
+        Assert::same($process->getExitCode(), 0);
+        Assert::true(\str_contains($process->getErrorOutput(), 'trusted'));
+    }
+
+    public function inlineConfigStillWorksWhenSkillsJsonIsAbsent(): void
+    {
+        // No skills.json. The existing 1.x inline contract must keep
+        // working unchanged — this regression-guards the fallback
+        // branch of the decision tree.
+        $process = $this->runSync();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(\is_file(self::TARGET_DIR . '/greeting/SKILL.md'));
+    }
+
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function skillsJsonAloneDrivesTargetWhenInlineIsAbsent(): void
+    {
+        // Sandbox's default composer.json has its own `extra.skills`
+        // block (with `trusted`), but no `target`. External provides
+        // the target. The combination must work.
+        $process = $this->runSync();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \is_file(self::EXTERNAL_TARGET . '/greeting/SKILL.md'),
+            'skills.json target must apply when used alone',
+        );
+    }
+
+    public function malformedSkillsJsonFailsTheRunWithClearPrefix(): void
+    {
+        \file_put_contents(self::SKILLS_JSON, '{ this is not json');
+
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0, 'malformed skills.json must fail');
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'skills.json:'),
+            'error must be prefixed with skills.json: so the user knows which file. Got: '
+            . $process->getErrorOutput(),
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'rogue' => 'value',
+    ])]
+    public function unknownKeyInSkillsJsonIsFatal(): void
+    {
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0);
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'rogue'),
+            'unknown-key error must name the offending key. Got: ' . $process->getErrorOutput(),
+        );
+    }
+
+    // ── skills:init ─────────────────────────────────────────────────────
+
+    #[WithSandboxExtras([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function initMigratesInlineProjectKeysIntoSkillsJson(): void
+    {
+        $process = $this->runInit();
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'init must succeed; stderr: ' . $process->getErrorOutput(),
+        );
+
+        // skills.json now carries the migrated project keys.
+        Assert::true(\is_file(self::SKILLS_JSON), 'skills.json must exist after init');
+        $skills = $this->readSkillsJson();
+        Assert::same($skills['target'] ?? null, 'external-target/skills');
+        Assert::same($skills['trusted'] ?? null, ['acme/skills-basic']);
+        Assert::true(
+            \array_key_exists('$schema', $skills),
+            '$schema pointer must be emitted into the generated file',
+        );
+
+        // composer.json no longer carries the migrated keys.
+        $composer = $this->readComposerJson();
+        $remainingSkills = $composer['extra']['skills'] ?? [];
+        Assert::false(
+            \array_key_exists('target', $remainingSkills),
+            'target must be removed from composer.json extra.skills',
+        );
+        Assert::false(\array_key_exists('trusted', $remainingSkills));
+    }
+
+    #[WithSandboxExtras([
+        'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function followUpSyncAfterInitReadsFromSkillsJson(): void
+    {
+        // End-to-end migration check: init the file, then run skills:update.
+        // The output must come out of skills.json, not the now-empty
+        // inline block (which still drives behaviour for projects that
+        // skipped init).
+        $initProc = $this->runInit();
+        Assert::same($initProc->getExitCode(), 0, 'init failed: ' . $initProc->getErrorOutput());
+
+        $syncProc = $this->runSync();
+        Assert::same(
+            $syncProc->getExitCode(),
+            0,
+            'follow-up sync must succeed. stderr: ' . $syncProc->getErrorOutput(),
+        );
+        Assert::true(
+            \is_file(self::EXTERNAL_TARGET . '/greeting/SKILL.md'),
+            'skills must land at the path declared in skills.json after init',
+        );
+    }
+
+    public function initRefusesToOverwriteExistingSkillsJsonWithoutForce(): void
+    {
+        \file_put_contents(self::SKILLS_JSON, "{\n  \"target\": \"keep-me\"\n}\n");
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runInit();
+
+        Assert::notSame($process->getExitCode(), 0, 'second init without --force must fail');
+        Assert::true(
+            \str_contains($process->getErrorOutput(), '--force'),
+            'error message must direct the user to --force. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'existing skills.json must be left untouched on refusal',
+        );
+    }
+
+    public function initForceFlagAllowsOverwrite(): void
+    {
+        \file_put_contents(self::SKILLS_JSON, "{}\n");
+
+        $process = $this->runInit('--force');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            '--force must allow overwrite. stderr: ' . $process->getErrorOutput(),
+        );
+        $skills = $this->readSkillsJson();
+        Assert::true(\array_key_exists('$schema', $skills), 'rewrite must emit fresh stub');
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private function runSync(string ...$args): Process
+    {
+        $command = 'skills:update';
+        if ($args !== []) {
+            $command .= ' ' . \implode(' ', $args);
+        }
+
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            $command,
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    private function runInit(string ...$args): Process
+    {
+        $command = 'skills:init';
+        if ($args !== []) {
+            $command .= ' ' . \implode(' ', $args);
+        }
+
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            $command,
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(self::SKILLS_JSON),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readComposerJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(Info::PROJECT_DIR . '/composer.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+
+        return $decoded;
+    }
+
+}

--- a/tests/Acceptance/SkillsJsonConfigTest.php
+++ b/tests/Acceptance/SkillsJsonConfigTest.php
@@ -205,6 +205,76 @@ final class SkillsJsonConfigTest
         );
     }
 
+    // ── security: paths must stay inside the project root ──────────────
+
+    #[WithSkillsJson([
+        'target' => '../escape/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function targetEscapingProjectRootViaSkillsJsonIsRejected(): void
+    {
+        // SyncPlanner's containment guard catches the escape regardless
+        // of where the value came from (CLI, inline composer.json,
+        // skills.json). This test pins the contract specifically for
+        // the skills.json source so a future loader refactor cannot
+        // silently bypass the planner.
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0, '../escape via skills.json must fail');
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'outside the project root'),
+            'stderr must explain containment failure. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \is_dir(Info::PROJECT_DIR . '/../escape'),
+            'no directory must be created outside the project root',
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => '/tmp/absolute-escape',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function absoluteTargetOutsideProjectRootViaSkillsJsonIsRejected(): void
+    {
+        // Absolute paths are honoured (matching the legacy contract),
+        // but they still must live inside the project. /tmp/...
+        // obviously does not.
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0);
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'outside the project root'),
+            'stderr must explain containment failure. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \is_dir('/tmp/absolute-escape'),
+            'no absolute escape directory must be created',
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'aliases' => ['../escape-alias'],
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function aliasEscapingProjectRootViaSkillsJsonIsRejected(): void
+    {
+        // Same guard for aliases: a junction at ../escape-alias would
+        // expose an arbitrary parent location through the project tree.
+        $process = $this->runSync();
+
+        Assert::notSame($process->getExitCode(), 0, 'alias ../escape via skills.json must fail');
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'outside the project root'),
+            'stderr must explain containment failure. Got: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \file_exists(Info::PROJECT_DIR . '/../escape-alias'),
+            'no junction must be created outside the project root',
+        );
+    }
+
     // ── skills:init ─────────────────────────────────────────────────────
 
     #[WithSandboxExtras([

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use JsonSchema\Validator;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Schema-matrix test for `resources/skills.schema.json`.
+ *
+ * The JSON Schema is hand-written and intended for IDE/editor support.
+ * Production code does not validate against it at runtime — the PHP
+ * mapper is the authoritative validator. This test guards the two
+ * surfaces from drifting apart by replaying a curated set of valid
+ * and invalid documents and asserting the schema agrees with what
+ * the PHP mapper would do.
+ *
+ * `justinrainbow/json-schema` is pulled in transitively via
+ * `composer/composer` (already required for the plugin) so no new
+ * production dependency is added.
+ */
+#[Test]
+final class SkillsSchemaTest
+{
+    private const SCHEMA_PATH = __DIR__ . '/../../resources/skills.schema.json';
+
+    public function emptyObjectIsAccepted(): void
+    {
+        $this->assertAccepts([]);
+    }
+
+    public function schemaOnlyDocumentIsAccepted(): void
+    {
+        // The stub `skills:init` writes contains just `$schema`. That
+        // must be a valid document under our own schema.
+        $this->assertAccepts([
+            '$schema' => 'https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json',
+        ]);
+    }
+
+    public function fullyPopulatedDocumentIsAccepted(): void
+    {
+        $this->assertAccepts([
+            'target' => '.agents/skills',
+            'aliases' => ['.claude/skills', '.cursor/skills'],
+            'trusted' => ['acme/skills-basic', 'acme/*'],
+            'trusted-replace' => true,
+            'discovery' => true,
+            'auto-sync' => true,
+        ]);
+    }
+
+    public function unknownTopLevelKeyIsRejected(): void
+    {
+        $this->assertRejects([
+            'target' => '.agents/skills',
+            'rogue-key' => 'value',
+        ]);
+    }
+
+    public function configFileKeyIsRejected(): void
+    {
+        // `config-file` was considered earlier in design but dropped.
+        // The schema must refuse it so editors flag legacy attempts.
+        $this->assertRejects([
+            'config-file' => 'other.json',
+        ]);
+    }
+
+    public function emptyTargetIsRejected(): void
+    {
+        // The PHP mapper rejects an empty `target`; the schema's
+        // `minLength: 1` constraint mirrors that.
+        $this->assertRejects([
+            'target' => '',
+        ]);
+    }
+
+    public function nonStringTargetIsRejected(): void
+    {
+        $this->assertRejects([
+            'target' => 42,
+        ]);
+    }
+
+    public function nonBooleanFlagIsRejected(): void
+    {
+        $this->assertRejects([
+            'auto-sync' => 'yes',
+        ]);
+    }
+
+    public function aliasesAsScalarIsRejected(): void
+    {
+        $this->assertRejects([
+            'aliases' => '.claude/skills',
+        ]);
+    }
+
+    public function emptyAliasEntryIsRejected(): void
+    {
+        $this->assertRejects([
+            'aliases' => [''],
+        ]);
+    }
+
+    public function bareVendorPatternIsRejected(): void
+    {
+        // The mapper rejects `acme` (no slash); the schema mirrors
+        // that with a pattern constraint.
+        $this->assertRejects([
+            'trusted' => ['acme'],
+        ]);
+    }
+
+    public function emptyTrustedEntryIsRejected(): void
+    {
+        $this->assertRejects([
+            'trusted' => [''],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    private function assertAccepts(array $document): void
+    {
+        [$valid, $errors] = $this->validate($document);
+
+        Assert::true(
+            $valid,
+            'document should validate but the schema rejected it. Errors: ' . \implode('; ', $errors),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    private function assertRejects(array $document): void
+    {
+        [$valid] = $this->validate($document);
+
+        Assert::false(
+            $valid,
+            'document should fail validation but the schema accepted it: '
+            . \json_encode($document, \JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * Run the document through justinrainbow/json-schema. Returns a
+     * `[bool $valid, list<string> $errors]` pair.
+     *
+     * @param array<string, mixed> $document
+     *
+     * @return array{0: bool, 1: list<string>}
+     */
+    private function validate(array $document): array
+    {
+        $schema = \json_decode(
+            (string) \file_get_contents(self::SCHEMA_PATH),
+            false,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+
+        // The validator wants stdClass for the root object but plain
+        // arrays for JSON arrays inside it (e.g. `aliases`). Encode
+        // with normal flags, then decode without assoc to get that
+        // mixed shape — and force the root to stdClass via cast,
+        // which keeps inner arrays as arrays.
+        /** @var object|array $decoded */
+        $decoded = \json_decode(
+            \json_encode($document, \JSON_THROW_ON_ERROR),
+            false,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        // An empty object decodes to `[]` (PHP empty array) — coerce
+        // to stdClass so the schema sees the right type.
+        $value = \is_object($decoded) ? $decoded : (object) [];
+
+        $validator = new Validator();
+        $validator->validate($value, $schema);
+
+        $errors = [];
+        foreach ($validator->getErrors() as $error) {
+            $errors[] = \sprintf('%s: %s', $error['property'] ?? '(root)', $error['message'] ?? '');
+        }
+
+        return [$validator->isValid(), $errors];
+    }
+}

--- a/tests/Acceptance/SkillsShowTest.php
+++ b/tests/Acceptance/SkillsShowTest.php
@@ -8,8 +8,10 @@ use Internal\Path;
 use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
 use LLM\Skills\Tests\Testo\Composer\WithSandboxExtras;
 use LLM\Skills\Tests\Testo\Filesystem;
+use LLM\Skills\Tests\Testo\SandboxStateGuard;
 use Symfony\Component\Process\Process;
 use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
 use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
 
@@ -32,6 +34,13 @@ final class SkillsShowTest
     {
         Filesystem::removeRecursive(self::TARGET_DIR);
         Filesystem::removeRecursive(Info::PROJECT_DIR . '/custom-skills-target');
+        SandboxStateGuard::snapshot();
+    }
+
+    #[AfterTest]
+    public function restoreSandbox(): void
+    {
+        SandboxStateGuard::restore();
     }
 
     // ── basics ──────────────────────────────────────────────────────────────

--- a/tests/Acceptance/SkillsSyncTest.php
+++ b/tests/Acceptance/SkillsSyncTest.php
@@ -8,8 +8,10 @@ use Internal\Path;
 use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
 use LLM\Skills\Tests\Testo\Composer\WithSandboxExtras;
 use LLM\Skills\Tests\Testo\Filesystem;
+use LLM\Skills\Tests\Testo\SandboxStateGuard;
 use Symfony\Component\Process\Process;
 use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
 use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
 
@@ -48,7 +50,10 @@ final class SkillsSyncTest
 
     /**
      * Wipe the synced skills directory before each test so assertions reflect
-     * what this run produced, not leftovers from previous runs.
+     * what this run produced, not leftovers from previous runs. Also snapshot
+     * composer.json / skills.json so the migration that `skills:update` now
+     * performs (moving inline extra.skills into skills.json) does not leak
+     * into the next test.
      */
     #[BeforeTest]
     public function clearTargetDir(): void
@@ -58,6 +63,13 @@ final class SkillsSyncTest
         Filesystem::removeRecursive(Info::PROJECT_DIR . '/config-target');
         Filesystem::removeRecursive(self::ALIAS_CLAUDE);
         Filesystem::removeRecursive(self::ALIAS_CURSOR);
+        SandboxStateGuard::snapshot();
+    }
+
+    #[AfterTest]
+    public function restoreSandbox(): void
+    {
+        SandboxStateGuard::restore();
     }
 
     // ── basic happy path ────────────────────────────────────────────────────

--- a/tests/Acceptance/StandaloneBinTest.php
+++ b/tests/Acceptance/StandaloneBinTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\BinSkillsRunner;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance tests for the standalone `bin/skills` binary running in
+ * a directory without a `composer.json`.
+ *
+ * The spec (see `spec-config-file.md` §3.2 / §10) says that, with no
+ * Composer install tree around, the utility must:
+ *
+ *  1. Treat the cwd as the project root.
+ *  2. Read `skills.json` directly when it exists (or use defaults).
+ *  3. Report "no donors available" and exit 0 instead of dying with a
+ *     Composer bootstrap error.
+ *
+ * Today the second leg of `update`/`show` still hard-requires
+ * Composer bootstrap and so fails with `Failed to bootstrap Composer`.
+ * These tests are the failing fixtures that drive the standalone-mode
+ * fallback implementation.
+ */
+#[Test]
+final class StandaloneBinTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-standalone-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    // ── update / show without composer.json ─────────────────────────────
+
+    public function updateInEmptyDirectoryDoesNotRequireComposerJson(): void
+    {
+        // Bare directory: no composer.json, no skills.json. The binary
+        // must still come up cleanly — there are simply no donors to
+        // consider, so it exits 0 with a "nothing to do" notice rather
+        // than the Composer bootstrap error.
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'update');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'update in an empty dir must succeed; got stderr: ' . $process->getErrorOutput()
+            . ' / stdout: ' . $process->getOutput(),
+        );
+        Assert::false(
+            \str_contains(
+                $process->getErrorOutput() . $process->getOutput(),
+                'Failed to bootstrap Composer',
+            ),
+            'standalone mode must not surface the Composer bootstrap error',
+        );
+    }
+
+    public function updateInEmptyDirectoryAnnouncesStandaloneMode(): void
+    {
+        // The user needs to know why nothing was synced — without a
+        // visible diagnostic, an empty target would look like a bug.
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'update');
+        $combined = $process->getOutput() . $process->getErrorOutput();
+
+        Assert::true(
+            \str_contains($combined, 'no donors available'),
+            'output must explain why nothing was copied. Got: ' . $combined,
+        );
+    }
+
+    public function updateReadsSkillsJsonWhenPresentEvenWithoutComposerJson(): void
+    {
+        // Project config still resolves correctly: the runner takes the
+        // cwd as the project root, finds skills.json, parses its target.
+        // We do not actually assert on filesystem effects (no donors →
+        // nothing to write); the proof is that the run succeeds and the
+        // configured target appears in the output / diagnostics.
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode([
+                'target' => 'my-target/skills',
+            ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES) . "\n",
+        );
+
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'update');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'update with skills.json but no composer.json must succeed. stderr: '
+            . $process->getErrorOutput(),
+        );
+    }
+
+    public function updateRejectsMalformedSkillsJsonInStandaloneMode(): void
+    {
+        // skills.json validation is the same in both modes: a broken
+        // file is fatal, with a `skills.json:` prefix on the error so
+        // the origin is unambiguous.
+        \file_put_contents($this->tmp . '/skills.json', '{ not valid');
+
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'update');
+
+        Assert::notSame(
+            $process->getExitCode(),
+            0,
+            'malformed skills.json must fail the run, just as in composer-attached mode',
+        );
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'skills.json:'),
+            'error must be prefixed with skills.json: so the user knows which file. Got: '
+            . $process->getErrorOutput(),
+        );
+    }
+
+    public function showInEmptyDirectoryDoesNotRequireComposerJson(): void
+    {
+        // skills:show is the same shape as update — read-only inspection
+        // of the same pipeline. It must survive the same standalone
+        // conditions.
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'show');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'show in an empty dir must succeed; got stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \str_contains(
+                $process->getErrorOutput() . $process->getOutput(),
+                'Failed to bootstrap Composer',
+            ),
+            'standalone show must not surface the Composer bootstrap error',
+        );
+    }
+
+    // ── init standalone (currently works but covered end-to-end) ────────
+
+    public function initInEmptyDirectoryWritesStubSkillsJson(): void
+    {
+        // The init command already handles standalone mode (it never
+        // tries to bootstrap Composer in the first place). This test
+        // pins the behaviour from the bin/skills entrypoint angle so a
+        // future refactor cannot accidentally regress it.
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'init');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'init in an empty dir must succeed. stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::true(
+            \is_file($this->tmp . '/skills.json'),
+            'init must create skills.json in the cwd',
+        );
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        Assert::same(\array_keys($decoded), ['$schema'], 'standalone init writes a stub');
+    }
+}

--- a/tests/Acceptance/StandaloneBinTest.php
+++ b/tests/Acceptance/StandaloneBinTest.php
@@ -16,18 +16,18 @@ use Testo\Test;
  * Acceptance tests for the standalone `bin/skills` binary running in
  * a directory without a `composer.json`.
  *
- * The spec (see `spec-config-file.md` §3.2 / §10) says that, with no
- * Composer install tree around, the utility must:
+ * Per `spec-config-file.md` §3.2 / §10, with no Composer install tree
+ * around the utility:
  *
- *  1. Treat the cwd as the project root.
- *  2. Read `skills.json` directly when it exists (or use defaults).
- *  3. Report "no donors available" and exit 0 instead of dying with a
- *     Composer bootstrap error.
+ *  1. Treats the cwd as the project root.
+ *  2. Reads `skills.json` directly when it exists (or uses defaults).
+ *  3. Reports that no donor providers are active and exits 0 — never
+ *     surfaces the `Failed to bootstrap Composer` error a naive
+ *     `Factory::create()` call would produce.
  *
- * Today the second leg of `update`/`show` still hard-requires
- * Composer bootstrap and so fails with `Failed to bootstrap Composer`.
- * These tests are the failing fixtures that drive the standalone-mode
- * fallback implementation.
+ * These tests pin the contract so a future refactor of the
+ * provider chain cannot accidentally regress standalone mode back to
+ * "Composer is mandatory".
  */
 #[Test]
 final class StandaloneBinTest
@@ -76,12 +76,30 @@ final class StandaloneBinTest
     {
         // The user needs to know why nothing was synced — without a
         // visible diagnostic, an empty target would look like a bug.
+        // The user-facing notice stays provider-neutral; specifics
+        // (which provider was inactive and why) flow through `-v`.
         $process = BinSkillsRunner::run(Path::create($this->tmp), 'update');
         $combined = $process->getOutput() . $process->getErrorOutput();
 
         Assert::true(
-            \str_contains($combined, 'no donors available'),
+            \str_contains($combined, 'no donor providers are active'),
             'output must explain why nothing was copied. Got: ' . $combined,
+        );
+    }
+
+    public function updateInEmptyDirectoryExplainsCauseUnderVerbose(): void
+    {
+        // The neutral notice tells *what*; the -v warning tells *why*
+        // (no composer.json at <cwd>). Without this line, a user
+        // staring at "no donor providers are active" would not know
+        // whether they hit the missing-file path or a bootstrap
+        // failure path.
+        $process = BinSkillsRunner::run(Path::create($this->tmp), 'update -v');
+        $combined = $process->getOutput() . $process->getErrorOutput();
+
+        Assert::true(
+            \str_contains($combined, 'no composer.json'),
+            '-v output must name the actual cause. Got: ' . $combined,
         );
     }
 

--- a/tests/Testo/Composer/BinSkillsRunner.php
+++ b/tests/Testo/Composer/BinSkillsRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Testo\Composer;
+
+use Internal\Path;
+use Symfony\Component\Process\Process;
+
+/**
+ * Counterpart of {@see ComposerRunner} for the standalone `bin/skills`
+ * binary. Used by acceptance tests that exercise the script's standalone
+ * mode — running outside any Composer project (no `composer.json` at the
+ * cwd) so the Composer bootstrap must NOT be required for success.
+ *
+ * The wrapper appends `--no-interaction --no-ansi` for stable output
+ * capture, mirroring {@see ComposerRunner}.
+ */
+final class BinSkillsRunner
+{
+    /**
+     * Absolute path to the project's `bin/skills` script. Resolved once
+     * from this file's location so callers do not need to figure it out.
+     */
+    public const BIN_PATH = __DIR__ . '/../../../bin/skills';
+
+    /**
+     * @param non-empty-string $command Subcommand and arguments, e.g. `update --discovery`.
+     * @param int<1, max> $timeout Hard timeout in seconds.
+     */
+    public static function run(
+        Path $cwd,
+        string $command,
+        int $timeout = 60,
+    ): Process {
+        \fwrite(\STDERR, "[acceptance] bin/skills {$command} in {$cwd} …\n");
+
+        $process = Process::fromShellCommandline(
+            \sprintf('php %s %s --no-interaction --no-ansi', \escapeshellarg(self::BIN_PATH), $command),
+            cwd: (string) $cwd,
+            env: ['SHELL_VERBOSITY' => '0'],
+        );
+        $process->setTimeout($timeout);
+        $process->run();
+
+        return $process;
+    }
+}

--- a/tests/Testo/Composer/WithSkillsJson.php
+++ b/tests/Testo/Composer/WithSkillsJson.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Testo\Composer;
+
+use Testo\Pipeline\Attribute\FallbackInterceptor;
+use Testo\Pipeline\Attribute\Interceptable;
+
+/**
+ * Writes a `skills.json` file into the sandbox project's root for the
+ * duration of the test, then removes it (and restores the original, if
+ * any) when the test finishes.
+ *
+ * Used by acceptance tests covering the `skills.json` precedence /
+ * fallback contract: the file's presence is the signal the mapper
+ * looks at, so attaching this attribute toggles which source of
+ * project config the next `composer skills:update` will read.
+ *
+ * Usage:
+ *
+ *     #[Test]
+ *     #[WithSkillsJson(['target' => 'external-target/skills'])]
+ *     public function externalConfigDrivesTarget(): void { ... }
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
+#[FallbackInterceptor(WithSkillsJsonInterceptor::class)]
+final readonly class WithSkillsJson implements Interceptable
+{
+    /**
+     * @param array<string, mixed> $content value to encode at
+     *        `<sandbox-root>/skills.json` for the duration of the test
+     */
+    public function __construct(
+        public array $content,
+    ) {}
+}

--- a/tests/Testo/Composer/WithSkillsJsonInterceptor.php
+++ b/tests/Testo/Composer/WithSkillsJsonInterceptor.php
@@ -35,7 +35,24 @@ final readonly class WithSkillsJsonInterceptor implements TestRunInterceptor
     {
         $path = Info::PROJECT_DIR . '/skills.json';
 
-        $previousContent = \is_file($path) ? \file_get_contents($path) : null;
+        // Distinguish three states for the post-test restore:
+        //   - file did not exist  → $previousContent = null  (delete in finally)
+        //   - file existed, read OK → $previousContent = string (write back)
+        //   - file existed, read failed → throw NOW, because finally would
+        //     otherwise see `false` and delete the original — corrupting the
+        //     sandbox on an unrelated IO failure.
+        $previousContent = null;
+        if (\is_file($path)) {
+            $read = \file_get_contents($path);
+            if ($read === false) {
+                throw new \RuntimeException(\sprintf(
+                    'WithSkillsJsonInterceptor: unable to read existing %s; refusing to '
+                    . 'overwrite to avoid losing the original on teardown.',
+                    $path,
+                ));
+            }
+            $previousContent = $read;
+        }
 
         \file_put_contents(
             $path,
@@ -48,7 +65,7 @@ final readonly class WithSkillsJsonInterceptor implements TestRunInterceptor
         try {
             return $next($info);
         } finally {
-            if ($previousContent === null || $previousContent === false) {
+            if ($previousContent === null) {
                 @\unlink($path);
             } else {
                 \file_put_contents($path, $previousContent);

--- a/tests/Testo/Composer/WithSkillsJsonInterceptor.php
+++ b/tests/Testo/Composer/WithSkillsJsonInterceptor.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Testo\Composer;
+
+use LLM\Skills\Tests\Acceptance\Info;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Pipeline\Middleware\TestRunInterceptor;
+
+/**
+ * Executes the {@see WithSkillsJson} attribute: drop a `skills.json` at
+ * the sandbox root for the duration of the test, restore the prior
+ * state in `finally` so a failing assertion does not contaminate the
+ * next test.
+ *
+ * Restoration handles three prior states:
+ *
+ * - **No file** — created by us; we delete it on teardown.
+ * - **File existed already** — overwritten by us; we restore its
+ *   original contents.
+ *
+ * In both cases the sandbox returns to the state it had before the
+ * test ran.
+ */
+final readonly class WithSkillsJsonInterceptor implements TestRunInterceptor
+{
+    public function __construct(
+        private WithSkillsJson $options,
+    ) {}
+
+    #[\Override]
+    public function runTest(TestInfo $info, callable $next): TestResult
+    {
+        $path = Info::PROJECT_DIR . '/skills.json';
+
+        $previousContent = \is_file($path) ? \file_get_contents($path) : null;
+
+        \file_put_contents(
+            $path,
+            \json_encode(
+                $this->options->content,
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
+
+        try {
+            return $next($info);
+        } finally {
+            if ($previousContent === null || $previousContent === false) {
+                @\unlink($path);
+            } else {
+                \file_put_contents($path, $previousContent);
+            }
+        }
+    }
+}

--- a/tests/Testo/SandboxStateGuard.php
+++ b/tests/Testo/SandboxStateGuard.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Testo;
+
+/**
+ * Snapshot/restore helper for the shared sandbox `composer.json` and
+ * `skills.json` files.
+ *
+ * Auto-migration in `skills:update` (and the `post-update-cmd`
+ * auto-sync hook) rewrites `composer.json` and creates
+ * `skills.json`. Tests share the sandbox directory, so without an
+ * explicit restore one test's migration would leak into the next
+ * (e.g. the second `skills:update` run would see the migrated
+ * skills.json from the first run instead of the inline block the
+ * sandbox ships with).
+ *
+ * Usage:
+ *
+ *     #[BeforeTest]
+ *     public function snapshotSandbox(): void
+ *     {
+ *         SandboxStateGuard::snapshot();
+ *     }
+ *
+ *     #[AfterTest]
+ *     public function restoreSandbox(): void
+ *     {
+ *         SandboxStateGuard::restore();
+ *     }
+ *
+ * Idempotent on missing files: `composer.json` is always present in
+ * the sandbox (snapshot is mandatory); `skills.json` may not be
+ * (snapshot records its absence, restore deletes the file if it
+ * appeared during the test).
+ */
+final class SandboxStateGuard
+{
+    private static ?string $composerJsonSnapshot = null;
+
+    /** False when no skills.json existed at snapshot time. */
+    private static string|false $skillsJsonSnapshot = false;
+
+    public static function snapshot(): void
+    {
+        $composerPath = self::composerJsonPath();
+        $content = \file_get_contents($composerPath);
+        if ($content === false) {
+            throw new \RuntimeException(\sprintf(
+                'SandboxStateGuard: failed to read %s for snapshot',
+                $composerPath,
+            ));
+        }
+        self::$composerJsonSnapshot = $content;
+
+        $skillsPath = self::skillsJsonPath();
+        if (\is_file($skillsPath)) {
+            $skills = \file_get_contents($skillsPath);
+            if ($skills === false) {
+                throw new \RuntimeException(\sprintf(
+                    'SandboxStateGuard: skills.json present at %s but unreadable',
+                    $skillsPath,
+                ));
+            }
+            self::$skillsJsonSnapshot = $skills;
+        } else {
+            self::$skillsJsonSnapshot = false;
+        }
+    }
+
+    public static function restore(): void
+    {
+        if (self::$composerJsonSnapshot !== null) {
+            \file_put_contents(self::composerJsonPath(), self::$composerJsonSnapshot);
+        }
+
+        $skillsPath = self::skillsJsonPath();
+        if (self::$skillsJsonSnapshot === false) {
+            if (\is_file($skillsPath)) {
+                @\unlink($skillsPath);
+            }
+        } else {
+            \file_put_contents($skillsPath, self::$skillsJsonSnapshot);
+        }
+    }
+
+    private static function composerJsonPath(): string
+    {
+        return \LLM\Skills\Tests\Acceptance\Info::PROJECT_DIR . '/composer.json';
+    }
+
+    private static function skillsJsonPath(): string
+    {
+        return \LLM\Skills\Tests\Acceptance\Info::PROJECT_DIR . '/skills.json';
+    }
+}

--- a/tests/Unit/Composer/ComposerJsonExtraReaderTest.php
+++ b/tests/Unit/Composer/ComposerJsonExtraReaderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Composer;
+
+use Composer\IO\BufferIO;
+use Internal\Path;
+use LLM\Skills\Composer\ComposerJsonExtraReader;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Unit coverage for the `composer.json` `extra` fallback reader.
+ *
+ * Used by `bin/skills` entrypoints when `Composer\Factory::create()`
+ * throws but `composer.json` is still readable: the user's inline
+ * `extra.skills` block must keep flowing into the runner so the
+ * legacy fallback contract holds. Each non-trivial failure path
+ * here returns `null` rather than throwing — the caller has no
+ * recovery available beyond "no extras".
+ */
+#[Test]
+final class ComposerJsonExtraReaderTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-extra-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function returnsNullWhenComposerJsonIsAbsent(): void
+    {
+        $result = (new ComposerJsonExtraReader())->read(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::null($result);
+    }
+
+    public function returnsExtraValueWhenPresent(): void
+    {
+        // The reader returns the raw `extra` field as-is, including
+        // any nested `skills` block — the mapper downstream handles
+        // shape validation.
+        \file_put_contents(
+            $this->tmp . '/composer.json',
+            \json_encode([
+                'name' => 'demo/consumer',
+                'extra' => [
+                    'skills' => ['target' => 'custom/skills'],
+                ],
+            ], \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR),
+        );
+
+        $result = (new ComposerJsonExtraReader())->read(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result, ['skills' => ['target' => 'custom/skills']]);
+    }
+
+    public function returnsNullWhenExtraKeyIsAbsent(): void
+    {
+        // composer.json may legitimately have no `extra` at all —
+        // that's a project with no inline customisation, not an error.
+        \file_put_contents(
+            $this->tmp . '/composer.json',
+            \json_encode(['name' => 'demo/no-extra'], \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR),
+        );
+
+        $result = (new ComposerJsonExtraReader())->read(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::null($result);
+    }
+
+    public function returnsNullAndWarnsOnMalformedJson(): void
+    {
+        // A broken composer.json is what Factory::create() may have
+        // tripped over in the first place. We do not re-fail the run
+        // (the caller already accepted that no Composer is available);
+        // we just disable the inline fallback and tell the user under -v.
+        \file_put_contents($this->tmp . '/composer.json', '{ definitely not valid json');
+
+        $io = new BufferIO(verbosity: \Symfony\Component\Console\Output\StreamOutput::VERBOSITY_VERBOSE);
+        $result = (new ComposerJsonExtraReader())->read(Path::create($this->tmp), $io);
+
+        Assert::null($result);
+        Assert::true(
+            \str_contains($io->getOutput(), 'inline extra.skills fallback disabled'),
+            '-v output must explain why the fallback is empty. Got: ' . $io->getOutput(),
+        );
+    }
+
+    public function returnsNullWhenRootIsNotAnObject(): void
+    {
+        // A JSON array at the root is technically valid JSON but not a
+        // Composer manifest. The reader simply yields null — same
+        // user-visible outcome as "no extras".
+        \file_put_contents($this->tmp . '/composer.json', '[1, 2, 3]');
+
+        $result = (new ComposerJsonExtraReader())->read(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::null($result);
+    }
+
+    public function returnsExtraWhenItIsAnEmptyObject(): void
+    {
+        // An empty `extra` decodes to an empty array — distinguishable
+        // from "no extra key" only by the caller. We propagate it
+        // verbatim; the project-config mapper treats `[]` as "use
+        // defaults" anyway.
+        \file_put_contents(
+            $this->tmp . '/composer.json',
+            '{"name": "demo/empty-extra", "extra": {}}',
+        );
+
+        $result = (new ComposerJsonExtraReader())->read(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result, []);
+    }
+}

--- a/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
+++ b/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
@@ -71,8 +71,10 @@ final class ExternalProjectConfigLoaderTest
     public function emptyObjectDecodesAsEmptyArray(): void
     {
         // `{}` is a valid (if uninteresting) skills.json — it means "no
-        // project-level overrides, use defaults across the board".
-        $this->writeFile([]);
+        // project-level overrides, use defaults across the board". Written
+        // as the literal JSON object form because `json_encode([])`
+        // emits the array form `[]`, which the loader correctly rejects.
+        \file_put_contents($this->tmp . '/skills.json', '{}');
 
         $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
 
@@ -102,13 +104,26 @@ final class ExternalProjectConfigLoaderTest
 
     public function listRootThrows(): void
     {
-        // A JSON array decodes to a non-empty list-shaped array; the
-        // loader distinguishes it from `{}` (which also decodes to `[]`)
-        // via `array_is_list`.
+        // A non-empty JSON array must be rejected — the contract is
+        // "root is a JSON object".
         \file_put_contents($this->tmp . '/skills.json', '[1, 2, 3]');
 
         Expect::exception(MalformedProjectConfig::class)
-            ->withMessageContaining('got a list');
+            ->withMessageContaining('root must be a JSON object');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    public function emptyListRootThrows(): void
+    {
+        // Edge case: `[]` and `{}` both decode to PHP `[]` under
+        // `json_decode(..., true)`. The loader must still tell them
+        // apart and reject the array form — that's what the
+        // `assoc=false` first-pass type check is for.
+        \file_put_contents($this->tmp . '/skills.json', '[]');
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('root must be a JSON object');
 
         (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
     }

--- a/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
+++ b/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Config\Mapper;
+
+use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Config\Mapper\ExternalProjectConfigLoader;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Expect;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+#[Test]
+final class ExternalProjectConfigLoaderTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-ext-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function returnsNullWhenFileIsAbsent(): void
+    {
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::null($result);
+    }
+
+    public function decodesValidObject(): void
+    {
+        $this->writeFile([
+            'target' => '.agents/skills',
+            'aliases' => ['.claude/skills'],
+        ]);
+
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::same($result, [
+            'target' => '.agents/skills',
+            'aliases' => ['.claude/skills'],
+        ]);
+    }
+
+    public function stripsSchemaKeyFromResult(): void
+    {
+        // `$schema` is editor metadata; the loader strips it so downstream
+        // code never sees it. The other keys must come through unchanged.
+        $this->writeFile([
+            '$schema' => 'https://example.com/skills.schema.json',
+            'target' => '.agents/skills',
+        ]);
+
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::same($result, ['target' => '.agents/skills']);
+    }
+
+    public function emptyObjectDecodesAsEmptyArray(): void
+    {
+        // `{}` is a valid (if uninteresting) skills.json — it means "no
+        // project-level overrides, use defaults across the board".
+        $this->writeFile([]);
+
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::same($result, []);
+    }
+
+    public function invalidJsonThrows(): void
+    {
+        \file_put_contents($this->tmp . '/skills.json', '{not valid json');
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: invalid JSON');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    public function nonObjectRootThrows(): void
+    {
+        // A scalar at the root is rejected — the loader expects an object.
+        \file_put_contents($this->tmp . '/skills.json', '"hello"');
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: root must be a JSON object');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    public function listRootThrows(): void
+    {
+        // A JSON array decodes to a non-empty list-shaped array; the
+        // loader distinguishes it from `{}` (which also decodes to `[]`)
+        // via `array_is_list`.
+        \file_put_contents($this->tmp . '/skills.json', '[1, 2, 3]');
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('got a list');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    public function unknownTopLevelKeyThrows(): void
+    {
+        // Strictness contract: only the documented keys are accepted.
+        $this->writeFile([
+            'target' => '.agents/skills',
+            'unexpected-key' => 'oops',
+        ]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('unexpected-key');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    public function configFileKeyInsideExternalFileIsRejected(): void
+    {
+        // The previously-considered config-file pointer is project-only;
+        // including it inside skills.json itself is nonsensical and the
+        // strict-keys check refuses it.
+        $this->writeFile([
+            'config-file' => 'other.json',
+            'target' => '.agents/skills',
+        ]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('config-file');
+
+        (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeFile(array $data): void
+    {
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -289,11 +289,15 @@ final class ProjectConfigMapperTest
         ]);
     }
 
-    public function autoSyncDefaultsToFalse(): void
+    public function autoSyncDefaultsToTrue(): void
     {
+        // Default flipped to true so most projects get the
+        // post-install/update freshness behaviour without ceremony.
+        // Projects with stricter CI policies opt out via
+        // `auto-sync: false`.
         $cfg = (new ProjectConfigMapper())->fromExtra(['skills' => []]);
 
-        Assert::same($cfg->autoSync, false);
+        Assert::same($cfg->autoSync, true);
     }
 
     public function autoSyncIsMappedWhenTrue(): void

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -4,16 +4,35 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Config\Mapper;
 
+use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\ProjectConfig;
+use LLM\Skills\Tests\Testo\Filesystem;
 use Testo\Assert;
 use Testo\Expect;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
 
 #[Test]
 final class ProjectConfigMapperTest
 {
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUpTmp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-mapper-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDownTmp(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
     public function nullExtraYieldsDefaults(): void
     {
         $cfg = (new ProjectConfigMapper())->fromExtra(null);
@@ -297,5 +316,120 @@ final class ProjectConfigMapperTest
             ->withMessageContaining('extra.skills.auto-sync');
 
         (new ProjectConfigMapper())->fromExtra(['skills' => ['auto-sync' => 'yes']]);
+    }
+
+    // ── forProject(): decision tree between skills.json and inline ──────
+
+    public function forProjectFallsBackToInlineWhenSkillsJsonAbsent(): void
+    {
+        // No skills.json in $tmp; the mapper must use the inline block
+        // exactly as fromExtra() would, and report no shadowed keys.
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['target' => 'inline/skills']],
+        );
+
+        Assert::same($resolution->config->target, 'inline/skills');
+        Assert::same($resolution->ignoredInlineKeys, []);
+    }
+
+    public function forProjectLoadsSkillsJsonWhenPresent(): void
+    {
+        $this->writeSkillsJson(['target' => 'external/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['target' => 'inline/skills']],
+        );
+
+        Assert::same(
+            $resolution->config->target,
+            'external/skills',
+            'skills.json must win when both sources are present',
+        );
+    }
+
+    public function forProjectListsShadowedInlineProjectKeys(): void
+    {
+        // skills.json is present, so inline project keys are shadowed.
+        // The caller surfaces this list under -v.
+        $this->writeSkillsJson(['target' => 'external/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => [
+                'target' => 'inline/skills',
+                'aliases' => ['.claude/skills'],
+                'auto-sync' => true,
+            ]],
+        );
+
+        Assert::same($resolution->ignoredInlineKeys, ['target', 'aliases', 'auto-sync']);
+    }
+
+    public function forProjectDoesNotListSourceAsShadowed(): void
+    {
+        // `source` is a donor-side key — the same root package may
+        // legitimately ship its own skills via `source` while also
+        // being a consumer via skills.json. The warning must not
+        // accuse `source` of being shadowed.
+        $this->writeSkillsJson(['target' => 'external/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => [
+                'source' => 'resources/skills',
+                'target' => 'inline/skills',
+            ]],
+        );
+
+        Assert::same(
+            $resolution->ignoredInlineKeys,
+            ['target'],
+            'source is a donor key and must not appear in the shadowed-keys list',
+        );
+    }
+
+    public function forProjectEmitsEmptyShadowedListWhenInlineHasOnlyDonorKey(): void
+    {
+        // skills.json + inline `source` only → nothing is shadowed,
+        // because no project-level inline key competes with it.
+        $this->writeSkillsJson(['target' => 'external/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['source' => 'resources/skills']],
+        );
+
+        Assert::same($resolution->ignoredInlineKeys, []);
+    }
+
+    public function forProjectPropagatesExternalErrors(): void
+    {
+        \file_put_contents($this->tmp . '/skills.json', '{ bad json');
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json:');
+
+        (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+    }
+
+    public function forProjectWithMissingSkillsJsonAndNullExtraReturnsDefaults(): void
+    {
+        $resolution = (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+
+        Assert::same($resolution->config->target, ProjectConfig::DEFAULT_TARGET);
+        Assert::same($resolution->ignoredInlineKeys, []);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeSkillsJson(array $data): void
+    {
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR),
+        );
     }
 }

--- a/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Config\Mapper;
+
+use Composer\IO\BufferIO;
+use Internal\Path;
+use LLM\Skills\Config\Mapper\MigrationStatus;
+use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Unit coverage for the auto-migration body. Acceptance counterparts
+ * exercise the same logic through `composer skills:update`; this
+ * suite isolates the decision tree (when to migrate vs skip vs fail)
+ * and the filesystem effects so failures point at the migrator
+ * rather than at upstream plumbing.
+ */
+#[Test]
+final class ProjectConfigMigratorTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-migrate-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function skipsWhenSkillsJsonAlreadyExists(): void
+    {
+        // Existing skills.json is the user's source of truth — never
+        // overwrite it via auto-migration. Inline keys, if present in
+        // composer.json, are simply ignored.
+        \file_put_contents($this->tmp . '/skills.json', '{"$schema":"foo"}');
+        $this->writeComposerJson([
+            'extra' => ['skills' => ['target' => 'noop']],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same($result->migratedKeys, []);
+        Assert::same(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            '{"$schema":"foo"}',
+            'existing skills.json must not be touched',
+        );
+    }
+
+    public function skipsWhenComposerJsonIsAbsent(): void
+    {
+        // Standalone mode: no composer.json means no inline to
+        // migrate from. The migrator is a no-op — it never
+        // proactively creates a stub.
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::false(\is_file($this->tmp . '/skills.json'));
+    }
+
+    public function skipsWhenInlineHasNoProjectKeys(): void
+    {
+        // Donor-side `source` is not a project key — the migrator
+        // must not consider it migratable. Without any project key,
+        // there's nothing to relocate.
+        $this->writeComposerJson([
+            'extra' => ['skills' => ['source' => 'resources/skills']],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::false(
+            \is_file($this->tmp . '/skills.json'),
+            'no skills.json must be created when there are no inline project keys',
+        );
+        // composer.json's `source` key stays put.
+        $composer = $this->readComposerJson();
+        Assert::same($composer['extra']['skills']['source'] ?? null, 'resources/skills');
+    }
+
+    public function migratesProjectKeysAndStripsThemFromComposerJson(): void
+    {
+        $this->writeComposerJson([
+            'name' => 'demo/consumer',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'trusted' => ['acme/*'],
+                    'auto-sync' => true,
+                ],
+            ],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+        Assert::same($result->migratedKeys, ['target', 'trusted', 'auto-sync']);
+
+        // The new skills.json carries the migrated keys plus `$schema`.
+        $skills = $this->readSkillsJson();
+        Assert::same($skills['target'] ?? null, 'custom/skills');
+        Assert::same($skills['trusted'] ?? null, ['acme/*']);
+        Assert::same($skills['auto-sync'] ?? null, true);
+        Assert::true(\array_key_exists('$schema', $skills));
+
+        // composer.json no longer contains the migrated keys.
+        $composer = $this->readComposerJson();
+        $remaining = $composer['extra']['skills'] ?? [];
+        Assert::false(\array_key_exists('target', $remaining));
+        Assert::false(\array_key_exists('trusted', $remaining));
+        Assert::false(\array_key_exists('auto-sync', $remaining));
+    }
+
+    public function preservesDonorSourceDuringMigration(): void
+    {
+        // A package can be both donor and consumer. The donor-side
+        // `source` key must stay in composer.json regardless of how
+        // many project keys move out.
+        $this->writeComposerJson([
+            'name' => 'demo/dual',
+            'extra' => [
+                'skills' => [
+                    'source' => 'resources/skills',
+                    'target' => 'custom/skills',
+                ],
+            ],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+
+        // donor `source` still in composer.json
+        $composer = $this->readComposerJson();
+        Assert::same($composer['extra']['skills']['source'] ?? null, 'resources/skills');
+        // and NOT in skills.json
+        $skills = $this->readSkillsJson();
+        Assert::false(\array_key_exists('source', $skills));
+    }
+
+    public function refusesToMigrateMalformedInline(): void
+    {
+        // Pre-flight catches malformed inline before any write —
+        // migrating the bug into skills.json would just relocate the
+        // problem.
+        $this->writeComposerJson([
+            'extra' => ['skills' => ['auto-sync' => 'yes']],
+        ]);
+
+        $io = new BufferIO();
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            $io,
+        );
+
+        Assert::same($result->status, MigrationStatus::Failed);
+        Assert::false(
+            \is_file($this->tmp . '/skills.json'),
+            'no skills.json must be written when inline is malformed',
+        );
+        // composer.json must be untouched too — the migrator never
+        // half-applies a failed migration.
+        $composer = $this->readComposerJson();
+        Assert::same($composer['extra']['skills']['auto-sync'] ?? null, 'yes');
+        Assert::true(\str_contains($io->getOutput(), 'cannot auto-migrate'));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeComposerJson(array $data): void
+    {
+        \file_put_contents(
+            $this->tmp . '/composer.json',
+            \json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n",
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readComposerJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents($this->tmp . '/composer.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+}

--- a/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
@@ -137,6 +137,99 @@ final class ProjectConfigMigratorTest
         Assert::false(\array_key_exists('auto-sync', $remaining));
     }
 
+    public function collapsesEmptyExtraSkillsAndExtraAfterMigration(): void
+    {
+        // The composer.json carries only project keys under
+        // extra.skills (no donor `source`, no unrelated entries).
+        // After migration the `"skills": {}` leftover and the
+        // now-empty `"extra": {}` are both stripped — composer.json
+        // should not accumulate dead nesting.
+        $this->writeComposerJson([
+            'name' => 'demo/clean',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'auto-sync' => false,
+                ],
+            ],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+
+        $composer = $this->readComposerJson();
+        Assert::false(
+            \array_key_exists('extra', $composer),
+            'empty extra must be removed entirely; composer.json keys: '
+            . \implode(', ', \array_keys($composer)),
+        );
+    }
+
+    public function keepsExtraSkillsWhenSourceRemains(): void
+    {
+        // Donor `source` lives alongside project keys. After migration
+        // the project keys are gone but `extra.skills.source` keeps
+        // the skills node alive — and therefore `extra` too.
+        $this->writeComposerJson([
+            'name' => 'demo/dual',
+            'extra' => [
+                'skills' => [
+                    'source' => 'resources/skills',
+                    'target' => 'custom/skills',
+                ],
+            ],
+        ]);
+
+        (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        $composer = $this->readComposerJson();
+        Assert::same(
+            $composer['extra']['skills']['source'] ?? null,
+            'resources/skills',
+            'donor `source` must keep extra.skills alive',
+        );
+    }
+
+    public function keepsExtraWhenOtherExtraKeysExist(): void
+    {
+        // Even if extra.skills becomes empty, `extra` may carry other
+        // top-level keys (composer plugin class declarations, scripts,
+        // …). Those must stay.
+        $this->writeComposerJson([
+            'name' => 'demo/has-other-extras',
+            'extra' => [
+                'skills' => ['target' => 'custom/skills'],
+                'branch-alias' => ['dev-main' => '1.x-dev'],
+            ],
+        ]);
+
+        (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        $composer = $this->readComposerJson();
+        Assert::true(
+            \array_key_exists('extra', $composer),
+            'extra must stay because branch-alias is still there',
+        );
+        Assert::false(
+            \array_key_exists('skills', $composer['extra'] ?? []),
+            'empty skills node must be removed',
+        );
+        Assert::true(
+            \array_key_exists('branch-alias', $composer['extra'] ?? []),
+            'unrelated extra keys must survive',
+        );
+    }
+
     public function preservesDonorSourceDuringMigration(): void
     {
         // A package can be both donor and consumer. The donor-side

--- a/tests/Unit/Config/VendorPatternTest.php
+++ b/tests/Unit/Config/VendorPatternTest.php
@@ -40,6 +40,18 @@ final class VendorPatternTest
         VendorPattern::fromString('acme');
     }
 
+    public function fromStringRejectsMultipleSlashes(): void
+    {
+        // Composer package names contain exactly one slash. Multi-slash
+        // patterns are nonsense (`a/b/c` cannot match any installed package)
+        // and used to silently parse with `b/c` as the package segment,
+        // which also disagreed with `resources/skills.schema.json`.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('exactly one');
+
+        VendorPattern::fromString('acme/foo/bar');
+    }
+
     public function fromStringRejectsLeadingSlash(): void
     {
         // strpos returns 0 ⇒ second clause fires (empty vendor before slash).

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Init;
+
+use Composer\IO\BufferIO;
+use Internal\Path;
+use LLM\Skills\Config\InitOptions;
+use LLM\Skills\Init\InitRunner;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Console\Command\Command;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Unit coverage for the `skills:init` runner: filesystem effects,
+ * exit codes, and the contents it writes. End-to-end interaction with
+ * Composer-rewriting via JsonManipulator is exercised in the
+ * acceptance suite — here we focus on the runner's own decisions.
+ */
+#[Test]
+final class InitRunnerTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-init-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function standaloneModeCreatesStubWithSchemaPointerOnly(): void
+    {
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+
+        $written = $this->readSkillsJson();
+        Assert::same(\array_keys($written), ['$schema']);
+        Assert::same(
+            $written['$schema'],
+            InitRunner::SCHEMA_URL,
+            '$schema pointer must use the published GitHub raw URL',
+        );
+
+        // Output advertises the mode so the user understands no composer.json
+        // edits happened (because there is no composer.json).
+        Assert::true(\str_contains($io->getOutput(), 'standalone mode'));
+    }
+
+    public function refusesToOverwriteExistingFileWithoutForce(): void
+    {
+        \file_put_contents($this->tmp . '/skills.json', '{"target":"existing"}');
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::FAILURE);
+        // File must not be touched when refusal triggers.
+        Assert::same(
+            \file_get_contents($this->tmp . '/skills.json'),
+            '{"target":"existing"}',
+            'refusal must leave existing skills.json untouched',
+        );
+    }
+
+    public function forceFlagOverwritesExistingFile(): void
+    {
+        \file_put_contents($this->tmp . '/skills.json', '{"target":"existing"}');
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            new BufferIO(),
+            new InitOptions(force: true),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+
+        $written = $this->readSkillsJson();
+        Assert::true(\array_key_exists('$schema', $written));
+        Assert::false(
+            \array_key_exists('target', $written),
+            '--force in standalone mode regenerates a stub (no migrated keys)',
+        );
+    }
+
+    public function absolutePathIsRejected(): void
+    {
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(path: '/etc/skills.json'),
+        );
+
+        Assert::same($code, Command::INVALID);
+        Assert::false(\is_file('/etc/skills.json'), 'must not touch an absolute path');
+    }
+
+    public function escapingProjectRootIsRejected(): void
+    {
+        // `../escape.json` lexically resolves outside the project — the
+        // containment guard rejects it before any write.
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(path: '../escape.json'),
+        );
+
+        Assert::same($code, Command::INVALID);
+        Assert::false(\is_file(\dirname($this->tmp) . '/escape.json'));
+    }
+
+    public function composerAttachedModeMigratesProjectKeysAndCleansComposerJson(): void
+    {
+        $this->writeComposerJson([
+            'name' => 'demo/consumer',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'trusted' => ['acme/*'],
+                    'auto-sync' => true,
+                ],
+            ],
+        ]);
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            new BufferIO(),
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+
+        $skills = $this->readSkillsJson();
+        Assert::same($skills['target'], 'custom/skills');
+        Assert::same($skills['trusted'], ['acme/*']);
+        Assert::same($skills['auto-sync'], true);
+
+        // The migrated keys must be gone from composer.json.
+        /** @var array{extra: array{skills?: array<string, mixed>}} $composer */
+        $composer = \json_decode(
+            (string) \file_get_contents($this->tmp . '/composer.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        $remainingSkills = $composer['extra']['skills'] ?? [];
+        Assert::false(\array_key_exists('target', $remainingSkills));
+        Assert::false(\array_key_exists('trusted', $remainingSkills));
+        Assert::false(\array_key_exists('auto-sync', $remainingSkills));
+    }
+
+    public function composerAttachedModePreservesDonorSourceKey(): void
+    {
+        // A package can be both a donor (declares extra.skills.source) and
+        // a consumer (declares project-level keys). `source` must stay
+        // exactly where it is — it is not project config.
+        $this->writeComposerJson([
+            'name' => 'demo/dual',
+            'extra' => [
+                'skills' => [
+                    'source' => 'resources/skills',
+                    'target' => 'custom/skills',
+                ],
+            ],
+        ]);
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            new BufferIO(),
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+
+        /** @var array{extra: array{skills: array<string, mixed>}} $composer */
+        $composer = \json_decode(
+            (string) \file_get_contents($this->tmp . '/composer.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        Assert::same(
+            $composer['extra']['skills']['source'] ?? null,
+            'resources/skills',
+            'donor `source` key must remain in composer.json',
+        );
+
+        // And `source` is NOT in skills.json — that key is donor-side, not project.
+        $skills = $this->readSkillsJson();
+        Assert::false(\array_key_exists('source', $skills));
+    }
+
+    public function composerAttachedModeRefusesMalformedInlineBlock(): void
+    {
+        // Pre-flight catches the malformed inline config before any file
+        // is written. Migrating "yes" into skills.json would just relocate
+        // the same error.
+        $this->writeComposerJson([
+            'name' => 'demo/broken',
+            'extra' => ['skills' => ['auto-sync' => 'yes']],
+        ]);
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::FAILURE);
+        Assert::false(
+            \is_file($this->tmp . '/skills.json'),
+            'no file must be written when the inline block is malformed',
+        );
+        Assert::true(\str_contains($io->getOutput(), 'inline extra.skills is malformed'));
+    }
+
+    public function composerAttachedModeStubWhenNoProjectKeys(): void
+    {
+        $this->writeComposerJson([
+            'name' => 'demo/empty',
+            'extra' => ['skills' => ['source' => 'resources/skills']],
+        ]);
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+        Assert::same(\array_keys($this->readSkillsJson()), ['$schema']);
+        Assert::true(\str_contains($io->getOutput(), 'no project keys to migrate'));
+    }
+
+    public function nonDefaultPathEmitsNotice(): void
+    {
+        // The loader only auto-discovers `skills.json`; warn the user when
+        // they pick a different name so they don't silently lose
+        // discovery on the next sync.
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(path: 'config/skills.json'),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+        Assert::true(\is_file($this->tmp . '/config/skills.json'));
+        Assert::true(\str_contains($io->getOutput(), 'will not be discovered'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+
+        return $decoded;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeComposerJson(array $data): void
+    {
+        \file_put_contents(
+            $this->tmp . '/composer.json',
+            \json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n",
+        );
+    }
+}

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -295,6 +295,51 @@ final class InitRunnerTest
         Assert::true(\str_contains($io->getOutput(), 'will not be discovered'));
     }
 
+    public function nonDefaultPathWithForceOverwritesExistingTargetAfterMigration(): void
+    {
+        // Cross-platform `--force` contract: the user-supplied target
+        // already exists, --force was passed, and composer.json has
+        // inline keys. After init: composer.json stripped, the
+        // pre-existing file at $target is overwritten by the migrated
+        // content. POSIX `rename()` would do this implicitly; Windows
+        // would otherwise refuse, leaving the new content stranded
+        // at the canonical path.
+        \mkdir($this->tmp . '/config', 0o777, true);
+        \file_put_contents($this->tmp . '/config/skills.json', '{"target":"stale"}');
+
+        $this->writeComposerJson([
+            'extra' => ['skills' => ['target' => 'fresh/skills']],
+        ]);
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(path: 'config/skills.json', force: true),
+        );
+
+        Assert::same(
+            $code,
+            Command::SUCCESS,
+            'force-overwrite must succeed; got stderr: ' . $io->getOutput(),
+        );
+
+        // The pre-existing stale file is gone; the migrated content
+        // lives at the requested non-default path.
+        $skills = \json_decode(
+            (string) \file_get_contents($this->tmp . '/config/skills.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        Assert::same($skills['target'] ?? null, 'fresh/skills', 'target must reflect migrated value');
+
+        // Canonical location is empty (the rename moved the file out).
+        Assert::false(
+            \is_file($this->tmp . '/skills.json'),
+            'rename must move the canonical file to the user-supplied path',
+        );
+    }
+
     public function nonDefaultPathWithInlineKeysMigratesAndRenames(): void
     {
         // Composer-attached + non-canonical `--path`: the migrator always

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -116,6 +116,30 @@ final class InitRunnerTest
         Assert::false(\is_file('/etc/skills.json'), 'must not touch an absolute path');
     }
 
+    public function existingDirectoryAtTargetIsRejectedWithClearError(): void
+    {
+        // A pre-existing directory at the target path is not "overwrite this
+        // file" territory — `file_put_contents` would later fail with a
+        // generic "failed to write" message. The runner now catches this up
+        // front and tells the user exactly what's wrong.
+        \mkdir($this->tmp . '/skills.json', 0o777, true);
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            InitOptions::default(),
+        );
+
+        Assert::same($code, Command::FAILURE);
+        Assert::true(
+            \str_contains($io->getOutput(), 'not a regular file'),
+            'error must spell out the conflict; got: ' . $io->getOutput(),
+        );
+        // The directory must NOT have been touched.
+        Assert::true(\is_dir($this->tmp . '/skills.json'));
+    }
+
     public function escapingProjectRootIsRejected(): void
     {
         // `../escape.json` lexically resolves outside the project — the

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -295,6 +295,59 @@ final class InitRunnerTest
         Assert::true(\str_contains($io->getOutput(), 'will not be discovered'));
     }
 
+    public function nonDefaultPathWithInlineKeysMigratesAndRenames(): void
+    {
+        // Composer-attached + non-canonical `--path`: the migrator always
+        // writes to <root>/skills.json; the runner then renames the file
+        // to the requested location. End state: composer.json stripped,
+        // file at the user-chosen path, no leftover canonical skills.json.
+        $this->writeComposerJson([
+            'name' => 'demo/non-canonical',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'trusted' => ['acme/*'],
+                ],
+            ],
+        ]);
+
+        $io = new BufferIO();
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(path: 'config/skills.json'),
+        );
+
+        Assert::same($code, Command::SUCCESS);
+        Assert::true(\is_file($this->tmp . '/config/skills.json'));
+        Assert::false(
+            \is_file($this->tmp . '/skills.json'),
+            'canonical skills.json must have been renamed away',
+        );
+
+        // composer.json was stripped during the migration step.
+        $composer = $this->readComposerJsonRaw();
+        Assert::false(\array_key_exists('target', $composer['extra']['skills'] ?? []));
+        Assert::false(\array_key_exists('trusted', $composer['extra']['skills'] ?? []));
+
+        // Non-default path always carries the auto-discovery warning.
+        Assert::true(\str_contains($io->getOutput(), 'will not be discovered'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readComposerJsonRaw(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents($this->tmp . '/composer.json'),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Unit/Init/InteractiveInitWizardTest.php
+++ b/tests/Unit/Init/InteractiveInitWizardTest.php
@@ -195,6 +195,33 @@ final class InteractiveInitWizardTest
         Assert::same($result['trusted'] ?? null, ['acme/*', 'vendor/pkg']);
     }
 
+    public function trustedNoneTokenClearsExistingList(): void
+    {
+        // With an existing trusted list, typing `<none>` at the prompt
+        // means "clear it" — not "keep current". Empty Enter still
+        // means "keep current" (covered by existingDefaultsAreShownInPrompts).
+        // The two paths must be distinguishable for the wizard to be
+        // useful as an editor of pre-existing skills.json values.
+        $io = $this->ioWithAnswers([
+            '',         // target
+            '',         // aliases
+            '<none>',   // trusted → clear
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, [
+            'trusted' => ['acme/*', 'vendor/pkg'],
+        ]);
+
+        Assert::false(
+            \array_key_exists('trusted', $result ?? []),
+            'cleared trusted must not land in the result (empty list is the default)',
+        );
+    }
+
     public function booleanPromptsCapturedCorrectly(): void
     {
         // Only non-default values land in the result map (defaults are

--- a/tests/Unit/Init/InteractiveInitWizardTest.php
+++ b/tests/Unit/Init/InteractiveInitWizardTest.php
@@ -25,12 +25,12 @@ final class InteractiveInitWizardTest
         // a skills.json with only `$schema`. The wizard returns an
         // empty array; the caller prepends the schema pointer.
         $io = $this->ioWithAnswers([
-            '',  // target (default)
+            '',  // target (default .agents/skills)
             '',  // aliases (default 'none')
             '',  // trusted (default '<none>')
             '',  // trusted-replace (default no)
             '',  // discovery (default no)
-            '',  // auto-sync (default no)
+            '',  // auto-sync (default yes — flipped on; omitted from result)
             'yes', // confirm write
         ]);
 

--- a/tests/Unit/Init/InteractiveInitWizardTest.php
+++ b/tests/Unit/Init/InteractiveInitWizardTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Init;
+
+use Composer\IO\BufferIO;
+use LLM\Skills\Init\InteractiveInitWizard;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Unit coverage for the `skills:init` interactive wizard.
+ *
+ * Drives the wizard with Composer's {@see BufferIO} — its
+ * `setUserInputs()` helper streams pre-baked answers into the
+ * underlying StringInput, so each test reads like a script.
+ */
+#[Test]
+final class InteractiveInitWizardTest
+{
+    public function acceptingAllDefaultsWithEmptyDefaultsYieldsEmptyResult(): void
+    {
+        // Empty answer + every-question defaults to "skip" = produces
+        // a skills.json with only `$schema`. The wizard returns an
+        // empty array; the caller prepends the schema pointer.
+        $io = $this->ioWithAnswers([
+            '',  // target (default)
+            '',  // aliases (default 'none')
+            '',  // trusted (default '<none>')
+            '',  // trusted-replace (default no)
+            '',  // discovery (default no)
+            '',  // auto-sync (default no)
+            'yes', // confirm write
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same($result, []);
+    }
+
+    public function overridingTargetIsReflectedInResult(): void
+    {
+        $io = $this->ioWithAnswers([
+            'custom/skills', // target
+            '',
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same($result, ['target' => 'custom/skills']);
+    }
+
+    public function aliasesByNumberMapToWellKnownPaths(): void
+    {
+        // `1,3` → .claude/skills, .agents/skills. Number selection
+        // is the easiest UX on Windows where checkboxes are awkward.
+        // We override target so the alias #3 (.agents/skills) does
+        // NOT collide with the default target; the equality check
+        // has its own dedicated test below.
+        $io = $this->ioWithAnswers([
+            'custom/skills',
+            '1,3',
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same($result, [
+            'target' => 'custom/skills',
+            'aliases' => ['.claude/skills', '.agents/skills'],
+        ]);
+    }
+
+    public function aliasesByRangeExpand(): void
+    {
+        // `1-3` → all three known aliases. Target offset to avoid
+        // the alias-vs-target collision check.
+        $io = $this->ioWithAnswers([
+            'custom/skills',
+            '1-3',
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same(
+            $result['aliases'] ?? null,
+            ['.claude/skills', '.cursor/skills', '.agents/skills'],
+        );
+    }
+
+    public function aliasesMixNumbersWithCustomPaths(): void
+    {
+        // Non-numeric tokens are treated as literal paths — lets the
+        // user combine the known shortlist with arbitrary entries.
+        $io = $this->ioWithAnswers([
+            '',
+            '1,custom/path,2',
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same(
+            $result['aliases'] ?? null,
+            ['.claude/skills', 'custom/path', '.cursor/skills'],
+        );
+    }
+
+    public function aliasEqualToTargetIsDroppedWithNotice(): void
+    {
+        // `.agents/skills` is option #3 AND the default target. The
+        // wizard drops it with a notice rather than letting the
+        // mapper bomb later.
+        $io = $this->ioWithAnswers([
+            '',          // target = .agents/skills (default)
+            '1,2,3',     // aliases: .claude, .cursor, .agents
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same(
+            $result['aliases'] ?? null,
+            ['.claude/skills', '.cursor/skills'],
+            '.agents/skills equals the target and must be dropped',
+        );
+        Assert::true(
+            \str_contains($io->getOutput(), 'dropped'),
+            'user must see why the alias was dropped',
+        );
+    }
+
+    public function noneInputClearsExistingAliases(): void
+    {
+        // --force on a project that already has aliases: defaults
+        // surface them, but the user can wipe the list by typing
+        // "none" (or `0`, or just Enter would keep them).
+        $io = $this->ioWithAnswers([
+            '',
+            'none',
+            '',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, [
+            'aliases' => ['.claude/skills', '.cursor/skills'],
+        ]);
+
+        Assert::false(
+            \array_key_exists('aliases', $result ?? []),
+            'empty list must not be written into skills.json',
+        );
+    }
+
+    public function trustedCsvIsParsedIntoList(): void
+    {
+        $io = $this->ioWithAnswers([
+            '',
+            '',
+            'acme/*,vendor/pkg',
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same($result['trusted'] ?? null, ['acme/*', 'vendor/pkg']);
+    }
+
+    public function booleanPromptsCapturedCorrectly(): void
+    {
+        // Only non-default values land in the result map (defaults are
+        // implicit). trusted-replace / discovery default to `false` →
+        // answering "yes" inverts them and they appear. auto-sync
+        // defaults to `true` → answering "no" inverts it and the
+        // key appears with `false`.
+        $io = $this->ioWithAnswers([
+            '',
+            '',
+            '',
+            'yes',  // trusted-replace → non-default true
+            'yes',  // discovery       → non-default true
+            'no',   // auto-sync       → non-default false
+            'yes',  // confirm write
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::same($result['trusted-replace'] ?? null, true);
+        Assert::same($result['discovery'] ?? null, true);
+        Assert::same($result['auto-sync'] ?? null, false);
+    }
+
+    public function autoSyncDefaultIsImplicitInResult(): void
+    {
+        // Accepting the new default (true) does not produce an
+        // `auto-sync` key — the default carries the value.
+        $io = $this->ioWithAnswers([
+            '', '', '', '', '',
+            '',     // auto-sync: accept default `true`
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::false(
+            \array_key_exists('auto-sync', $result ?? []),
+            'auto-sync=true is the default and must not be echoed',
+        );
+    }
+
+    public function finalConfirmationNoAbortsCleanly(): void
+    {
+        // The wizard returns null when the user backs out at the
+        // final write prompt. Caller (InitRunner) treats that as
+        // SUCCESS without touching the filesystem.
+        $io = $this->ioWithAnswers([
+            'custom/skills',
+            '',
+            '',
+            '',
+            '',
+            '',
+            'no',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, []);
+
+        Assert::null($result);
+        Assert::true(\str_contains($io->getOutput(), 'aborted'));
+    }
+
+    public function existingDefaultsAreShownInPrompts(): void
+    {
+        // When defaults carry a value (e.g. from existing skills.json
+        // under --force), the prompts surface them so the user can
+        // accept verbatim. Empty input therefore keeps the value.
+        $io = $this->ioWithAnswers([
+            '',     // target → keep custom/skills
+            '',     // aliases → keep claude+cursor
+            '',     // trusted → keep
+            '',
+            '',
+            '',
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, [
+            'target' => 'custom/skills',
+            'aliases' => ['.claude/skills', '.cursor/skills'],
+            'trusted' => ['acme/*'],
+        ]);
+
+        Assert::same($result['target'] ?? null, 'custom/skills');
+        Assert::same($result['aliases'] ?? null, ['.claude/skills', '.cursor/skills']);
+        Assert::same($result['trusted'] ?? null, ['acme/*']);
+    }
+
+    /**
+     * @param list<string> $answers
+     */
+    private function ioWithAnswers(array $answers): BufferIO
+    {
+        $io = new BufferIO();
+        $io->setUserInputs($answers);
+
+        return $io;
+    }
+}


### PR DESCRIPTION
## Summary

Four threads, one PR:

1. **`skills.json` as the new project-config file.** A dedicated JSON file at the project root replaces the inline `extra.skills` block in `composer.json`. Strict shape, ships with a hand-written JSON Schema for editor support.
2. **Auto-migration on `skills:update`.** Write-mode commands (`skills:update`, `skills:init`, the `post-update-cmd` auto-sync hook) move the legacy inline `extra.skills` block into `skills.json` on first contact and strip it from `composer.json`. After that, `composer.json` is left alone forever. Read-only paths (`skills:show`, `post-install-cmd`) never rewrite the file — they emit a one-line notice instead.
3. **`skills:init` command.** Explicit version of the migration above, plus a standalone stub-writer for projects without `composer.json`.
4. **`DonorProvider` abstraction.** Composer is now one provider behind an interface, not the load-bearing dependency. The standalone `bin/skills` works in directories without `composer.json`: the provider reports inactive and the runner emits a `[llm/skills] no donor providers are active — nothing to sync. Run with -v for details.` notice instead of dying on the Composer bootstrap. Future GitHub / `skills.sh` / npm providers plug in behind the same interface.
5. **`auto-sync` default flipped to `true`.** Most users were copy-pasting `"auto-sync": true` anyway — make it the default and let dissenters opt out with `"auto-sync": false`. New behavioural default: installing the plugin and running `composer install` already produces a synced `.agents/skills/`.
6. **Interactive `skills:init` wizard.** Walks the user through every project-config knob with descriptions and defaults; non-interactive callers still get the silent migrate/stub path.

## Motivation

- The `extra.skills` block grew too noisy for `composer.json` and had no practical IDE schema story.
- `composer.json` is a poor fit for the planned `skills add foo/bar` workflow — that command needs to write project state, and the right surface for it is a file we own.
- Pinning the utility to Composer was a self-imposed limit. Composer is a great donor source, but it shouldn't be the *only* one — the user should be able to run `skills update` in any directory and have it do something sensible, with packagist (Composer) as the first of many ecosystems we'll teach it to read.

## What changed

### Project config — `skills.json` is the only artifact

`skills.json` is the long-lived project config. Inline `extra.skills` is a transitional
state — the first time a write-mode command runs, it auto-migrates the block and never has
to look at it again.

**Write-mode commands** (`skills:update`, `skills:init`, `post-update-cmd` autosync):

```
1. skills.json at project root → use it; composer.json is NOT touched
2. no skills.json, inline extra.skills has project keys → migrate:
     - write skills.json with the migrated keys
     - strip the keys from composer.json via JsonManipulator
     - emit `[migrate] moved extra.skills → skills.json (...)`
     - continue with the freshly written config
3. neither → defaults
```

**Read-only commands** (`skills:show`, `post-install-cmd` autosync):

```
1. skills.json at project root → use it; composer.json is NOT touched
2. no skills.json, inline extra.skills present → use inline + emit
   [notice] pointing at skills:update
3. neither → defaults
```

The asymmetry: `composer install` is a fetch step, and `skills:show` is read-only by name. Silently rewriting `composer.json` from either would be surprising. Other surfaces are write-mode by nature, so cleaning up the legacy artifact along the way is in character.

There is no `--no-migrate` flag. To suppress migration for one run, use `skills:show` (no mutation) or `composer install --no-scripts`.

**Strict mapping** on `skills.json`: unknown top-level keys are fatal, `$schema` is the only accepted metadata key (and stripped before mapping), nested `config-file` is rejected. The PHP mapper is the authoritative validator; the shipped schema mirrors it for editors.

### `skills:init` command

New command, registered in both the Composer plugin and the standalone bin:

```
composer skills:init [--path=PATH] [--force]   # alias: skills:i
skills init          [--path=PATH] [--force]   # alias: i
```

Same migration body as the auto-migration path. `init` exists for two cases:

- **Pre-`skills:update` setup** — bootstrap `skills.json` before the first sync (some users prefer to see the migration as a discrete step).
- **Standalone projects** (no `composer.json` at cwd) — write a stub `skills.json` containing only the `$schema` pointer. Nothing else is touched.

Shared implementation: a new `ProjectConfigMigrator` service does the actual work. `InitRunner` and `SyncRunner` both call into it. The migrator:

- Reads `composer.json` and validates the inline `extra.skills` block. Refuses to migrate a malformed config — fix `composer.json` first, then rerun.
- Partitions keys: `target`, `aliases`, `trusted`, `trusted-replace`, `discovery`, `auto-sync` move into `skills.json`; donor-side `source` stays in `composer.json`. A package can be both donor and consumer.
- Writes `skills.json` first, then rewrites `composer.json` via Composer's `JsonManipulator` (formatting / key order preserved).
- Idempotent: if `skills.json` already exists or there are no inline keys, the migrator returns `Skipped` without touching anything.

Refusal behaviour specific to `init`:

- Refuses to overwrite an existing `skills.json` without `--force`.
- Refuses if `--path` points at an existing non-file (a directory, etc.) with a clear "not a regular file" message.
- `--path=PATH` honours the project-root containment rule. A non-default path also gets a notice — subsequent commands only auto-discover `skills.json` at the project root.

### Donor providers

New interface `LLM\Skills\Discovery\Provider\DonorProvider`:

- `isActive(Path $projectRoot): bool` — does this provider have anything to contribute at all? Used to drive the `no donor providers are active` notice when every provider is inactive.
- `discover(Path $projectRoot): DonorDiscoveryResult` — enumerate donor packages.
- `directDependencies(Path $projectRoot): list<non-empty-string>` — packages the consumer treats as direct deps (for implicit trust). Providers without that concept return `[]`.

`ComposerProvider` is the first implementation. Accepts an optional `Composer` instance; when `null`, reports inactive and contributes nothing. Bootstrap concerns live in the entrypoints (`Composer\Command\*` and `Console\Command\*`), not in the provider.

`SyncRunner::run`, `ShowRunner::run`, and `InspectionBuilder::build` no longer accept `Composer` — they take `(Path $projectRoot, DonorProvider $provider, mixed $extra, ...)`. The pipeline downstream of the provider is unchanged.

### Standalone `bin/skills`

`Console\Command\Sync` and `Console\Command\Show` now try `Factory::create()` on a best-effort basis: if no `composer.json` is present at the cwd (or bootstrap fails for any other reason), they pass a `null` Composer into `ComposerProvider`. The runner sees no active provider and emits the provider-neutral notice:

```
[llm/skills] no donor providers are active — nothing to sync. Run with -v for details.
```

(The `nothing to sync` part reads `nothing to show` from `ShowRunner`.) Exit code: 0. The fatal `Failed to bootstrap Composer` error is gone. The specific cause — missing `composer.json` vs failed bootstrap on a parseable one — is emitted as a `-v` warning at the entrypoint, so users who pass `-v` see why the provider went inactive.

## Tests

346 tests total, all green:

| Suite              | Coverage added                                                                                                    |
|--------------------|-------------------------------------------------------------------------------------------------------------------|
| `Unit/Config`      | `ExternalProjectConfigLoader` (file absent, malformed JSON, non-object root, unknown keys, empty list `[]` distinct from empty object `{}`, `$schema` strip). |
| `Unit/Config`      | `ProjectConfigMapper::forProject` decision tree, shadowed-keys list, exclusion of donor-side `source`.            |
| `Unit/Config`      | `ProjectConfigMigrator` — eligibility decisions, malformed-inline refusal, donor `source` preserved, skills.json-present idempotency. |
| `Unit/Composer`    | `ComposerJsonExtraReader` — best-effort `extra` reader used when `Factory::create()` throws on a parseable `composer.json`. |
| `Unit/Init`        | `InitRunner` — standalone stub, refusal, `--force`, absolute / escape paths, migration, donor-key preservation, pre-existing dir at target. |
| `Unit/Config`      | `VendorPattern` — rejects multi-slash patterns (`a/b/c`).                                                          |
| `Acceptance`       | `SkillsJsonConfigTest` — precedence, `-v` shadowing warning, inline fallback, malformed file, init end-to-end.    |
| `Acceptance`       | `SkillsAutoMigrateTest` — write-mode migration on `skills:update`; no-op when `skills.json` already exists or no inline keys; `post-update-cmd` migrates while `post-install-cmd` does not; `skills:show` is read-only and emits the legacy-config notice. |
| `Acceptance`       | `SkillsSchemaTest` — JSON Schema accept/reject matrix mirroring the PHP mapper.                                   |
| `Acceptance`       | `StandaloneBinTest` — `bin/skills update`/`show`/`init` in directories without `composer.json`; reads `skills.json` when present; rejects malformed `skills.json`. |

The shared sandbox at `tests/Sandbox/project` now snapshots/restores both `composer.json` and `skills.json` between tests (via a new `SandboxStateGuard` helper) so the auto-migration that `skills:update` performs cannot leak from one test into the next.

`composer psalm` and `composer cs:diff` are clean.

## New / changed files

**New** — production:

- `resources/skills.schema.json`
- `src/Composer/ComposerJsonExtraReader.php`
- `src/Config/InitOptions.php`
- `src/Config/Mapper/ExternalProjectConfigLoader.php`
- `src/Config/Mapper/MigrationResult.php`
- `src/Config/Mapper/MigrationStatus.php`
- `src/Config/Mapper/ProjectConfigMigrator.php`
- `src/Config/ProjectConfigResolution.php`
- `src/Discovery/Provider/DonorProvider.php`
- `src/Discovery/Provider/ComposerProvider.php`
- `src/Init/InitRunner.php`
- `src/Composer/Command/Init.php` (Composer plugin command)
- `src/Console/Command/Init.php` (standalone bin command)
- `src/Console/InitCliDefinition.php`

**New** — tests / testo infra:

- `tests/Acceptance/SkillsAutoMigrateTest.php`
- `tests/Acceptance/SkillsJsonConfigTest.php`
- `tests/Acceptance/SkillsSchemaTest.php`
- `tests/Acceptance/StandaloneBinTest.php`
- `tests/Unit/Composer/ComposerJsonExtraReaderTest.php`
- `tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php`
- `tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php`
- `tests/Unit/Init/InitRunnerTest.php`
- `tests/Testo/Composer/BinSkillsRunner.php`
- `tests/Testo/Composer/WithSkillsJson.php`
- `tests/Testo/Composer/WithSkillsJsonInterceptor.php`
- `tests/Testo/SandboxStateGuard.php`

**Modified** — production:

- `bin/skills` — registers the `init` command.
- `README.md` — new section on `skills.json`, command table updated.
- `src/Composer/CommandProvider.php`, `src/Composer/SkillsPlugin.php`, `src/Composer/Command/{Sync,Show}.php`, `src/Console/Command/{Sync,Show}.php` — pivot to `ComposerProvider`, best-effort Composer bootstrap in standalone mode.
- `src/Config/Mapper/ProjectConfigMapper.php` — new `forProject()` entrypoint; per-field validation extracted into a shared `mapSkillsBlock()`.
- `src/Show/{InspectionBuilder,ShowRunner}.php`, `src/Sync/SyncRunner.php` — take `DonorProvider` instead of `Composer`; Composer-specific direct-deps logic moves into `ComposerProvider`.
- `tests/Unit/Config/Mapper/ProjectConfigMapperTest.php` — new cases for `forProject` and the shadowed-keys list.

**Specs:**

- `spec-config-file.md` — full design write-up for the external config and `skills:init`.

## Backward compatibility

- **`skills:show` on a 1.x project**: unchanged behaviour. Reads inline `extra.skills` and emits a one-line notice pointing at `skills:update` for migration. Never mutates `composer.json`.
- **`skills:update` on a 1.x project (first run)**: produces the same synced files as before, but additionally migrates the inline block. A `[migrate]` line announces what moved. Subsequent runs are no-ops for `composer.json`.
- **Projects that already have `skills.json`**: behaviour is identical — `composer.json` is never touched.
- **Donor packages**: untouched. Auto-migration is a project-level concern and never relocates donor-side `extra.skills.source`.
- **`composer install --no-scripts`**: still suppresses the auto-sync hook entirely, including any migration it would have done.
- **`auto-sync` default flipped from `false` → `true`**: existing 1.x projects with no explicit `auto-sync` setting will now run `skills:update` automatically after the next `composer install` / `update`. The on-by-default UX is the intentional change; users who prefer the old "nothing happens until I say so" behaviour set `"auto-sync": false` once.

The two behavioural changes a careful user might notice are the migration write to `composer.json` and the new on-by-default auto-sync. Both are addressed by setting `"auto-sync": false` and either keeping the inline block (read-only commands tolerate it) or running `skills:update` to formalise the migration. No 2.0 bump is forced.

## Test plan

- [x] `composer test` (365 passed)
- [x] `composer psalm` (clean)
- [x] `composer cs:diff` (clean)
- [x] Manual: `php bin/skills update` in a fresh empty dir → exit 0 with neutral `[no donor providers are active]` notice; `-v` names the actual cause.
- [x] Manual: `composer skills:update` in a project with inline `extra.skills` → `[migrate]` line printed, `skills.json` created with migrated keys, `composer.json` stripped (donor `source` preserved if present).
- [x] Manual: `composer skills:update` re-run → no `[migrate]` line, `composer.json` byte-for-byte unchanged.
- [x] Manual: `composer skills:show` on a 1.x-style project → no mutation, `[notice] legacy inline config detected (...)` printed.
- [ ] Reviewer sanity-check: run `composer skills:update` (or `skills:init`) on a real consumer project and confirm the `composer.json` diff is minimal — just the removed project keys, no formatting churn.
