### PR TITLE
fix: load 0.x donors on skills:add (pre-1.0 caret) + dedupe archive inspection

### DIFF
--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -7,7 +7,6 @@ namespace LLM\Skills\Add;
 use Composer\IO\IOInterface;
 use Internal\Path;
 use LLM\Skills\Config\AddOptions;
-use LLM\Skills\Config\Mapper\VendorConfigMapper;
 use LLM\Skills\Config\RemoteEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
@@ -15,10 +14,11 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\UnknownAdapterException;
+use LLM\Skills\Discovery\Provider\Remote\DonorArchiveInspector;
+use LLM\Skills\Discovery\Provider\Remote\DonorArchiveRejection;
 use LLM\Skills\Discovery\Provider\Remote\RefResolver;
 use LLM\Skills\Discovery\Provider\Remote\RemoteFetchException;
 use LLM\Skills\Discovery\Provider\Remote\RemoteFetcher;
-use LLM\Skills\Discovery\SkillTreeScanner;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -61,9 +61,8 @@ final readonly class AddRunner
         private HostAdapterRegistry $registry,
         private RemoteFetcher $fetcher,
         private SkillsJsonWriter $writer = new SkillsJsonWriter(),
-        private VendorConfigMapper $vendorMapper = new VendorConfigMapper(),
         private RefResolver $refResolver = new RefResolver(),
-        private SkillTreeScanner $scanner = new SkillTreeScanner(),
+        private DonorArchiveInspector $inspector = new DonorArchiveInspector(),
     ) {}
 
     /**
@@ -124,7 +123,7 @@ final readonly class AddRunner
             return Command::FAILURE;
         }
 
-        $donorPackageName = $this->validateArchiveShipsSkillsSource(
+        $donorPackageName = $this->inspectArchive(
             $extractedRoot,
             $io,
             $adapter->id(),
@@ -293,92 +292,68 @@ final readonly class AddRunner
     }
 
     /**
-     * Confirm the fetched archive is a usable donor. Two acceptable shapes:
+     * Confirm the fetched archive is a usable donor and return the name
+     * to scope the follow-up sync on. Delegates the parse-and-classify
+     * rules to the shared {@see DonorArchiveInspector} — the same
+     * inspector {@see \LLM\Skills\Discovery\Provider\Remote\RemoteProvider}
+     * runs during sync, so the two paths agree on what counts as a donor.
      *
-     * 1. **Composer-shaped donor** — `composer.json` is present, declares
-     *    `name`, and declares `extra.skills.source`. The donor's package
-     *    name comes from the manifest's `name` field.
-     * 2. **Bare skill repo** — no `composer.json` (or one without the
-     *    expected fields), but the archive ships a top-level `skills/`
-     *    directory. The donor's package name falls back to
-     *    `$parsed->package` (set by the adapter — for GitHub the
-     *    `<owner>/<repo>` path). Mirrors the local-provider auto-discovery
-     *    path for ad-hoc skill packs that don't bother with a Composer
-     *    manifest. Same logic in {@see \LLM\Skills\Discovery\Provider\Remote\RemoteProvider::discover()}
-     *    keeps the post-add sync working without a separate code path.
+     * Both accepted shapes (Composer-shaped and bare skill repo) carry a
+     * package name; `skills:add` only needs the name, so it treats them
+     * alike. A rejection is reported to the console and yields `null`.
      *
      * @return non-empty-string|null donor package name, or `null` if the archive cannot be used
      */
-    private function validateArchiveShipsSkillsSource(
+    private function inspectArchive(
         Path $extractedRoot,
         IOInterface $io,
         string $adapterId,
         ParsedAddInput $parsed,
     ): ?string {
-        $composerJsonPath = (string) $extractedRoot->join('composer.json');
-        $packageName = null;
-        $extra = null;
+        $inspection = $this->inspector->inspect($extractedRoot, $parsed->package);
 
-        if (\is_file($composerJsonPath)) {
-            $contents = \file_get_contents($composerJsonPath);
-            if ($contents === false) {
-                $io->writeError('<error>[llm/skills] failed to read composer.json from fetched archive</error>');
-                return null;
-            }
-
-            try {
-                /** @var mixed $decoded */
-                $decoded = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
-            } catch (\JsonException $e) {
-                $io->writeError('<error>[llm/skills] fetched composer.json is not valid JSON: ' . $e->getMessage() . '</error>');
-                return null;
-            }
-            if (!\is_array($decoded)) {
-                $io->writeError('<error>[llm/skills] fetched composer.json must be a JSON object</error>');
-                return null;
-            }
-
-            /** @var mixed $rawName */
-            $rawName = $decoded['name'] ?? null;
-            if (\is_string($rawName) && $rawName !== '' && \str_contains($rawName, '/')) {
-                /** @var non-empty-string $packageName */
-                $packageName = $rawName;
-            }
-
-            /** @var mixed $extra */
-            $extra = $decoded['extra'] ?? null;
+        $rejection = $inspection->rejection;
+        if ($rejection !== null) {
+            $io->writeError('<error>[llm/skills] '
+                . $this->describeRejection($rejection, $inspection->detail, $adapterId, $parsed)
+                . '</error>');
+            return null;
         }
 
-        if ($packageName !== null && VendorConfigMapper::declaresSkills($extra)) {
-            return $packageName;
-        }
+        return $inspection->packageName;
+    }
 
-        // Composer manifest is missing or non-conforming. Fall through to
-        // auto-discovery: require at least one SKILL.md somewhere in the
-        // archive, and synthesise the donor's name from the adapter-side
-        // identifier.
-        if ($this->scanner->scan($extractedRoot) === []) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] fetched archive for %s:%s ships neither a composer.json '
-                . 'with extra.skills.source nor any SKILL.md files — '
-                . 'cannot register as a skill donor</error>',
+    /**
+     * Phrase a {@see DonorArchiveRejection} for the `skills:add`
+     * console channel. The inspector owns the *classification*; the
+     * wording (and the "fetched"/`--from` framing) is this command's.
+     *
+     * @psalm-pure
+     */
+    private function describeRejection(
+        DonorArchiveRejection $rejection,
+        ?string $detail,
+        string $adapterId,
+        ParsedAddInput $parsed,
+    ): string {
+        return match ($rejection) {
+            DonorArchiveRejection::ComposerJsonUnreadable =>
+                'failed to read composer.json from fetched archive',
+            DonorArchiveRejection::ComposerJsonInvalidJson =>
+                'fetched composer.json is not valid JSON: ' . ($detail ?? ''),
+            DonorArchiveRejection::ComposerJsonNotObject =>
+                'fetched composer.json must be a JSON object',
+            DonorArchiveRejection::NoDonorShape => \sprintf(
+                'fetched archive for %s:%s ships neither a composer.json with extra.skills.source '
+                . 'nor any SKILL.md files — cannot register as a skill donor',
                 $adapterId,
                 $parsed->package ?? $parsed->url ?? $parsed->from,
-            ));
-            return null;
-        }
-
-        $synthesisedName = $packageName ?? $parsed->package;
-        if ($synthesisedName === null) {
-            $io->writeError(\sprintf(
-                '<error>[llm/skills] fetched archive ships SKILL.md files but no package '
-                . 'name to register it under (composer.json missing AND --from=%s did not '
-                . 'derive a vendor/repo identifier)</error>',
+            ),
+            DonorArchiveRejection::NoPackageName => \sprintf(
+                'fetched archive ships SKILL.md files but no package name to register it under '
+                . '(composer.json missing AND --from=%s did not derive a vendor/repo identifier)',
                 $adapterId,
-            ));
-            return null;
-        }
-
-        return $synthesisedName;
+            ),
+        };
     }
 }

--- a/src/Add/PostAddSync.php
+++ b/src/Add/PostAddSync.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Add;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Internal\Path;
+use LLM\Skills\Config\SyncOptions;
+use LLM\Skills\Config\VendorPattern;
+use LLM\Skills\Discovery\Provider\DonorProviderBuilder;
+use LLM\Skills\Sync\SyncRunner;
+
+/**
+ * The scoped single-donor sync that runs after a successful
+ * `skills:add`, so the just-registered skills land in the target
+ * immediately — matching `composer require`'s "edit + install"
+ * ergonomics.
+ *
+ * Shared by both entrypoints ({@see \LLM\Skills\Composer\Command\Add}
+ * and {@see \LLM\Skills\Console\Command\Add}) so the wiring lives in one
+ * place instead of two copies that could drift.
+ *
+ * Works with or without a Composer instance: the standalone bin invoked
+ * outside a project passes `null`, which the builder + mapper treat the
+ * same as an empty `extra.skills` block — only the just-added remote
+ * donor syncs, which is exactly what a `skills:add` invocation means.
+ *
+ * @internal
+ */
+final class PostAddSync
+{
+    /**
+     * @param string|null $donorPackageName Composer-package name of the just-registered
+     *        donor (read from the fetched composer.json's `name`, NOT from the CLI input —
+     *        those can differ; e.g. GitHub's `<owner>/<repo>` path is unrelated to the
+     *        package's `name`). Scopes the sync to that one donor; `null` widens to no filter.
+     */
+    public static function run(
+        Path $projectRoot,
+        ?Composer $composer,
+        IOInterface $io,
+        ?string $donorPackageName,
+    ): int {
+        /** @var mixed $extra */
+        $extra = $composer?->getPackage()->getExtra();
+        $provider = (new DonorProviderBuilder())->build($projectRoot, $composer, $extra);
+
+        $syncOptions = new SyncOptions(
+            packageFilters: self::filterFor($donorPackageName),
+            extraTrusted: [],
+            targetOverride: null,
+            interactive: false,
+            dryRun: false,
+            discovery: null,
+            aliasOverrides: null,
+            autoMigrate: false,
+        );
+
+        return (new SyncRunner())->run($projectRoot, $provider, $extra, $io, $syncOptions);
+    }
+
+    /**
+     * Single-element `packageFilters` scoped to the donor's
+     * Composer-package name. `null` / empty widens to no filter (the
+     * providers' full donor set syncs).
+     *
+     * @return list<VendorPattern>
+     *
+     * @psalm-pure
+     */
+    private static function filterFor(?string $donorPackageName): array
+    {
+        if ($donorPackageName === null || $donorPackageName === '') {
+            return [];
+        }
+        return [VendorPattern::fromString($donorPackageName)];
+    }
+}

--- a/src/Composer/Command/Add.php
+++ b/src/Composer/Command/Add.php
@@ -7,9 +7,8 @@ namespace LLM\Skills\Composer\Command;
 use Composer\Command\BaseCommand;
 use Internal\Path;
 use LLM\Skills\Add\AddRunner;
+use LLM\Skills\Add\PostAddSync;
 use LLM\Skills\Config\RemoteEntry;
-use LLM\Skills\Config\SyncOptions;
-use LLM\Skills\Config\VendorPattern;
 use LLM\Skills\Console\AddCliDefinition;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
@@ -17,8 +16,6 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\CachePathBuilder;
 use LLM\Skills\Discovery\Provider\Remote\Http\ComposerHttpClient;
 use LLM\Skills\Discovery\Provider\Remote\HttpArchiveFetcher;
-use LLM\Skills\Discovery\Provider\DonorProviderBuilder;
-use LLM\Skills\Sync\SyncRunner;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -61,7 +58,11 @@ final class Add extends BaseCommand
             new GithubAdapter($http),
             new GitlabAdapter($http),
         );
-        $fetcher = new HttpArchiveFetcher($http, $projectRoot, self::cacheBuilderFor($composer));
+        $fetcher = new HttpArchiveFetcher(
+            $http,
+            $projectRoot,
+            CachePathBuilder::fromVendorDir($composer->getConfig()->get('vendor-dir')),
+        );
 
         $runner = new AddRunner($registry, $fetcher);
         $donorPackageName = null;
@@ -82,54 +83,6 @@ final class Add extends BaseCommand
         // new skills land in the target without re-syncing everything
         // else. Matches `composer require <pkg>` ergonomics, which
         // only installs the requested package's tree.
-        $extra = $composer->getPackage()->getExtra();
-        $provider = (new DonorProviderBuilder())->build($projectRoot, $composer, $extra);
-
-        $syncOptions = new SyncOptions(
-            packageFilters: self::filterFor($donorPackageName),
-            extraTrusted: [],
-            targetOverride: null,
-            interactive: false,
-            dryRun: false,
-            discovery: null,
-            aliasOverrides: null,
-            autoMigrate: false,
-        );
-        return (new SyncRunner())->run($projectRoot, $provider, $extra, $this->getIO(), $syncOptions);
-    }
-
-    /**
-     * Honour the project's configured `vendor-dir` when computing the
-     * cache layout. Without this, a `vendor-dir: "deps"` project would
-     * see cached archives written under `vendor/` (which Composer may
-     * not even use, and which `composer install` doesn't gitignore).
-     */
-    private static function cacheBuilderFor(\Composer\Composer $composer): CachePathBuilder
-    {
-        /** @var mixed $vendorDir */
-        $vendorDir = $composer->getConfig()->get('vendor-dir');
-        if (!\is_string($vendorDir) || $vendorDir === '') {
-            return new CachePathBuilder();
-        }
-        return new CachePathBuilder(Path::create($vendorDir)->join('llm-skills/cache'));
-    }
-
-    /**
-     * Single-element `packageFilters` scoped to the donor's
-     * Composer-package name (read from the fetched composer.json's
-     * `name`, NOT from `$options->input` — those can differ; e.g.
-     * GitHub's `<owner>/<repo>` path is unrelated to the package's
-     * `name`).
-     *
-     * @return list<VendorPattern>
-     *
-     * @psalm-pure
-     */
-    private static function filterFor(?string $donorPackageName): array
-    {
-        if ($donorPackageName === null || $donorPackageName === '') {
-            return [];
-        }
-        return [VendorPattern::fromString($donorPackageName)];
+        return PostAddSync::run($projectRoot, $composer, $this->getIO(), $donorPackageName);
     }
 }

--- a/src/Console/Command/Add.php
+++ b/src/Console/Command/Add.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace LLM\Skills\Console\Command;
 
 use Composer\Composer;
-use Composer\Config;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
 use Composer\IO\NullIO;
 use Internal\Path;
 use LLM\Skills\Add\AddRunner;
+use LLM\Skills\Add\PostAddSync;
 use LLM\Skills\Config\RemoteEntry;
-use LLM\Skills\Config\SyncOptions;
-use LLM\Skills\Config\VendorPattern;
 use LLM\Skills\Console\AddCliDefinition;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
@@ -21,8 +19,6 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\CachePathBuilder;
 use LLM\Skills\Discovery\Provider\Remote\Http\ComposerHttpClient;
 use LLM\Skills\Discovery\Provider\Remote\HttpArchiveFetcher;
-use LLM\Skills\Discovery\Provider\DonorProviderBuilder;
-use LLM\Skills\Sync\SyncRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -77,7 +73,11 @@ final class Add extends Command
             new GithubAdapter($http),
             new GitlabAdapter($http),
         );
-        $fetcher = new HttpArchiveFetcher($http, $projectRoot, self::cacheBuilderFor($config));
+        $fetcher = new HttpArchiveFetcher(
+            $http,
+            $projectRoot,
+            CachePathBuilder::fromVendorDir($config->get('vendor-dir')),
+        );
 
         $runner = new AddRunner($registry, $fetcher);
         $donorPackageName = null;
@@ -94,56 +94,11 @@ final class Add extends Command
             return $exit;
         }
 
-        // Without a Composer instance there is no root package to read
-        // an `extra` from — fall through with `null`, which the mapper
-        // treats the same as an empty `extra.skills` block. Only the
-        // just-registered remote donor will sync.
-        /** @var mixed $extra */
-        $extra = $composer?->getPackage()->getExtra();
-        $provider = (new DonorProviderBuilder())->build($projectRoot, $composer, $extra);
-        $syncOptions = new SyncOptions(
-            packageFilters: self::filterFor($donorPackageName),
-            extraTrusted: [],
-            targetOverride: null,
-            interactive: false,
-            dryRun: false,
-            discovery: null,
-            aliasOverrides: null,
-            autoMigrate: false,
-        );
-        return (new SyncRunner())->run($projectRoot, $provider, $extra, $io, $syncOptions);
-    }
-
-    /**
-     * Honour the project's configured `vendor-dir` so a custom value
-     * doesn't leave the cache under an unused `vendor/` directory.
-     * Takes a `Config` rather than a `Composer` so the standalone
-     * no-composer.json path (default Config from
-     * {@see Factory::createConfig()}) can still resolve the cache
-     * layout correctly — its `vendor-dir` is just the default
-     * `vendor`, which is the right answer for that mode.
-     */
-    private static function cacheBuilderFor(Config $config): CachePathBuilder
-    {
-        /** @var mixed $vendorDir */
-        $vendorDir = $config->get('vendor-dir');
-        if (!\is_string($vendorDir) || $vendorDir === '') {
-            return new CachePathBuilder();
-        }
-        return new CachePathBuilder(Path::create($vendorDir)->join('llm-skills/cache'));
-    }
-
-    /**
-     * @return list<VendorPattern>
-     *
-     * @psalm-pure
-     */
-    private static function filterFor(?string $donorPackageName): array
-    {
-        if ($donorPackageName === null || $donorPackageName === '') {
-            return [];
-        }
-        return [VendorPattern::fromString($donorPackageName)];
+        // Without a Composer instance there is no root package to read an
+        // `extra` from — PostAddSync falls through with `null`, which the
+        // mapper treats the same as an empty `extra.skills` block. Only
+        // the just-registered remote donor will sync.
+        return PostAddSync::run($projectRoot, $composer, $io, $donorPackageName);
     }
 
     /**

--- a/src/Discovery/Provider/DonorProviderBuilder.php
+++ b/src/Discovery/Provider/DonorProviderBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LLM\Skills\Discovery\Provider;
 
 use Composer\Composer;
-use Composer\Config;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Internal\Path;
@@ -77,26 +76,6 @@ final readonly class DonorProviderBuilder
     }
 
     /**
-     * Build a {@see CachePathBuilder} rooted at the supplied Config's
-     * `vendor-dir` so a custom value (`deps/`, `build/vendor/`, …) is
-     * honoured. Without this, the cache would always land under a
-     * hard-coded `vendor/` directory that Composer may not even use,
-     * leaving cached archives outside the vendor tree's `.gitignore`.
-     * For the no-project mode (a default Config built via
-     * {@see Factory::createConfig()}) `vendor-dir` is the literal
-     * `vendor` default, which is exactly the right answer.
-     */
-    private static function cacheBuilderFor(Config $config): CachePathBuilder
-    {
-        /** @var mixed $vendorDir */
-        $vendorDir = $config->get('vendor-dir');
-        if (!\is_string($vendorDir) || $vendorDir === '') {
-            return new CachePathBuilder();
-        }
-        return new CachePathBuilder(Path::create($vendorDir)->join('llm-skills/cache'));
-    }
-
-    /**
      * Build the remote provider. Wires the GitHub adapter, an HTTP
      * client (so auth.json credentials apply), and an archive fetcher
      * into the {@see RemoteProvider} skeleton.
@@ -130,7 +109,7 @@ final readonly class DonorProviderBuilder
             $composer !== null
                 ? $this->guessProjectRootForFetcher($composer)
                 : Path::create(\getcwd() ?: '.'),
-            self::cacheBuilderFor($config),
+            CachePathBuilder::fromVendorDir($config->get('vendor-dir')),
         );
 
         return new RemoteProvider($source, $fetcher);

--- a/src/Discovery/Provider/Remote/CachePathBuilder.php
+++ b/src/Discovery/Provider/Remote/CachePathBuilder.php
@@ -77,6 +77,31 @@ final readonly class CachePathBuilder
     ) {}
 
     /**
+     * Build a cache builder from a Composer `vendor-dir` config value.
+     *
+     * Honours a custom `vendor-dir` (`deps/`, `build/vendor/`, …) so the
+     * cache lands inside the actual vendor tree — gitignored by the same
+     * rule as the rest of `vendor/`. A missing / non-string / empty value
+     * falls back to the default `vendor/` layout.
+     *
+     * Takes the raw config value (`mixed`) rather than a Composer
+     * `Config` so this class stays Composer-agnostic; the caller does the
+     * one-line `$config->get('vendor-dir')` read. Centralises what was
+     * three identical `cacheBuilderFor()` helpers across the `skills:add`
+     * entrypoints and {@see \LLM\Skills\Discovery\Provider\DonorProviderBuilder}.
+     *
+     * @psalm-mutation-free
+     */
+    public static function fromVendorDir(mixed $vendorDir): self
+    {
+        if (!\is_string($vendorDir) || $vendorDir === '') {
+            return new self();
+        }
+        /** @psalm-suppress ImpureMethodCall Path::create()/join() are mutation-free; psalm conservatism */
+        return new self(Path::create($vendorDir)->join('llm-skills/cache'));
+    }
+
+    /**
      * Build the cache directory path for the given entry and
      * resolved ref. The directory may not exist yet — the fetcher
      * decides whether to create it. The path is always absolute,

--- a/src/Discovery/Provider/Remote/DonorArchiveInspection.php
+++ b/src/Discovery/Provider/Remote/DonorArchiveInspection.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider\Remote;
+
+use Internal\Path;
+
+/**
+ * Result of {@see DonorArchiveInspector::inspect()} — the shared
+ * classification of an extracted archive, in a shape both the
+ * `skills:add` path ({@see \LLM\Skills\Add\AddRunner}) and the sync
+ * path ({@see RemoteProvider}) can finish off their own way.
+ *
+ * Exactly one of three outcomes holds, built via the named
+ * constructors so invalid combinations are unrepresentable:
+ *
+ * - {@see self::composerShaped()} — `composer.json` declares `name` +
+ *   `extra.skills.source`. Carries the name and the raw `extra` so the
+ *   caller can hand it to {@see \LLM\Skills\Config\Mapper\VendorConfigMapper::fromExtra()}.
+ * - {@see self::bareSkillRepo()} — no usable manifest, but the archive
+ *   ships `SKILL.md` files. Carries the synthesised name, the `source`
+ *   container, and the discovered skill directories.
+ * - {@see self::rejected()} — not a donor; carries the
+ *   {@see DonorArchiveRejection} (and an optional detail line).
+ *
+ * @psalm-immutable
+ */
+final readonly class DonorArchiveInspection
+{
+    /**
+     * @param non-empty-string|null $packageName donor package name (accepted outcomes only)
+     * @param mixed $extra raw `composer.json` `extra` (composer-shaped only)
+     * @param non-empty-string|null $source relative container of the discovered skills
+     *        (bare-skill-repo only)
+     * @param list<Path> $discoveredSkillDirs absolute skill directories (bare-skill-repo only)
+     * @param non-empty-string|null $detail extra context for the rejection message
+     *        (e.g. the JSON parse error)
+     *
+     * @psalm-mutation-free
+     */
+    private function __construct(
+        public bool $isComposerShaped,
+        public ?string $packageName,
+        public mixed $extra,
+        public ?string $source,
+        public array $discoveredSkillDirs,
+        public ?DonorArchiveRejection $rejection,
+        public ?string $detail,
+    ) {}
+
+    /**
+     * @param non-empty-string $packageName
+     *
+     * @psalm-pure
+     */
+    public static function composerShaped(string $packageName, mixed $extra): self
+    {
+        return new self(
+            isComposerShaped: true,
+            packageName: $packageName,
+            extra: $extra,
+            source: null,
+            discoveredSkillDirs: [],
+            rejection: null,
+            detail: null,
+        );
+    }
+
+    /**
+     * @param non-empty-string $packageName
+     * @param non-empty-string $source
+     * @param list<Path> $discoveredSkillDirs
+     *
+     * @psalm-pure
+     */
+    public static function bareSkillRepo(
+        string $packageName,
+        string $source,
+        array $discoveredSkillDirs,
+    ): self {
+        return new self(
+            isComposerShaped: false,
+            packageName: $packageName,
+            extra: null,
+            source: $source,
+            discoveredSkillDirs: $discoveredSkillDirs,
+            rejection: null,
+            detail: null,
+        );
+    }
+
+    /**
+     * @param non-empty-string|null $detail
+     *
+     * @psalm-pure
+     */
+    public static function rejected(DonorArchiveRejection $rejection, ?string $detail = null): self
+    {
+        return new self(
+            isComposerShaped: false,
+            packageName: null,
+            extra: null,
+            source: null,
+            discoveredSkillDirs: [],
+            rejection: $rejection,
+            detail: $detail,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isRejected(): bool
+    {
+        return $this->rejection !== null;
+    }
+}

--- a/src/Discovery/Provider/Remote/DonorArchiveInspector.php
+++ b/src/Discovery/Provider/Remote/DonorArchiveInspector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider\Remote;
+
+use Internal\Path;
+use LLM\Skills\Config\Mapper\VendorConfigMapper;
+use LLM\Skills\Discovery\DiscoveredSkill;
+use LLM\Skills\Discovery\SkillTreeScanner;
+
+/**
+ * Classifies an extracted archive as a skill donor — the single
+ * source of truth shared by the two code paths that fetch a remote
+ * archive and then have to decide what it is:
+ *
+ * - {@see \LLM\Skills\Add\AddRunner} validates the archive during
+ *   `skills:add` (it only needs the donor's package name to scope the
+ *   follow-up sync).
+ * - {@see RemoteProvider} does the same during `skills:update`, then
+ *   turns the result into a {@see \LLM\Skills\Config\VendorConfig}.
+ *
+ * Keeping the parse-and-classify rules here — rather than mirrored in
+ * both callers — is what stops the two paths from drifting: a drift
+ * where `skills:add` accepts an archive the sync then rejects (or vice
+ * versa) is exactly what leaves a skill registered but never copied.
+ *
+ * Two archive shapes are accepted (see {@see DonorArchiveInspection}):
+ *
+ * 1. **Composer-shaped** — `composer.json` present, `name` well-formed
+ *    (`vendor/package`), and `extra.skills.source` declared.
+ * 2. **Bare skill repo** — no usable manifest, but `SKILL.md` files
+ *    live somewhere in the tree ({@see SkillTreeScanner} probes the
+ *    conventional roots first, then recurses). The name falls back to
+ *    the adapter-side `$packageHint`.
+ *
+ * Anything else is a {@see DonorArchiveRejection}.
+ */
+final readonly class DonorArchiveInspector
+{
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private SkillTreeScanner $scanner = new SkillTreeScanner(),
+    ) {}
+
+    /**
+     * @param non-empty-string|null $packageHint adapter-side identifier used as the
+     *        donor name for the bare-skill-repo shape (for GitHub, `<owner>/<repo>`);
+     *        `null` when the adapter could not derive one.
+     */
+    public function inspect(Path $extractedRoot, ?string $packageHint): DonorArchiveInspection
+    {
+        $packageName = null;
+        $extra = null;
+
+        $composerJsonPath = (string) $extractedRoot->join('composer.json');
+        if (\is_file($composerJsonPath)) {
+            $contents = \file_get_contents($composerJsonPath);
+            if ($contents === false) {
+                return DonorArchiveInspection::rejected(DonorArchiveRejection::ComposerJsonUnreadable);
+            }
+
+            try {
+                /** @var mixed $decoded */
+                $decoded = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                $detail = $e->getMessage();
+                return DonorArchiveInspection::rejected(
+                    DonorArchiveRejection::ComposerJsonInvalidJson,
+                    $detail !== '' ? $detail : null,
+                );
+            }
+
+            if (!\is_array($decoded)) {
+                return DonorArchiveInspection::rejected(DonorArchiveRejection::ComposerJsonNotObject);
+            }
+
+            /** @var mixed $rawName */
+            $rawName = $decoded['name'] ?? null;
+            if (\is_string($rawName) && $rawName !== '' && \str_contains($rawName, '/')) {
+                /** @var non-empty-string $packageName */
+                $packageName = $rawName;
+            }
+
+            /** @var mixed $extra */
+            $extra = $decoded['extra'] ?? null;
+        }
+
+        // Composer-shaped donor: hand the name + raw extra back for the
+        // caller to run through the mapper.
+        if ($packageName !== null && VendorConfigMapper::declaresSkills($extra)) {
+            return DonorArchiveInspection::composerShaped($packageName, $extra);
+        }
+
+        // Auto-discovery fallback: no usable manifest, but the archive
+        // may still ship SKILL.md files at conventional or nested roots.
+        $discovered = $this->scanner->scan($extractedRoot);
+        if ($discovered === []) {
+            return DonorArchiveInspection::rejected(DonorArchiveRejection::NoDonorShape);
+        }
+
+        $synthesisedName = $packageName ?? $packageHint;
+        if ($synthesisedName === null) {
+            return DonorArchiveInspection::rejected(DonorArchiveRejection::NoPackageName);
+        }
+
+        return DonorArchiveInspection::bareSkillRepo(
+            $synthesisedName,
+            $discovered[0]->container,
+            \array_map(static fn(DiscoveredSkill $skill): Path => $skill->dir, $discovered),
+        );
+    }
+}

--- a/src/Discovery/Provider/Remote/DonorArchiveRejection.php
+++ b/src/Discovery/Provider/Remote/DonorArchiveRejection.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider\Remote;
+
+/**
+ * Why {@see DonorArchiveInspector} refused to treat an extracted
+ * archive as a skill donor.
+ *
+ * The inspector classifies; each caller phrases the reason for its
+ * own channel ({@see \LLM\Skills\Add\AddRunner} writes to the console,
+ * {@see RemoteProvider} accumulates warnings), so the enum carries the
+ * *what* and leaves the *wording* to the caller.
+ */
+enum DonorArchiveRejection
+{
+    /**
+     * `composer.json` exists but could not be read off disk.
+     */
+    case ComposerJsonUnreadable;
+
+    /**
+     * `composer.json` is present but not valid JSON.
+     */
+    case ComposerJsonInvalidJson;
+
+    /**
+     * `composer.json` decoded to something other than an object.
+     */
+    case ComposerJsonNotObject;
+
+    /**
+     * Neither a `composer.json` declaring `extra.skills.source` nor any
+     * `SKILL.md` file — the archive is not a donor in any accepted shape.
+     */
+    case NoDonorShape;
+
+    /**
+     * The archive ships `SKILL.md` files but there is no package name to
+     * register it under (no usable `composer.json` name AND no hint from
+     * the adapter side).
+     */
+    case NoPackageName;
+}

--- a/src/Discovery/Provider/Remote/RefResolver.php
+++ b/src/Discovery/Provider/Remote/RefResolver.php
@@ -21,11 +21,14 @@ namespace LLM\Skills\Discovery\Provider\Remote;
  * Composer ships a full semver implementation in
  * `composer/semver`, but the resolver here intentionally rolls a
  * narrow subset: only the pieces this plugin actually requires, no
- * `*` / `~` / `>=` / `<` / `||` parsing, no per-major caret
- * edge cases below 1.0.0. Keeping this minimal means the resolver
- * stays pure, testable from a fixture list of tag strings, and
- * impossible to misuse by passing weird Composer constraints
- * we do not promise to support.
+ * `*` / `~` / `>=` / `<` / `||` parsing. Caret support does follow
+ * Composer's pre-1.0 rule (`^0.y.z` locks the minor), so a version
+ * `skills:add` pins on a 0.x donor resolves the same way Composer
+ * would — otherwise `formatCaret()` would emit a `^0.y.z` constraint
+ * that `resolveCaret()` could never satisfy. Keeping the rest minimal
+ * means the resolver stays pure, testable from a fixture list of tag
+ * strings, and impossible to misuse by passing weird Composer
+ * constraints we do not promise to support.
  *
  * @psalm-immutable
  */
@@ -134,17 +137,17 @@ final readonly class RefResolver
      * highest stable tag that satisfies the constraint, or null
      * when none does.
      *
-     * Constraint shapes:
+     * Constraint shapes (the ceiling follows Composer's rule — bump
+     * the left-most non-zero component the constraint specified):
      *
      * - `^1.2.3` → `>= 1.2.3, < 2.0.0`
      * - `^1.2`   → `>= 1.2.0, < 2.0.0`
      * - `^1`     → `>= 1.0.0, < 2.0.0`
+     * - `^0.2.3` → `>= 0.2.3, < 0.3.0`  (0.x locks the minor)
+     * - `^0.0.3` → `>= 0.0.3, < 0.0.4`  (0.0.x locks the patch)
      * - `^v1.2.3` is treated identically to `^1.2.3`
      *
-     * Pre-1.0 caret semantics (`^0.2.3` meaning `< 0.3.0`) are
-     * intentionally not implemented — caret support is only
-     * promised for major>=1. Pre-1.0 inputs return null rather
-     * than guessing.
+     * See {@see self::caretCeiling()} for the exact upper-bound rule.
      *
      * @param list<non-empty-string> $tags
      *
@@ -158,17 +161,14 @@ final readonly class RefResolver
         if ($match !== 1) {
             return null;
         }
+        $minorGiven = isset($m[2]) && $m[2] !== '';
+        $patchGiven = isset($m[3]) && $m[3] !== '';
         $major = (int) $m[1];
-        $minor = isset($m[2]) && $m[2] !== '' ? (int) $m[2] : 0;
-        $patch = isset($m[3]) && $m[3] !== '' ? (int) $m[3] : 0;
-
-        if ($major < 1) {
-            // Pre-1.0 caret semantics differ — out of scope.
-            return null;
-        }
+        $minor = $minorGiven ? (int) $m[2] : 0;
+        $patch = $patchGiven ? (int) $m[3] : 0;
 
         $floor = [$major, $minor, $patch];
-        $ceiling = [$major + 1, 0, 0];
+        $ceiling = self::caretCeiling($major, $minor, $patch, $minorGiven, $patchGiven);
 
         $best = null;
         /** @var array{int, int, int}|null $bestParts */
@@ -227,6 +227,49 @@ final readonly class RefResolver
     public function isCaretConstraint(string $ref): bool
     {
         return \preg_match(self::CARET_CONSTRAINT_REGEX, $ref) === 1;
+    }
+
+    /**
+     * Exclusive upper bound for a caret constraint, following
+     * Composer's rule: bump the left-most non-zero component among
+     * those the constraint specified and zero everything to its
+     * right. When every specified component is zero, bump the
+     * least-significant specified component.
+     *
+     * - `^1.2.3` → `[2, 0, 0]`  (major is the left-most non-zero)
+     * - `^0.2.3` → `[0, 3, 0]`  (minor locked once major is 0)
+     * - `^0.0.3` → `[0, 0, 4]`  (patch locked once major+minor are 0)
+     * - `^0.2`   → `[0, 3, 0]`
+     * - `^0`     → `[1, 0, 0]`
+     * - `^0.0`   → `[0, 1, 0]`
+     *
+     * @return array{int, int, int}
+     *
+     * @psalm-pure
+     */
+    private static function caretCeiling(
+        int $major,
+        int $minor,
+        int $patch,
+        bool $minorGiven,
+        bool $patchGiven,
+    ): array {
+        if ($major !== 0) {
+            return [$major + 1, 0, 0];
+        }
+        if ($minorGiven && $minor !== 0) {
+            return [0, $minor + 1, 0];
+        }
+        if (!$minorGiven) {
+            // `^0` allows the whole 0.x range.
+            return [1, 0, 0];
+        }
+        if ($patchGiven && $patch !== 0) {
+            return [0, 0, $patch + 1];
+        }
+        // All specified components are zero: `^0.0.0` locks the patch,
+        // `^0.0` locks the minor.
+        return $patchGiven ? [0, 0, 1] : [0, 1, 0];
     }
 
     /**

--- a/src/Discovery/Provider/Remote/RemoteProvider.php
+++ b/src/Discovery/Provider/Remote/RemoteProvider.php
@@ -8,11 +8,9 @@ use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedVendorConfig;
 use LLM\Skills\Config\Mapper\VendorConfigMapper;
 use LLM\Skills\Config\VendorConfig;
-use LLM\Skills\Discovery\DiscoveredSkill;
 use LLM\Skills\Discovery\DonorDiscoveryResult;
 use LLM\Skills\Discovery\MalformedDonor;
 use LLM\Skills\Discovery\Provider\DonorProvider;
-use LLM\Skills\Discovery\SkillTreeScanner;
 
 /**
  * {@see DonorProvider} for donors fetched from arbitrary repository
@@ -56,7 +54,7 @@ final readonly class RemoteProvider implements DonorProvider
         private RemoteDonorSource $source = new NullRemoteDonorSource(),
         private ?RemoteFetcher $fetcher = null,
         private VendorConfigMapper $vendorMapper = new VendorConfigMapper(),
-        private SkillTreeScanner $scanner = new SkillTreeScanner(),
+        private DonorArchiveInspector $inspector = new DonorArchiveInspector(),
     ) {}
 
     #[\Override]
@@ -141,23 +139,17 @@ final readonly class RemoteProvider implements DonorProvider
      * archive cannot be turned into a donor. Accumulates per-ref
      * warnings + malformed entries into the caller's lists.
      *
-     * Two acceptable archive shapes:
+     * The parse-and-classify step is delegated to the shared
+     * {@see DonorArchiveInspector} — the same inspector `skills:add`
+     * runs when it fetches the archive, so what the two paths accept as
+     * a donor never drifts. This method only turns the inspection into
+     * a {@see VendorConfig} (or a warning):
      *
-     * 1. **Composer-shaped donor** — `composer.json` is present and
-     *    declares `name` + `extra.skills.source`. The donor's package
-     *    name comes from `composer.json`'s `name` field. This is the
-     *    primary supported shape for ecosystems that already publish
-     *    a Composer manifest.
-     *
-     * 2. **Bare skill repo** — no `composer.json` (or one without
-     *    `extra.skills.source`), but the archive ships `SKILL.md` files
-     *    somewhere ({@see SkillTreeScanner} finds them in conventional
-     *    roots or, failing that, anywhere in the tree). The donor's
-     *    package name falls back to `RemoteDonorRef::$packageHint` (set
-     *    from the entry's adapter-side identifier — for GitHub,
-     *    `<owner>/<repo>`). Mirrors the local-provider auto-discovery
-     *    path for ad-hoc skill packs that don't bother with a Composer
-     *    manifest.
+     * - **Composer-shaped** → hand the name + raw `extra` to the mapper;
+     *   a mapper rejection lifts to a warning AND a {@see MalformedDonor}.
+     * - **Bare skill repo** → synthesise a `VendorConfig` from the
+     *   auto-discovered skill directories.
+     * - **Rejected** → a per-ref warning, no donor.
      *
      * @param list<string>             $warnings  appended to in place
      * @param list<MalformedDonor>     $malformed appended to in place
@@ -171,56 +163,23 @@ final readonly class RemoteProvider implements DonorProvider
         array &$warnings,
         array &$malformed,
     ): ?VendorConfig {
-        $composerJsonPath = (string) $path->join('composer.json');
-        $extra = null;
-        $packageName = null;
+        $inspection = $this->inspector->inspect($path, $ref->packageHint);
 
-        if (\is_file($composerJsonPath)) {
-            $contents = \file_get_contents($composerJsonPath);
-            if ($contents === false) {
-                $warnings[] = \sprintf(
-                    'remote %s: failed to read composer.json',
-                    $ref->describe(),
-                );
-                return null;
-            }
-
-            try {
-                /** @var mixed $decoded */
-                $decoded = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
-            } catch (\JsonException $e) {
-                $warnings[] = \sprintf(
-                    'remote %s: composer.json is not valid JSON: %s',
-                    $ref->describe(),
-                    $e->getMessage(),
-                );
-                return null;
-            }
-
-            if (!\is_array($decoded)) {
-                $warnings[] = \sprintf(
-                    'remote %s: composer.json must be a JSON object',
-                    $ref->describe(),
-                );
-                return null;
-            }
-
-            /** @var mixed $rawName */
-            $rawName = $decoded['name'] ?? null;
-            if (\is_string($rawName) && $rawName !== '' && \str_contains($rawName, '/')) {
-                /** @var non-empty-string $packageName */
-                $packageName = $rawName;
-            }
-
-            /** @var mixed $extra */
-            $extra = $decoded['extra'] ?? null;
+        $rejection = $inspection->rejection;
+        if ($rejection !== null) {
+            $warnings[] = \sprintf(
+                'remote %s: %s',
+                $ref->describe(),
+                $this->describeRejection($rejection, $inspection->detail),
+            );
+            return null;
         }
 
-        // Composer-shaped donor: composer.json present, name well-shaped,
-        // extra.skills.source declared. Hand off to the mapper.
-        if ($packageName !== null && VendorConfigMapper::declaresSkills($extra)) {
+        if ($inspection->isComposerShaped) {
+            /** @var non-empty-string $packageName */
+            $packageName = $inspection->packageName;
             try {
-                $donor = $this->vendorMapper->fromExtra($packageName, $path, $extra);
+                $donor = $this->vendorMapper->fromExtra($packageName, $path, $inspection->extra);
             } catch (MalformedVendorConfig $e) {
                 $warnings[] = $e->getMessage();
                 /** @var non-empty-string $reason */
@@ -235,52 +194,53 @@ final readonly class RemoteProvider implements DonorProvider
             return $this->decorate($donor, $ref);
         }
 
-        // Auto-discovery fallback: no usable composer.json metadata, but
-        // the archive may still ship SKILL.md files. Scan for them —
-        // conventional roots first, then a bounded recursion — so repos
-        // that nest skills (e.g. `maintenance/skills/<name>/`) are caught
-        // too. Synthesise a donor using the entry's `packageHint` as the
-        // name. Without a hint we have nothing stable to call it — abort.
-        $discovered = $this->scanner->scan($path);
-        if ($discovered === []) {
-            $warnings[] = \sprintf(
-                'remote %s: archive ships neither a composer.json with extra.skills.source '
-                . 'nor any SKILL.md files — not a donor',
-                $ref->describe(),
-            );
-            return null;
-        }
-        $synthesisedName = $packageName ?? $ref->packageHint;
-        if ($synthesisedName === null) {
-            $warnings[] = \sprintf(
-                'remote %s: archive ships SKILL.md files but no package name to '
-                . 'register it under (composer.json missing AND the adapter could not '
-                . 'derive a `vendor/repo` identifier)',
-                $ref->describe(),
-            );
-            return null;
-        }
-
-        // NOTE: `discovered: false` even though the skills were auto-found.
-        // The `discovered` flag drives "auto-found locally, opt in via
-        // --discovery" semantics — but remote entries are already explicit
-        // (the user typed `skills:add`). Treating them as discoverable
-        // would show a misleading [discovered] badge and gate them behind
-        // a flag they shouldn't need. The explicit skill directories ride
-        // on `discoveredSkillDirs` so the enumerator finds them at whatever
+        // Bare skill repo. NOTE: `discovered: false` even though the
+        // skills were auto-found. The `discovered` flag drives
+        // "auto-found locally, opt in via --discovery" semantics — but
+        // remote entries are already explicit (the user typed
+        // `skills:add`). Treating them as discoverable would show a
+        // misleading [discovered] badge and gate them behind a flag they
+        // shouldn't need. The explicit skill directories ride on
+        // `discoveredSkillDirs` so the enumerator finds them at whatever
         // depth they live.
+        /** @var non-empty-string $packageName */
+        $packageName = $inspection->packageName;
+        /** @var non-empty-string $source */
+        $source = $inspection->source;
         return $this->decorate(
             new VendorConfig(
-                packageName: $synthesisedName,
+                packageName: $packageName,
                 packageRoot: $path,
-                source: $discovered[0]->container,
-                discoveredSkillDirs: \array_map(
-                    static fn(DiscoveredSkill $skill): Path => $skill->dir,
-                    $discovered,
-                ),
+                source: $source,
+                discoveredSkillDirs: $inspection->discoveredSkillDirs,
             ),
             $ref,
         );
+    }
+
+    /**
+     * Phrase a {@see DonorArchiveRejection} for a per-ref sync warning.
+     * The inspector owns the *classification*; the `remote <ref>:`
+     * framing is added by the caller.
+     *
+     * @psalm-pure
+     */
+    private function describeRejection(DonorArchiveRejection $rejection, ?string $detail): string
+    {
+        return match ($rejection) {
+            DonorArchiveRejection::ComposerJsonUnreadable =>
+                'failed to read composer.json',
+            DonorArchiveRejection::ComposerJsonInvalidJson =>
+                'composer.json is not valid JSON: ' . ($detail ?? ''),
+            DonorArchiveRejection::ComposerJsonNotObject =>
+                'composer.json must be a JSON object',
+            DonorArchiveRejection::NoDonorShape =>
+                'archive ships neither a composer.json with extra.skills.source '
+                . 'nor any SKILL.md files — not a donor',
+            DonorArchiveRejection::NoPackageName =>
+                'archive ships SKILL.md files but no package name to register it under '
+                . '(composer.json missing AND the adapter could not derive a `vendor/repo` identifier)',
+        };
     }
 
     /**

--- a/tests/Unit/Discovery/Provider/Remote/Adapter/GithubAdapterTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/Adapter/GithubAdapterTest.php
@@ -225,6 +225,25 @@ final class GithubAdapterTest
         Assert::same($ref->ref, 'v1.5.0');
     }
 
+    public function resolveCaretResolvesPre1Constraint(): void
+    {
+        // Regression: `skills:add owner/repo` on a 0.x donor stores a
+        // `^0.y.z` caret (via RefResolver::formatCaret), and the
+        // follow-up sync must be able to resolve it — otherwise the
+        // just-registered skill never lands in the target.
+        $http = new InMemoryHttpClient([
+            'https://api.github.com/repos/acme/skills/tags?per_page=100' => self::tagsResponse([
+                '0.10.37', '0.10.38', '0.11.0',
+            ]),
+        ]);
+        $adapter = new GithubAdapter($http);
+
+        $ref = $adapter->resolve(self::entry('acme/skills', ref: '^0.10.38'));
+
+        // `^0.10.38` locks the minor → `0.11.0` is out of range.
+        Assert::same($ref->ref, '0.10.38');
+    }
+
     public function resolveCaretNoMatchingTagThrows(): void
     {
         $http = new InMemoryHttpClient([

--- a/tests/Unit/Discovery/Provider/Remote/RefResolverTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/RefResolverTest.php
@@ -156,13 +156,44 @@ final class RefResolverTest
         Assert::same($r->resolveCaret('^v1.2.0', ['v1.2.0', 'v1.5.0']), 'v1.5.0');
     }
 
-    public function caretPre1MajorReturnsNull(): void
+    public function caretPre1LocksTheMinor(): void
     {
-        // Pre-1.0 caret has different semantics (0.x is treated as
-        // major+patch); the resolver doesn't promise to support it.
+        // Composer's pre-1.0 rule: `^0.2.3` means `>=0.2.3 <0.3.0`,
+        // so `0.3.0` is out of range and the highest in-range wins.
         $r = new RefResolver();
 
-        Assert::same($r->resolveCaret('^0.2.3', ['0.2.3', '0.2.5', '0.3.0']), null);
+        Assert::same($r->resolveCaret('^0.2.3', ['0.2.3', '0.2.5', '0.3.0']), '0.2.5');
+    }
+
+    public function caretPre1BelowFloorIsRejected(): void
+    {
+        $r = new RefResolver();
+
+        Assert::same($r->resolveCaret('^0.2.3', ['0.2.2', '0.3.0']), null);
+    }
+
+    public function caretPre1WithZeroMinorLocksThePatch(): void
+    {
+        // `^0.0.3` means `>=0.0.3 <0.0.4` — only the exact patch matches.
+        $r = new RefResolver();
+
+        Assert::same($r->resolveCaret('^0.0.3', ['0.0.3', '0.0.4', '0.1.0']), '0.0.3');
+    }
+
+    public function formatCaretAndResolveCaretRoundTripForPre1Tag(): void
+    {
+        // Regression: `skills:add` on a 0.x donor stores whatever
+        // `formatCaret()` returns, then the sync feeds it straight back
+        // into `resolveCaret()`. The two must agree, or the just-added
+        // skill never loads.
+        $r = new RefResolver();
+        $constraint = $r->formatCaret('0.10.38');
+
+        Assert::same($constraint, '^0.10.38');
+        Assert::same(
+            $r->resolveCaret((string) $constraint, ['0.10.37', '0.10.38', '0.11.0']),
+            '0.10.38',
+        );
     }
 
     public function caretMalformedReturnsNull(): void


### PR DESCRIPTION
## Problem

`skills:add <owner/repo>` **without** `--ref` registered the donor in `skills.json` but never copied its skills into the target — the reported symptom "the skill is added to skills.json but not loaded".

Root cause was an asymmetry in `RefResolver`:

- `skills:add` resolves the latest stable tag and stores it as a `^X.Y.Z` caret. For a **0.x** donor `formatCaret()` emitted e.g. `^0.10.38`.
- The follow-up sync re-resolves that constraint, but `resolveCaret()` **rejected any `major < 1`** — so the sync could never satisfy the caret `skills:add` had just written.

Since most PHP libraries are still `0.x` (the reproduction donor, `php-testo/testo`, is `0.10.x`), this hit the common case. The `1.x` path worked, which is why the single end-to-end test — pinned with an explicit `--ref` and off by default — never caught it.

## Fix (commit 1)

Implement Composer's pre-1.0 caret rule in `resolveCaret` via a `caretCeiling()` helper:

- `^0.10.38` → `>=0.10.38 <0.11.0` (0.x locks the minor)
- `^0.0.3` → `>=0.0.3 <0.0.4` (0.0.x locks the patch)

`formatCaret` and `resolveCaret` are now a symmetric round-trip, and version pinning is preserved for 0.x donors.

## Refactor (commit 2) — dedupe the drift-prone code

The bug's shape (add accepts what sync rejects) also lived in **duplicated archive-inspection logic**, mirrored line-for-line in `AddRunner::validateArchiveShipsSkillsSource` and `RemoteProvider::buildDonor` (comments even flagged them as "same logic" / "mirrors").

- Extract the shared parse-and-classify into **`DonorArchiveInspector`** → `DonorArchiveInspection` (composer-shaped / bare-skill-repo / rejected, reason as `DonorArchiveRejection`). Each caller keeps only its own tail.
- **`CachePathBuilder::fromVendorDir()`** replaces three identical `cacheBuilderFor()` helpers.
- **`PostAddSync`** centralises the post-add scoped-sync wiring both add entrypoints copied.

No behaviour change in the refactor.

## Tests

- New: pre-1.0 caret cases + `formatCaret → resolveCaret` round-trip regression in `RefResolverTest`; adapter-level `resolveCaretResolvesPre1Constraint` (offline, via `InMemoryHttpClient`).
- Unit + Feature: 552 pass. Acceptance: 134 pass (incl. live `skills:add` and `StandaloneBinTest`).
- E2E: `composer skills:add php-testo/testo --from=github` (no `--ref`) → exit 0, 11 skills copied.

## Note

`StandaloneBinTest` references `bin/skills`, which is renamed to `bin/skills1` on the current working tree (unrelated WIP). Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)