### PR TITLE
feat: rename the `remote` config key to `sources` with auto-migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ every donor, the per-skill sync status, and what is being skipped and why. `skil
 bootstraps a [`skills.json`](#project-configuration) at the project root and (when
 `composer.json` carries legacy inline project keys) migrates them out. `skills:add` registers
 a donor that lives outside Composer (e.g. a GitHub repository) and immediately fetches its
-skills — see [Remote sources](#remote-sources).
+skills — see [Donor sources](#donor-sources).
 
 | Option                | Where  | Description                                                                                                                                                        |
 |-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -99,7 +99,7 @@ skills — see [Remote sources](#remote-sources).
 | `--alias=PATH`        | update | Extra path mirrored at the target via a junction/symlink (repeatable). Passing `--alias` at all replaces the configured aliases entirely. See [Aliases](#aliases). |
 | `--trust=PATTERN`     | both   | Trust an extra pattern for this run (repeatable).                                                                                                                  |
 | `--discovery`         | both   | Include packages that ship `SKILL.md` files but do not declare `extra.skills` (see [Auto-discovery](#auto-discovery)).                                              |
-| `--from=ID`           | update | Scope the sync to a single provider id (`composer`, `github`, …). See [Remote sources](#remote-sources).                                                            |
+| `--from=ID`           | update | Scope the sync to a single provider id (`composer`, `github`, …). See [Donor sources](#donor-sources).                                                              |
 | `--dry-run`           | update | Print actions; no files written.                                                                                                                                   |
 
 Short flag `-d` for `--discovery` is registered only by the standalone `bin/skills` binary;
@@ -179,7 +179,7 @@ where to put it, who to trust, whether to auto-sync.
   "path-from-root": "packages/api",
 
   "local":  { "composer": true },
-  "remote": [
+  "sources": [
     { "from": "github", "package": "acme/skills", "ref": "^1.2.0" },
     { "from": "github", "package": "team/skills-pack", "ref": "^2",
       "skills": ["code-review", "refactor"] }
@@ -196,14 +196,21 @@ where to put it, who to trust, whether to auto-sync.
 | `discovery`       | bool        | `false`          | When `true`, auto-discovery is on by default (CLI overrides).                           |
 | `auto-sync`       | bool        | `true`           | Run `skills:update` after `composer install` / `update`. Set to `false` to opt out.     |
 | `path-from-root`  | string      | _(unset)_        | The project's own location below an intended outer root, e.g. `packages/api`. When set, `target` and aliases resolve against (and stay inside) that verified root instead of the project directory. See [path-from-root](#path-from-root). |
-| `local`           | object      | `{}`             | Per-local-provider on/off map. Keys: `composer` (default `true`), `npm`/`go` (future, default `false`). See [Remote sources](#remote-sources). |
-| `remote`          | object[]    | `[]`             | Explicit remote donor refs. Managed by `skills:add`; documented in [Remote sources](#remote-sources). |
+| `local`           | object      | `{}`             | Per-local-provider on/off map. Keys: `composer` (default `true`), `npm`/`go` (future, default `false`). See [Donor sources](#donor-sources). |
+| `sources`         | object[]    | `[]`             | Explicit donor source entries. Managed by `skills:add`; documented in [Donor sources](#donor-sources). |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
 directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent projects.
 
 The fastest way to get a valid `skills.json` is `composer skills:init` (see below). Bootstrap
 it once and commit it alongside `composer.json`.
+
+> [!NOTE]
+> **`remote` was renamed to `sources`.** Existing files keep working — `remote` is still read
+> as a deprecated alias. Any write-mode command (`skills:update`, `skills:init`, `skills:add`)
+> migrates the key in place and prints a `[migrate]` line; read-only `skills:show` just emits a
+> `[deprecated]` notice. Having both `remote` and `sources` in the same file is a fatal config
+> error — keep `sources` only.
 
 ### Strict shape
 
@@ -403,14 +410,14 @@ Bare `vendor` without `/` is rejected as ambiguous.
 Shipped in [`resources/trusted-composer.txt`](resources/trusted-composer.txt); extended by PR. Other registries (npm, go) will ship their own per-ecosystem files when the corresponding local providers land — see [`spec-remote.md`](spec-remote.md) §8.
 
 
-## Remote sources
+## Donor sources
 
 `llm/skills` reads donors from two axes:
 
 - **Local providers** — walk a manifest the project already owns. Today only `composer`; `npm` and `go` are reserved in the vocabulary but ship later.
 - **Remote providers** — fetch an explicit ref from a URL (currently GitHub and GitLab; the format is forward-compatible with Bitbucket, npm registry, Go module proxy, private Packagist, `http`/`zip`).
 
-Both axes coexist. When the same package name arrives via both, the **remote entry wins** (you typed it; the transitive Composer pickup is treated as stale) and the displaced donor is logged under `-v`.
+Both axes coexist. When the same package name arrives via both, the **`sources` entry wins** (you typed it; the transitive Composer pickup is treated as stale) and the displaced donor is logged under `-v`.
 
 ### `skills:add` — register a remote donor
 
@@ -437,7 +444,7 @@ The command:
 2. resolves the ref — explicit value wins verbatim; without `--ref` the adapter picks the highest stable tag, falling back to the highest prerelease tag, then to the default branch HEAD;
 3. downloads the archive into `vendor/llm-skills/cache/...` (gitignored by virtue of vendor);
 4. validates that the archive is a donor — either a `composer.json` with `extra.skills.source`, or (for bare skill repos) at least one `SKILL.md` found by [auto-discovery](#auto-discovery);
-5. upserts the entry into `skills.json` `remote[]` (stable-sorted by `(from, host, package)`, atomic write — falls back to `unlink + rename` on Windows where `rename()` refuses to overwrite an existing destination);
+5. upserts the entry into `skills.json` `sources[]` (stable-sorted by `(from, host, package)`, atomic write — falls back to `unlink + rename` on Windows where `rename()` refuses to overwrite an existing destination);
 6. runs a single-entry sync so the new skills land in the target right away — same ergonomics as `composer require`. Suppress with `--no-sync`.
 
 | Option        | Description                                                                                                   |
@@ -453,7 +460,7 @@ Stored entries look like:
 
 ```jsonc
 {
-  "remote": [
+  "sources": [
     { "from": "github", "package": "acme/skills", "ref": "^1.2.0" },
     { "from": "github", "package": "team/internal-skills",
       "host": "https://github.corp.example.com", "ref": "^1",
@@ -466,12 +473,12 @@ The composite key is `(from, host, package | url)`: same triplet = upsert in pla
 
 #### Per-entry skill allowlist
 
-A donor often ships more skills than you want in a given project. The optional `skills` field on each `remote[]` entry narrows the donor to a named subset:
+A donor often ships more skills than you want in a given project. The optional `skills` field on each `sources[]` entry narrows the donor to a named subset:
 
 - **Absent / omitted** → sync every skill the donor ships (legacy behaviour).
 - **Non-empty list of names** → only those skills are copied; the rest are silently skipped.
 - **Empty list (`"skills": []`)** → the donor is registered but no skills are pulled from it. Useful for staging a donor before opting into its content or for temporarily disabling a donor without deleting the entry.
-- Names that do not exist in the fetched archive emit a `-v` warning (`skill "X" declared in remote.skills but not found in the donor`) so typos surface without aborting the sync.
+- Names that do not exist in the fetched archive emit a `-v` warning (`skill "X" declared in the skill allowlist but not found in the donor`) so typos surface without aborting the sync.
 
 `skills:add --skill=NAME` is the CLI surface: pass `--skill` repeatedly to build the list. The flag is **additive on upsert** — running `skills:add` again on the same entry adds the new names to whatever was already stored. A follow-up `skills:add` without `--skill` does **not** touch the existing allowlist (whether it was a populated list or an explicit empty one). Removing a name or clearing the allowlist entirely is a manual edit of `skills.json`.
 
@@ -499,7 +506,7 @@ composer skills:update --from=composer    # only local Composer donors
 composer skills:update --from=github      # only remote GitHub donors
 ```
 
-The id matches `local.{id}` keys and `remote[].from` values. Each donor's provenance is set at the source: `ComposerProvider` tags `composer`; `RemoteProvider` tags the entry's `from`. The filter is a simple equality check on that tag.
+The id matches `local.{id}` keys and `sources[].from` values. Each donor's provenance is set at the source: `ComposerProvider` tags `composer`; `RemoteProvider` tags the entry's `from`. The filter is a simple equality check on that tag.
 
 ### Local provider toggles
 
@@ -507,7 +514,7 @@ The id matches `local.{id}` keys and `remote[].from` values. Each donor's proven
 { "local": { "composer": false } }    // disable Composer discovery entirely
 ```
 
-`local.composer` defaults to `true` (preserves the pre-`local` behaviour). When set to `false`, transitive Composer packages are no longer scanned — useful when the project wants its donors purely from `remote[]`.
+`local.composer` defaults to `true` (preserves the pre-`local` behaviour). When set to `false`, transitive Composer packages are no longer scanned — useful when the project wants its donors purely from `sources[]`.
 
 For the full architectural rationale, the version-resolution cascade, the cache layout, and the multi-registry trust model, see [`spec-remote.md`](spec-remote.md).
 

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -77,22 +77,37 @@
                 }
             }
         },
-        "remote": {
+        "sources": {
             "type": "array",
-            "description": "Explicit remote donor refs. Each entry tells the remote provider what to fetch and from where: an adapter id in `from`, an identifier in `package` or `url`, and optional `host`/`ref`/`skills`/adapter-specific extras.",
+            "description": "Explicit donor sources. Each entry tells the provider what to fetch and from where: an adapter id in `from`, an identifier in `package` or `url`, and optional `host`/`ref`/`skills`/adapter-specific extras.",
             "default": [],
             "items": {
                 "oneOf": [
-                    { "$ref": "#/$defs/remoteByPackage" },
-                    { "$ref": "#/$defs/remoteByUrl" }
+                    { "$ref": "#/$defs/sourceByPackage" },
+                    { "$ref": "#/$defs/sourceByUrl" }
+                ]
+            }
+        },
+        "remote": {
+            "type": "array",
+            "deprecated": true,
+            "description": "Renamed to sources; read as an alias, auto-migrated by skills:update.",
+            "default": [],
+            "items": {
+                "oneOf": [
+                    { "$ref": "#/$defs/sourceByPackage" },
+                    { "$ref": "#/$defs/sourceByUrl" }
                 ]
             }
         }
     },
+    "not": {
+        "required": ["sources", "remote"]
+    },
     "$defs": {
-        "remoteByPackage": {
+        "sourceByPackage": {
             "type": "object",
-            "description": "Remote entry for name-based adapters (github, gitlab, bitbucket, composer, npm, go, skills.sh).",
+            "description": "Donor source entry for name-based adapters (github, gitlab, bitbucket, composer, npm, go, skills.sh).",
             "required": ["from", "package"],
             "properties": {
                 "from": {
@@ -124,9 +139,9 @@
                 }
             }
         },
-        "remoteByUrl": {
+        "sourceByUrl": {
             "type": "object",
-            "description": "Remote entry for URL-only adapters (http, zip).",
+            "description": "Donor source entry for URL-only adapters (http, zip).",
             "required": ["from", "url"],
             "properties": {
                 "from": {
@@ -148,7 +163,7 @@
                 },
                 "skills": {
                     "type": "array",
-                    "description": "Optional allowlist of skill directory names to sync from this donor. Absent / omitted → sync every skill the donor ships; empty list → donor is registered but no skills are pulled (matches `remoteByPackage` semantics).",
+                    "description": "Optional allowlist of skill directory names to sync from this donor. Absent / omitted → sync every skill the donor ships; empty list → donor is registered but no skills are pulled (matches `sourceByPackage` semantics).",
                     "items": {
                         "type": "string",
                         "minLength": 1

--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -146,7 +146,7 @@ final readonly class AddRunner
         );
 
         try {
-            $this->writer->upsertRemote($projectRoot, $entry);
+            $this->writer->upsertSource($projectRoot, $entry);
         } catch (\Throwable $e) {
             $io->writeError('<error>[llm/skills] failed to update skills.json: ' . $e->getMessage() . '</error>');
             return Command::FAILURE;

--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -7,7 +7,7 @@ namespace LLM\Skills\Add;
 use Composer\IO\IOInterface;
 use Internal\Path;
 use LLM\Skills\Config\AddOptions;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
@@ -66,9 +66,9 @@ final readonly class AddRunner
     ) {}
 
     /**
-     * @param \Closure(RemoteEntry, non-empty-string):void|null $onRegistered
+     * @param \Closure(SourceEntry, non-empty-string):void|null $onRegistered
      *         invoked exactly once after the entry is upserted into
-     *         `skills.json`. Receives the {@see RemoteEntry} AND the
+     *         `skills.json`. Receives the {@see SourceEntry} AND the
      *         donor's actual Composer-package name (read from the
      *         fetched `composer.json`'s `name` field).
      *
@@ -136,7 +136,7 @@ final readonly class AddRunner
         // Step 6: upsert into skills.json. The `--skill` allowlist (if
         // any) is forwarded verbatim; the writer's upsert logic merges
         // it with whatever names already lived in a matching entry.
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: $parsed->from,
             package: $parsed->package,
             url: $parsed->url,
@@ -165,7 +165,7 @@ final readonly class AddRunner
     }
 
     /**
-     * Build a {@see RemoteEntry} from the parsed input for the
+     * Build a {@see SourceEntry} from the parsed input for the
      * adapter's `resolve()` call. The synthesised entry differs
      * from what will eventually land in `skills.json` only in that
      * its `ref` is the user-typed value (or null) — the storage-level
@@ -173,9 +173,9 @@ final readonly class AddRunner
      *
      * @psalm-pure
      */
-    private static function syntheticEntry(ParsedAddInput $parsed): RemoteEntry
+    private static function syntheticEntry(ParsedAddInput $parsed): SourceEntry
     {
-        return new RemoteEntry(
+        return new SourceEntry(
             from: $parsed->from,
             package: $parsed->package,
             url: $parsed->url,

--- a/src/Add/SkillsJsonWriter.php
+++ b/src/Add/SkillsJsonWriter.php
@@ -6,18 +6,20 @@ namespace LLM\Skills\Add;
 
 use Internal\Path;
 use LLM\Skills\Config\Mapper\ExternalProjectConfigLoader;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
 use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Filesystem\AtomicFileWriter;
 
 /**
  * Mutates the project's `skills.json` to insert or update a single
- * `remote[]` entry on behalf of `skills:add`.
+ * `sources[]` entry on behalf of `skills:add`.
  *
  * Three guarantees:
  *
  * - **Upsert by composite key** — `(from, host ?? '', package | url)`.
  *   Same key ⇒ overwrite in place; new key ⇒ append.
- * - **Stable sort** — after the upsert the whole `remote[]` is
+ * - **Stable sort** — after the upsert the whole `sources[]` is
  *   reordered by composite key so diffs are deterministic across
  *   adds. Manual edits may produce any order in between; the next
  *   add normalises it.
@@ -28,7 +30,9 @@ use LLM\Skills\Config\RemoteEntry;
  * When the file does not exist yet, the writer creates it with the
  * canonical `$schema` pointer (the same one
  * {@see ProjectConfigMigrator} emits). Existing files keep all their
- * other keys verbatim — only `remote[]` is touched.
+ * other keys verbatim — only `sources[]` is touched. A file still on
+ * the deprecated `remote` key has its entries folded into `sources`
+ * and the old key dropped, since the writer rewrites the whole file.
  */
 final readonly class SkillsJsonWriter
 {
@@ -44,7 +48,7 @@ final readonly class SkillsJsonWriter
      *
      * @throws \RuntimeException when the file cannot be written
      */
-    public function upsertRemote(Path $projectRoot, RemoteEntry $entry): void
+    public function upsertSource(Path $projectRoot, RemoteEntry $entry): void
     {
         /** @psalm-suppress ImpureMethodCall Path::join() is mutation-free */
         $filePath = (string) $projectRoot->join(ExternalProjectConfigLoader::FILE_NAME);
@@ -55,23 +59,52 @@ final readonly class SkillsJsonWriter
         // write so editors keep the IDE-validation pointer.
         $payload = ['$schema' => ProjectConfigMigrator::SCHEMA_URL] + $payload;
 
-        /** @var mixed $existingRemote */
-        $existingRemote = $payload['remote'] ?? [];
-        if (!\is_array($existingRemote)) {
-            $existingRemote = [];
-        }
-
-        $entries = self::normaliseExisting($existingRemote);
+        $entries = self::normaliseExisting(self::collectExistingEntries($payload));
         $updated = self::upsertByCompositeKey($entries, $entry);
         $sorted = self::stableSort($updated);
 
-        $payload['remote'] = \array_map(self::serialise(...), $sorted);
+        // The whole file is rewritten under the canonical key; a
+        // lingering deprecated alias is dropped from the output.
+        unset($payload[ProjectConfigMapper::DEPRECATED_SOURCES_KEY]);
+        $payload[ProjectConfigMapper::SOURCES_KEY] = \array_map(self::serialise(...), $sorted);
 
-        self::atomicWrite($filePath, self::encode($payload));
+        AtomicFileWriter::write($filePath, self::encode($payload));
     }
 
     /**
-     * Normalise existing `remote[]` content into a list of arrays. We
+     * Gather the donor entries already on file, reading both the
+     * canonical `sources` key and the deprecated `remote` alias so a
+     * legacy file's entries survive the rewrite. A hand-edited file
+     * carrying both keys (rejected by the mapper on load) has its two
+     * lists concatenated; the composite-key upsert collapses any
+     * duplicates that result.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return list<mixed>
+     *
+     * @psalm-pure
+     */
+    private static function collectExistingEntries(array $payload): array
+    {
+        $out = [];
+        foreach ([ProjectConfigMapper::SOURCES_KEY, ProjectConfigMapper::DEPRECATED_SOURCES_KEY] as $key) {
+            /** @var mixed $list */
+            $list = $payload[$key] ?? null;
+            if (!\is_array($list)) {
+                continue;
+            }
+            /** @var mixed $entry */
+            foreach ($list as $entry) {
+                /** @psalm-suppress MixedAssignment entries are normalised downstream */
+                $out[] = $entry;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Normalise existing `sources[]` content into a list of arrays. We
      * keep the loaded shape verbatim — re-parsing through the mapper
      * would be redundant since the file was already validated when it
      * was written.
@@ -267,7 +300,7 @@ final readonly class SkillsJsonWriter
     }
 
     /**
-     * Sort `remote[]` by composite key so diffs are stable across
+     * Sort `sources[]` by composite key so diffs are stable across
      * adds. Two entries that share a composite key would have been
      * collapsed by {@see self::upsertByCompositeKey()}; here we just
      * need a deterministic ordering.
@@ -380,38 +413,5 @@ final readonly class SkillsJsonWriter
             throw new \RuntimeException('failed to encode skills.json payload');
         }
         return $json . "\n";
-    }
-
-    /**
-     * Write the content into a sibling temp file then rename into
-     * place. The rename is atomic on most filesystems (POSIX + NTFS),
-     * so a reader can never see a half-written file.
-     *
-     * Windows quirk: {@see \rename()} refuses to overwrite an
-     * existing destination on Windows (returns false / triggers a
-     * warning), even though NTFS itself supports atomic replace via
-     * `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`. PHP's `rename` does
-     * not pass that flag. So when the destination already exists we
-     * unlink it first and retry; this opens a sub-millisecond window
-     * where the file is gone, but the alternative — failing every
-     * second `skills:add` — is worse. POSIX never enters the retry
-     * path because the initial rename overwrites cleanly.
-     */
-    private static function atomicWrite(string $filePath, string $content): void
-    {
-        $tmp = $filePath . '.' . \bin2hex(\random_bytes(4)) . '.tmp';
-        if (\file_put_contents($tmp, $content) === false) {
-            throw new \RuntimeException('failed to write temp skills.json at ' . $tmp);
-        }
-        if (@\rename($tmp, $filePath)) {
-            return;
-        }
-        // First rename failed. If the destination already exists, this
-        // is the Windows-overwrite case; unlink and retry once.
-        if (\file_exists($filePath) && @\unlink($filePath) && @\rename($tmp, $filePath)) {
-            return;
-        }
-        @\unlink($tmp);
-        throw new \RuntimeException('failed to rename temp skills.json into ' . $filePath);
     }
 }

--- a/src/Add/SkillsJsonWriter.php
+++ b/src/Add/SkillsJsonWriter.php
@@ -8,7 +8,7 @@ use Internal\Path;
 use LLM\Skills\Config\Mapper\ExternalProjectConfigLoader;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
 use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Filesystem\AtomicFileWriter;
 
 /**
@@ -48,7 +48,7 @@ final readonly class SkillsJsonWriter
      *
      * @throws \RuntimeException when the file cannot be written
      */
-    public function upsertSource(Path $projectRoot, RemoteEntry $entry): void
+    public function upsertSource(Path $projectRoot, SourceEntry $entry): void
     {
         /** @psalm-suppress ImpureMethodCall Path::join() is mutation-free */
         $filePath = (string) $projectRoot->join(ExternalProjectConfigLoader::FILE_NAME);
@@ -144,7 +144,7 @@ final readonly class SkillsJsonWriter
      *
      * @psalm-pure
      */
-    private static function upsertByCompositeKey(array $existing, RemoteEntry $new): array
+    private static function upsertByCompositeKey(array $existing, SourceEntry $new): array
     {
         $newKey = $new->compositeKey();
 
@@ -256,7 +256,7 @@ final readonly class SkillsJsonWriter
     /**
      * Render an entry with `skills` overridden by the supplied list
      * (used by the upsert path to honour the merge result without
-     * mutating the original {@see RemoteEntry}). `$skills === null`
+     * mutating the original {@see SourceEntry}). `$skills === null`
      * omits the field entirely.
      *
      * @param list<non-empty-string>|null $skills
@@ -265,7 +265,7 @@ final readonly class SkillsJsonWriter
      *
      * @psalm-pure
      */
-    private static function serialiseWithSkills(RemoteEntry $entry, ?array $skills): array
+    private static function serialiseWithSkills(SourceEntry $entry, ?array $skills): array
     {
         $out = self::serialise($entry);
         // serialise() already emitted `skills` from the entry; the
@@ -329,15 +329,15 @@ final readonly class SkillsJsonWriter
      * `package` or `url` → `ref` (if present) → `skills` (if present)
      * → extras.
      *
-     * @param RemoteEntry|array<string, mixed> $entry
+     * @param SourceEntry|array<string, mixed> $entry
      *
      * @return array<string, mixed>
      *
      * @psalm-pure
      */
-    private static function serialise(RemoteEntry|array $entry): array
+    private static function serialise(SourceEntry|array $entry): array
     {
-        if ($entry instanceof RemoteEntry) {
+        if ($entry instanceof SourceEntry) {
             $out = ['from' => $entry->from];
             if ($entry->host !== null) {
                 $out['host'] = $entry->host;
@@ -368,7 +368,7 @@ final readonly class SkillsJsonWriter
 
     /**
      * Composite key of an already-serialised entry. Mirrors
-     * {@see RemoteEntry::compositeKey()} but operates on the raw
+     * {@see SourceEntry::compositeKey()} but operates on the raw
      * map form so we never have to round-trip through the mapper.
      *
      * @param array<string, mixed> $entry

--- a/src/Composer/Command/Add.php
+++ b/src/Composer/Command/Add.php
@@ -8,7 +8,7 @@ use Composer\Command\BaseCommand;
 use Internal\Path;
 use LLM\Skills\Add\AddRunner;
 use LLM\Skills\Add\PostAddSync;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Console\AddCliDefinition;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
@@ -70,7 +70,7 @@ final class Add extends BaseCommand
             $projectRoot,
             $this->getIO(),
             $options,
-            static function (RemoteEntry $_entry, string $packageName) use (&$donorPackageName): void {
+            static function (SourceEntry $_entry, string $packageName) use (&$donorPackageName): void {
                 $donorPackageName = $packageName;
             },
         );

--- a/src/Composer/CommandProvider.php
+++ b/src/Composer/CommandProvider.php
@@ -18,7 +18,7 @@ use LLM\Skills\Composer\Command\Sync;
  * - {@see Sync}  — `skills:update`, the primary "copy skills into the project" command.
  * - {@see Show}  — `skills:show`, the read-only inspection counterpart.
  * - {@see Init}  — `skills:init`, bootstraps `skills.json` (and migrates legacy inline keys).
- * - {@see Add}   — `skills:add`, registers a remote donor (currently GitHub) and fetches
+ * - {@see Add}   — `skills:add`, registers a donor source (currently GitHub) and fetches
  *                  its skills immediately. The standalone `bin/skills` binary mirrors all
  *                  four under short names (`update` / `show` / `init` / `add`).
  *

--- a/src/Config/Mapper/ExternalProjectConfigLoader.php
+++ b/src/Config/Mapper/ExternalProjectConfigLoader.php
@@ -55,6 +55,7 @@ final readonly class ExternalProjectConfigLoader
         'auto-sync',
         'path-from-root',
         'local',
+        'sources',
         'remote',
     ];
 

--- a/src/Config/Mapper/MappedSkillsBlock.php
+++ b/src/Config/Mapper/MappedSkillsBlock.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+use LLM\Skills\Config\ProjectConfig;
+
+/**
+ * Internal result of {@see ProjectConfigMapper::mapSkillsBlock()}: the
+ * mapped {@see ProjectConfig} plus a flag recording whether the block
+ * declared its donor sources under the deprecated `remote` key rather
+ * than `sources`. The mapper is shared by the external `skills.json`
+ * and inline `extra.skills` paths; bundling the flag lets both surface
+ * the deprecation upward without widening the public `fromExtra()`
+ * signature.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class MappedSkillsBlock
+{
+    /**
+     * @param bool $usedDeprecatedSourcesKey true when the block used `remote`
+     *        instead of `sources`
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public ProjectConfig $config,
+        public bool $usedDeprecatedSourcesKey,
+    ) {}
+}

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -42,10 +42,24 @@ use LLM\Skills\Discovery\Provider\ProviderId;
 final readonly class ProjectConfigMapper
 {
     /**
+     * Canonical key for the list of explicit donor sources.
+     */
+    public const SOURCES_KEY = 'sources';
+
+    /**
+     * Deprecated alias of {@see self::SOURCES_KEY}, still read everywhere
+     * project config is read and auto-migrated by write-mode commands.
+     */
+    public const DEPRECATED_SOURCES_KEY = 'remote';
+
+    /**
      * Project-level keys understood under `extra.skills`. Donor-side
      * keys (`source`) are deliberately excluded — they describe the
      * package as a donor, not as a consumer, and must not be flagged
      * as "shadowed" when `skills.json` is in effect.
+     *
+     * The deprecated `remote` alias stays in the list so a shadowed
+     * inline block still reports it and inline migration can extract it.
      *
      * @var list<non-empty-string>
      */
@@ -58,7 +72,8 @@ final readonly class ProjectConfigMapper
         'auto-sync',
         'path-from-root',
         'local',
-        'remote',
+        self::SOURCES_KEY,
+        self::DEPRECATED_SOURCES_KEY,
     ];
 
     /**
@@ -86,13 +101,18 @@ final readonly class ProjectConfigMapper
     {
         $external = $this->externalLoader->load($projectRoot);
         if ($external !== null) {
-            $config = $this->mapSkillsBlock($external, 'skills.json');
+            $mapped = $this->mapSkillsBlock($external, 'skills.json');
             $ignored = $this->collectIgnoredInlineKeys($extra);
 
-            return new ProjectConfigResolution($config, $ignored);
+            return new ProjectConfigResolution($mapped->config, $ignored, $mapped->usedDeprecatedSourcesKey);
         }
 
-        return new ProjectConfigResolution($this->fromExtra($extra));
+        $mapped = $this->mapExtra($extra);
+
+        return new ProjectConfigResolution(
+            $mapped->config,
+            usedDeprecatedSourcesKey: $mapped->usedDeprecatedSourcesKey,
+        );
     }
 
     /**
@@ -109,23 +129,7 @@ final readonly class ProjectConfigMapper
      */
     public function fromExtra(mixed $extra): ProjectConfig
     {
-        if ($extra === null || $extra === []) {
-            return ProjectConfig::default();
-        }
-
-        if (!\is_array($extra)) {
-            throw new MalformedProjectConfig('Root extra must be an object');
-        }
-
-        $skills = $extra['skills'] ?? null;
-        if ($skills === null) {
-            return ProjectConfig::default();
-        }
-        if (!\is_array($skills)) {
-            throw new MalformedProjectConfig('extra.skills must be an object');
-        }
-
-        return $this->mapSkillsBlock($skills, 'extra.skills');
+        return $this->mapExtra($extra)->config;
     }
 
     /**
@@ -270,6 +274,38 @@ final readonly class ProjectConfigMapper
     }
 
     /**
+     * Map an inline `extra` array, keeping the deprecation flag that
+     * {@see self::fromExtra()} discards for back-compat. Shared by
+     * {@see self::forProject()}'s inline branch.
+     *
+     * @param mixed $extra raw value of root `composer.json` `extra` field
+     *
+     * @throws MalformedProjectConfig when `extra.skills` is present but invalid
+     *
+     * @psalm-mutation-free
+     */
+    private function mapExtra(mixed $extra): MappedSkillsBlock
+    {
+        if ($extra === null || $extra === []) {
+            return new MappedSkillsBlock(ProjectConfig::default(), false);
+        }
+
+        if (!\is_array($extra)) {
+            throw new MalformedProjectConfig('Root extra must be an object');
+        }
+
+        $skills = $extra['skills'] ?? null;
+        if ($skills === null) {
+            return new MappedSkillsBlock(ProjectConfig::default(), false);
+        }
+        if (!\is_array($skills)) {
+            throw new MalformedProjectConfig('extra.skills must be an object');
+        }
+
+        return $this->mapSkillsBlock($skills, 'extra.skills');
+    }
+
+    /**
      * Per-field validator shared by both inline and external sources.
      * `$prefix` is woven into error messages so the user knows where
      * to look (`extra.skills.target` vs `skills.json: target`).
@@ -281,7 +317,7 @@ final readonly class ProjectConfigMapper
      *
      * @psalm-mutation-free
      */
-    private function mapSkillsBlock(array $skills, string $prefix): ProjectConfig
+    private function mapSkillsBlock(array $skills, string $prefix): MappedSkillsBlock
     {
         $target = $skills['target'] ?? ProjectConfig::DEFAULT_TARGET;
         if (!\is_string($target) || $target === '') {
@@ -318,9 +354,25 @@ final readonly class ProjectConfigMapper
         $pathFromRoot = $this->mapPathFromRoot($skills['path-from-root'] ?? null, $prefix);
 
         $local = $this->mapLocal($skills['local'] ?? [], $prefix);
-        $remote = $this->mapRemote($skills['remote'] ?? [], $prefix);
 
-        return new ProjectConfig(
+        // `sources` is canonical; `remote` is the deprecated alias feeding
+        // the same validator. Both keys in one block is fatal — the file
+        // is ours and strict, so there is no merge or precedence rule.
+        $hasSources = \array_key_exists(self::SOURCES_KEY, $skills);
+        $usedDeprecatedSourcesKey = \array_key_exists(self::DEPRECATED_SOURCES_KEY, $skills);
+        if ($hasSources && $usedDeprecatedSourcesKey) {
+            throw new MalformedProjectConfig(\sprintf(
+                '%s: both "%s" and "%s" are present; keep "%s" only',
+                $prefix,
+                self::SOURCES_KEY,
+                self::DEPRECATED_SOURCES_KEY,
+                self::SOURCES_KEY,
+            ));
+        }
+        $sourcesKey = $usedDeprecatedSourcesKey ? self::DEPRECATED_SOURCES_KEY : self::SOURCES_KEY;
+        $remote = $this->mapRemote($skills[$sourcesKey] ?? [], $prefix, $sourcesKey);
+
+        $config = new ProjectConfig(
             target: $target,
             trusted: $trusted,
             trustedReplace: $replace,
@@ -331,6 +383,8 @@ final readonly class ProjectConfigMapper
             local: $local,
             remote: $remote,
         );
+
+        return new MappedSkillsBlock($config, $usedDeprecatedSourcesKey);
     }
 
     /**
@@ -449,6 +503,9 @@ final readonly class ProjectConfigMapper
      * caller does not have to.
      *
      * @param non-empty-string $prefix
+     * @param non-empty-string $key config key the list was read from (`sources` or its
+     *        deprecated `remote` alias), woven into error messages so the user sees the
+     *        key they actually wrote
      *
      * @return list<RemoteEntry>
      *
@@ -456,14 +513,14 @@ final readonly class ProjectConfigMapper
      *
      * @psalm-mutation-free
      */
-    private function mapRemote(mixed $raw, string $prefix): array
+    private function mapRemote(mixed $raw, string $prefix, string $key): array
     {
         if ($raw === [] || $raw === null) {
             return [];
         }
         if (!\is_array($raw) || !\array_is_list($raw)) {
             throw new MalformedProjectConfig(
-                self::field($prefix, 'remote') . ' must be a list of objects',
+                self::field($prefix, $key) . ' must be a list of objects',
             );
         }
 
@@ -474,18 +531,18 @@ final readonly class ProjectConfigMapper
          * @var mixed $entry
          */
         foreach ($raw as $index => $entry) {
-            $parsed = $this->mapRemoteEntry($entry, $prefix, $index);
+            $parsed = $this->mapRemoteEntry($entry, $prefix, $key, $index);
 
-            $key = $parsed->compositeKey();
-            if (isset($seen[$key])) {
+            $compositeKey = $parsed->compositeKey();
+            if (isset($seen[$compositeKey])) {
                 throw new MalformedProjectConfig(\sprintf(
                     '%s[%d] duplicates an earlier entry (composite key: %s)',
-                    self::field($prefix, 'remote'),
+                    self::field($prefix, $key),
                     $index,
-                    $key,
+                    $compositeKey,
                 ));
             }
-            $seen[$key] = true;
+            $seen[$compositeKey] = true;
             $out[] = $parsed;
         }
 
@@ -494,14 +551,16 @@ final readonly class ProjectConfigMapper
 
     /**
      * @param non-empty-string $prefix
+     * @param non-empty-string $key config key the entry was read from (`sources` or its
+     *        deprecated `remote` alias)
      *
      * @throws MalformedProjectConfig
      *
      * @psalm-pure
      */
-    private function mapRemoteEntry(mixed $entry, string $prefix, int $index): RemoteEntry
+    private function mapRemoteEntry(mixed $entry, string $prefix, string $key, int $index): RemoteEntry
     {
-        $field = self::field($prefix, 'remote') . '[' . $index . ']';
+        $field = self::field($prefix, $key) . '[' . $index . ']';
 
         if (!\is_array($entry) || \array_is_list($entry)) {
             throw new MalformedProjectConfig($field . ' must be an object');

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -575,7 +575,7 @@ final readonly class ProjectConfigMapper
         }
         if (!ProviderId::isKnownRemote($rawFrom)) {
             throw new MalformedProjectConfig(\sprintf(
-                '%s.from "%s" is not a known remote adapter (known: %s)',
+                '%s.from "%s" is not a known source adapter (known: %s)',
                 $field,
                 $rawFrom,
                 \implode(', ', ProviderId::REMOTE_IDS),

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -8,7 +8,7 @@ use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\ProjectConfigResolution;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorPattern;
 use LLM\Skills\Discovery\Provider\ProviderId;
@@ -168,7 +168,7 @@ final readonly class ProjectConfigMapper
      * Read an optional string field that must be non-empty when present.
      * Returns null when the key is absent.
      *
-     * @param non-empty-string $field path prefix for error messages, e.g. `skills.json: remote[0]`
+     * @param non-empty-string $field path prefix for error messages, e.g. `skills.json: sources[0]`
      * @param non-empty-string $name field name inside the entry
      *
      * @return non-empty-string|null
@@ -191,7 +191,7 @@ final readonly class ProjectConfigMapper
     }
 
     /**
-     * Pick adapter-specific extras out of a `remote[]` entry — anything
+     * Pick adapter-specific extras out of a `sources[]` entry — anything
      * that is not one of the well-known keys (`from`, `package`, `url`,
      * `host`, `ref`). Stored verbatim so adapters can read their own
      * keys (`sha256` on `zip`, custom proxy options on `go`, …) without
@@ -230,7 +230,7 @@ final readonly class ProjectConfigMapper
     }
 
     /**
-     * Parse the optional `remote[].skills` allowlist. Three states:
+     * Parse the optional `sources[].skills` allowlist. Three states:
      *
      * - absent / `null` → no filter, every skill is synced (default);
      * - non-empty list → only the listed skills are synced;
@@ -247,7 +247,7 @@ final readonly class ProjectConfigMapper
      *
      * @psalm-pure
      */
-    private static function mapRemoteSkills(mixed $raw, string $field): ?array
+    private static function mapSourceSkills(mixed $raw, string $field): ?array
     {
         if ($raw === null) {
             return null;
@@ -370,7 +370,7 @@ final readonly class ProjectConfigMapper
             ));
         }
         $sourcesKey = $usedDeprecatedSourcesKey ? self::DEPRECATED_SOURCES_KEY : self::SOURCES_KEY;
-        $remote = $this->mapRemote($skills[$sourcesKey] ?? [], $prefix, $sourcesKey);
+        $sources = $this->mapSources($skills[$sourcesKey] ?? [], $prefix, $sourcesKey);
 
         $config = new ProjectConfig(
             target: $target,
@@ -381,7 +381,7 @@ final readonly class ProjectConfigMapper
             autoSync: $autoSync,
             pathFromRoot: $pathFromRoot,
             local: $local,
-            remote: $remote,
+            sources: $sources,
         );
 
         return new MappedSkillsBlock($config, $usedDeprecatedSourcesKey);
@@ -495,7 +495,7 @@ final readonly class ProjectConfigMapper
     }
 
     /**
-     * Parse and validate the `remote[]` list. Each entry is structurally
+     * Parse and validate the `sources[]` list. Each entry is structurally
      * an object with a mandatory `from` (adapter id), exactly one of
      * `package` / `url`, and optional `host` / `ref` plus
      * adapter-specific extras. Composite uniqueness on
@@ -507,13 +507,13 @@ final readonly class ProjectConfigMapper
      *        deprecated `remote` alias), woven into error messages so the user sees the
      *        key they actually wrote
      *
-     * @return list<RemoteEntry>
+     * @return list<SourceEntry>
      *
      * @throws MalformedProjectConfig
      *
      * @psalm-mutation-free
      */
-    private function mapRemote(mixed $raw, string $prefix, string $key): array
+    private function mapSources(mixed $raw, string $prefix, string $key): array
     {
         if ($raw === [] || $raw === null) {
             return [];
@@ -531,7 +531,7 @@ final readonly class ProjectConfigMapper
          * @var mixed $entry
          */
         foreach ($raw as $index => $entry) {
-            $parsed = $this->mapRemoteEntry($entry, $prefix, $key, $index);
+            $parsed = $this->mapSourceEntry($entry, $prefix, $key, $index);
 
             $compositeKey = $parsed->compositeKey();
             if (isset($seen[$compositeKey])) {
@@ -558,7 +558,7 @@ final readonly class ProjectConfigMapper
      *
      * @psalm-pure
      */
-    private function mapRemoteEntry(mixed $entry, string $prefix, string $key, int $index): RemoteEntry
+    private function mapSourceEntry(mixed $entry, string $prefix, string $key, int $index): SourceEntry
     {
         $field = self::field($prefix, $key) . '[' . $index . ']';
 
@@ -618,11 +618,11 @@ final readonly class ProjectConfigMapper
             }
         }
 
-        $skills = self::mapRemoteSkills($entry['skills'] ?? null, $field);
+        $skills = self::mapSourceSkills($entry['skills'] ?? null, $field);
 
         $extras = self::collectExtras($entry);
 
-        return new RemoteEntry(
+        return new SourceEntry(
             from: $from,
             package: $package,
             url: $url,

--- a/src/Config/Mapper/ProjectConfigMigrator.php
+++ b/src/Config/Mapper/ProjectConfigMigrator.php
@@ -8,6 +8,7 @@ use Composer\IO\IOInterface;
 use Composer\Json\JsonManipulator;
 use Internal\Path;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Filesystem\AtomicFileWriter;
 
 /**
  * Moves a project's legacy inline `extra.skills` block out of
@@ -75,8 +76,12 @@ final readonly class ProjectConfigMigrator
 
     /**
      * Pull the project-level keys out of an inline `extra.skills`
-     * block, in canonical order. Donor `source` and any unrelated
-     * keys are deliberately dropped.
+     * block, in canonical order, as they should be written into
+     * `skills.json`. Donor `source` and any unrelated keys are
+     * deliberately dropped, and a deprecated `remote` value is folded
+     * into the canonical `sources` key so the written file never
+     * carries the alias. A block with both keys is rejected pre-flight
+     * by the mapper, so at most one of the pair is present here.
      *
      * @param array<array-key, mixed> $skills the inline `extra.skills` value
      *
@@ -88,9 +93,48 @@ final readonly class ProjectConfigMigrator
     {
         $out = [];
         foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            // The alias never lands in the output under its own name;
+            // its value is picked up when the canonical key is visited.
+            if ($key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY) {
+                continue;
+            }
             if (\array_key_exists($key, $skills)) {
                 /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
                 $out[$key] = $skills[$key];
+                continue;
+            }
+            if (
+                $key === ProjectConfigMapper::SOURCES_KEY
+                && \array_key_exists(ProjectConfigMapper::DEPRECATED_SOURCES_KEY, $skills)
+            ) {
+                /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
+                $out[$key] = $skills[ProjectConfigMapper::DEPRECATED_SOURCES_KEY];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * List the project-level keys physically present in an inline
+     * `extra.skills` block, in canonical order and under their
+     * original names (the deprecated `remote` alias is reported as
+     * `remote`). Callers use this to strip the exact keys from
+     * `composer.json`, which {@see self::extractProjectKeys()} cannot
+     * provide because it rewrites the alias to `sources`.
+     *
+     * @param array<array-key, mixed> $skills the inline `extra.skills` value
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-pure
+     */
+    public static function presentProjectKeys(array $skills): array
+    {
+        $out = [];
+        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                $out[] = $key;
             }
         }
 
@@ -152,8 +196,13 @@ final readonly class ProjectConfigMigrator
         /** @var array<string, mixed> $skills */
         $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
 
+        // Keys as written to skills.json (alias folded into `sources`)
+        // versus keys as they physically sit in composer.json (used to
+        // strip the originals). The two diverge only for a `remote`
+        // block.
         $migrated = self::extractProjectKeys($skills);
-        if ($migrated === []) {
+        $presentKeys = self::presentProjectKeys($skills);
+        if ($presentKeys === []) {
             // composer.json exists but carries no inline project keys
             // (maybe just a donor `source`, or no skills block at all).
             // Nothing to migrate — and we deliberately do NOT auto-create
@@ -187,7 +236,7 @@ final readonly class ProjectConfigMigrator
         }
 
         $manipulator = new JsonManipulator($original);
-        foreach (\array_keys($migrated) as $key) {
+        foreach ($presentKeys as $key) {
             if (!$manipulator->removeSubNode('extra', 'skills.' . $key)) {
                 $io->writeError(\sprintf(
                     '<error>[llm/skills] failed to remove extra.skills.%s from composer.json '
@@ -204,7 +253,7 @@ final readonly class ProjectConfigMigrator
         // `extra` itself when it becomes empty (the user might not have
         // anything else under it). Donor-side `source` and any other
         // unrelated `extra.skills` keys keep both nodes alive.
-        $remaining = \array_diff(\array_keys($skills), \array_keys($migrated));
+        $remaining = \array_diff(\array_keys($skills), $presentKeys);
         if ($remaining === []) {
             $manipulator->removeSubNode('extra', 'skills');
             $manipulator->removeMainKeyIfEmpty('extra');
@@ -219,5 +268,94 @@ final readonly class ProjectConfigMigrator
         }
 
         return MigrationResult::migrated(\array_keys($migrated));
+    }
+
+    /**
+     * Rename the deprecated `remote` key to `sources` in an existing
+     * `skills.json`, in place. Returns:
+     *
+     * - {@see MigrationStatus::Skipped} when there is no `skills.json`,
+     *   when it already uses `sources` (or uses neither key), or when
+     *   it carries BOTH keys — the last case is left untouched so the
+     *   mapper's fatal "both present" error stands rather than the
+     *   migration guessing which list wins. Malformed JSON is also
+     *   skipped, letting {@see ExternalProjectConfigLoader} surface the
+     *   precise parse error during mapping.
+     * - {@see MigrationStatus::Migrated} after rewriting the file with
+     *   the key renamed, every other key and its position preserved.
+     * - {@see MigrationStatus::Failed} when the file exists but a read,
+     *   encode, or write step errored out (message already on `$io`).
+     */
+    public function renameSourcesKey(Path $projectRoot, IOInterface $io): MigrationResult
+    {
+        $skillsJsonPath = (string) $projectRoot->join(ExternalProjectConfigLoader::FILE_NAME);
+        if (!\is_file($skillsJsonPath)) {
+            return MigrationResult::skipped();
+        }
+
+        $original = \file_get_contents($skillsJsonPath);
+        if ($original === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to read skills.json at %s</error>',
+                $skillsJsonPath,
+            ));
+            return MigrationResult::failed();
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($original, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return MigrationResult::skipped();
+        }
+
+        if (!\is_array($decoded)) {
+            return MigrationResult::skipped();
+        }
+
+        $hasDeprecated = \array_key_exists(ProjectConfigMapper::DEPRECATED_SOURCES_KEY, $decoded);
+        $hasCanonical = \array_key_exists(ProjectConfigMapper::SOURCES_KEY, $decoded);
+        if (!$hasDeprecated || $hasCanonical) {
+            return MigrationResult::skipped();
+        }
+
+        // Rebuild the map so the renamed key keeps its original slot and
+        // every sibling key stays verbatim.
+        $rebuilt = [];
+        /** @var mixed $value */
+        foreach ($decoded as $key => $value) {
+            $target = $key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY
+                ? ProjectConfigMapper::SOURCES_KEY
+                : $key;
+            /** @psalm-suppress MixedAssignment value type is validated later by the mapper */
+            $rebuilt[$target] = $value;
+        }
+
+        $json = \json_encode(
+            $rebuilt,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+        );
+        if ($json === false) {
+            $io->writeError('<error>[llm/skills] failed to encode skills.json during key rename</error>');
+            return MigrationResult::failed();
+        }
+
+        try {
+            AtomicFileWriter::write($skillsJsonPath, $json . "\n");
+        } catch (\RuntimeException $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to write skills.json during key rename: %s</error>',
+                $e->getMessage(),
+            ));
+            return MigrationResult::failed();
+        }
+
+        $io->write(\sprintf(
+            '<info>[migrate]</info> renamed "%s" to "%s" in skills.json',
+            ProjectConfigMapper::DEPRECATED_SOURCES_KEY,
+            ProjectConfigMapper::SOURCES_KEY,
+        ));
+
+        return MigrationResult::migrated([ProjectConfigMapper::SOURCES_KEY]);
     }
 }

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -53,7 +53,7 @@ final readonly class ProjectConfig
      *         fall back to {@see ProviderId::defaultLocalEnabled()} — `composer` defaults to
      *         enabled (preserves the pre-`local` behaviour), every other id defaults to off
      *         so a new provider stays opt-in until its implementation lands.
-     * @param list<RemoteEntry> $remote remote donor refs declared by the project. The remote
+     * @param list<SourceEntry> $sources donor sources declared by the project. The remote
      *         provider treats each entry as an explicit fetch target. Empty list means
      *         the remote provider stays inactive — symmetric with `local.composer == false`.
      *
@@ -68,7 +68,7 @@ final readonly class ProjectConfig
         public bool $autoSync = true,
         public ?string $pathFromRoot = null,
         public array $local = [],
-        public array $remote = [],
+        public array $sources = [],
     ) {}
 
     /**
@@ -88,7 +88,7 @@ final readonly class ProjectConfig
             autoSync: true,
             pathFromRoot: null,
             local: [],
-            remote: [],
+            sources: [],
         );
     }
 
@@ -125,7 +125,7 @@ final readonly class ProjectConfig
             $this->autoSync,
             $this->pathFromRoot,
             $this->local,
-            $this->remote,
+            $this->sources,
         );
     }
 
@@ -145,7 +145,7 @@ final readonly class ProjectConfig
             $this->autoSync,
             $this->pathFromRoot,
             $this->local,
-            $this->remote,
+            $this->sources,
         );
     }
 }

--- a/src/Config/ProjectConfigResolution.php
+++ b/src/Config/ProjectConfigResolution.php
@@ -22,11 +22,16 @@ final readonly class ProjectConfigResolution
      *        present under `extra.skills` in `composer.json` that were shadowed
      *        by a `skills.json` at the project root. Always empty when the
      *        inline block was used as the source of truth.
+     * @param bool $usedDeprecatedSourcesKey true when the winning config block declared
+     *        its donor sources under the deprecated `remote` key instead of `sources`.
+     *        Callers surface a deprecation notice; write-mode callers migrate the file
+     *        before mapping, so they never observe it set.
      *
      * @psalm-mutation-free
      */
     public function __construct(
         public ProjectConfig $config,
         public array $ignoredInlineKeys = [],
+        public bool $usedDeprecatedSourcesKey = false,
     ) {}
 }

--- a/src/Config/SourceEntry.php
+++ b/src/Config/SourceEntry.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Config;
 
 /**
- * One entry of the `remote[]` list in `skills.json`.
+ * One entry of the `sources[]` list in `skills.json`.
  *
  * Each entry tells the remote provider what to fetch and where from:
  * `from` is the adapter id (a value from {@see \LLM\Skills\Discovery\Provider\ProviderId}),
@@ -21,7 +21,7 @@ namespace LLM\Skills\Config;
  *
  * @psalm-immutable
  */
-final readonly class RemoteEntry
+final readonly class SourceEntry
 {
     /**
      * @param non-empty-string $from adapter id, e.g. {@see \LLM\Skills\Discovery\Provider\ProviderId::GITHUB}
@@ -69,7 +69,7 @@ final readonly class RemoteEntry
         $hasUrl = $url !== null;
         if ($hasPackage === $hasUrl) {
             throw new \InvalidArgumentException(
-                'RemoteEntry requires exactly one of $package or $url to be non-null; got '
+                'SourceEntry requires exactly one of $package or $url to be non-null; got '
                 . ($hasPackage ? 'both set' : 'neither set'),
             );
         }
@@ -84,7 +84,7 @@ final readonly class RemoteEntry
             foreach ($skills as $name) {
                 if (!\is_string($name) || $name === '') {
                     throw new \InvalidArgumentException(
-                        'RemoteEntry $skills must be a list of non-empty strings.',
+                        'SourceEntry $skills must be a list of non-empty strings.',
                     );
                 }
             }

--- a/src/Config/SyncOptions.php
+++ b/src/Config/SyncOptions.php
@@ -34,7 +34,7 @@ final readonly class SyncOptions
      * @param non-empty-string|null $fromFilter `--from=<id>` scope. When set,
      *         the runner keeps only donors whose {@see VendorConfig::$provenance} matches
      *         this id. The vocabulary is shared with `skills.json` `local.{id}` and
-     *         `remote[].from`.
+     *         `sources[].from`.
      *
      * @psalm-mutation-free
      */

--- a/src/Config/TrustedVendorRegistry.php
+++ b/src/Config/TrustedVendorRegistry.php
@@ -20,7 +20,7 @@ use LLM\Skills\Info;
  *
  * The trust files apply only to **local-provider transitive
  * discoveries**. Direct deps are implicit-trusted because the user
- * typed them; entries in `remote[]` are likewise implicit-trusted as
+ * typed them; entries in `sources[]` are likewise implicit-trusted as
  * explicit, typed-by-the-user signals of intent.
  *
  * Not annotated `@psalm-immutable`: the loader does filesystem IO.

--- a/src/Config/VendorConfig.php
+++ b/src/Config/VendorConfig.php
@@ -33,7 +33,7 @@ final readonly class VendorConfig
      *         `skills:update --from=<id>` to filter the donor list.
      * @param bool $implicitTrust the user explicitly declared this donor — the trust
      *         list is not consulted. Set by {@see \LLM\Skills\Discovery\Provider\Remote\RemoteProvider}
-     *         for every `remote[]` entry, regardless of `from` value. Local providers
+     *         for every `sources[]` entry, regardless of `from` value. Local providers
      *         keep this `false` and let {@see \LLM\Skills\Sync\SyncPlanner} run the
      *         per-registry trust check.
      * @param list<non-empty-string>|null $skillFilter optional allowlist of skill
@@ -97,7 +97,7 @@ final readonly class VendorConfig
 
     /**
      * Return a copy of this donor flagged as implicit-trusted. The
-     * `remote[]` provider calls this on every donor it produces so
+     * `sources[]` provider calls this on every donor it produces so
      * the planner does not consult the trust list for them
      * (user-declared = trusted).
      *

--- a/src/Console/AddCliDefinition.php
+++ b/src/Console/AddCliDefinition.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Input\InputOption;
  */
 final class AddCliDefinition
 {
-    private const DESCRIPTION = 'Register a remote donor in skills.json and fetch its skills.';
+    private const DESCRIPTION = 'Register a donor source in skills.json and fetch its skills.';
 
     /**
      * @param non-empty-string $name

--- a/src/Console/Command/Add.php
+++ b/src/Console/Command/Add.php
@@ -11,7 +11,7 @@ use Composer\IO\NullIO;
 use Internal\Path;
 use LLM\Skills\Add\AddRunner;
 use LLM\Skills\Add\PostAddSync;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Console\AddCliDefinition;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
@@ -85,7 +85,7 @@ final class Add extends Command
             $projectRoot,
             $io,
             $options,
-            static function (RemoteEntry $_entry, string $packageName) use (&$donorPackageName): void {
+            static function (SourceEntry $_entry, string $packageName) use (&$donorPackageName): void {
                 $donorPackageName = $packageName;
             },
         );

--- a/src/Console/Command/Add.php
+++ b/src/Console/Command/Add.php
@@ -35,7 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * {@see Factory::createConfig()}, the cache lives under
  * `<cwd>/vendor/llm-skills/cache` (the default layout), and the new
  * entry is upserted into `<cwd>/skills.json`. Composer-local donors
- * stay inactive in that mode — only the just-added remote donor
+ * stay inactive in that mode — only the just-added donor source
  * syncs, which is exactly what a `skills:add` invocation means.
  *
  * @internal
@@ -97,7 +97,7 @@ final class Add extends Command
         // Without a Composer instance there is no root package to read an
         // `extra` from — PostAddSync falls through with `null`, which the
         // mapper treats the same as an empty `extra.skills` block. Only
-        // the just-registered remote donor will sync.
+        // the just-registered donor source will sync.
         return PostAddSync::run($projectRoot, $composer, $io, $donorPackageName);
     }
 

--- a/src/Console/SyncCliDefinition.php
+++ b/src/Console/SyncCliDefinition.php
@@ -91,7 +91,7 @@ final class SyncCliDefinition
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Scope the sync to donors from a single provider. The id matches '
-                . 'skills.json local.{id} keys (e.g. "composer") and remote[].from values '
+                . 'skills.json local.{id} keys (e.g. "composer") and sources[].from values '
                 . '(e.g. "github"). Without this flag, all active providers contribute.',
             );
     }

--- a/src/Discovery/Provider/CompositeDonorProvider.php
+++ b/src/Discovery/Provider/CompositeDonorProvider.php
@@ -15,7 +15,7 @@ use LLM\Skills\Discovery\MalformedDonor;
  * Children are queried in **declaration order**; on duplicate
  * `packageName` collisions the later child wins (the displaced earlier
  * entry is reported as a `-v` warning). Wire the composite with locals
- * first and remote last so an explicit `remote[]` entry naturally
+ * first and remote last so an explicit `sources[]` entry naturally
  * overrides a transitive local discovery of the same package name.
  *
  * `isActive()` is the OR of all children. `directDependencies()` is the

--- a/src/Discovery/Provider/DonorProviderBuilder.php
+++ b/src/Discovery/Provider/DonorProviderBuilder.php
@@ -36,9 +36,9 @@ use LLM\Skills\Discovery\Provider\Remote\SkillsJsonRemoteDonorSource;
  *     toggle. Inactive when no Composer instance is supplied or when
  *     the toggle is `false`.
  *  2. **`RemoteProvider`** — wired with a {@see SkillsJsonRemoteDonorSource}
- *     (reads `remote[]` from `skills.json`) and a {@see HttpArchiveFetcher}
+ *     (reads `sources[]` from `skills.json`) and a {@see HttpArchiveFetcher}
  *     (downloads + extracts archives into `vendor/llm-skills/cache/...`).
- *     Inactive when `remote[]` is empty.
+ *     Inactive when `sources[]` is empty.
  *
  * Remote is wired LAST so the composite's "later-wins" semantic
  * makes explicit remote entries override transitive local discoveries

--- a/src/Discovery/Provider/ProviderId.php
+++ b/src/Discovery/Provider/ProviderId.php
@@ -11,7 +11,7 @@ namespace LLM\Skills\Discovery\Provider;
  *
  * - `skills.json` `local: { <id>: bool }` keys — which local providers
  *   are enabled in the current project.
- * - `skills.json` `remote[].from` values — which source adapter resolves
+ * - `skills.json` `sources[].from` values — which source adapter resolves
  *   a given remote entry.
  * - The `--from=<id>` CLI flag on `skills:update` (Phase 5).
  *
@@ -47,7 +47,7 @@ final class ProviderId
     ];
 
     /**
-     * Identifiers that may appear as `from` values inside `remote[]`.
+     * Identifiers that may appear as `from` values inside `sources[]`.
      * Larger than {@see LOCAL_IDS} because remote adapters cover both
      * VCS hosts (no local manifest) and package registries.
      *

--- a/src/Discovery/Provider/Remote/Adapter/GithubAdapter.php
+++ b/src/Discovery/Provider/Remote/Adapter/GithubAdapter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpClient;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpException;
@@ -173,7 +173,7 @@ final readonly class GithubAdapter implements HostAdapter
     }
 
     #[\Override]
-    public function resolve(RemoteEntry $entry): RemoteDonorRef
+    public function resolve(SourceEntry $entry): RemoteDonorRef
     {
         if ($entry->from !== self::ID) {
             throw new RemoteResolveException(
@@ -248,7 +248,7 @@ final readonly class GithubAdapter implements HostAdapter
      * @param non-empty-string $apiBase
      * @param non-empty-string $package owner/repo
      */
-    private function resolveCascade(RemoteEntry $entry, string $apiBase, string $package): RemoteDonorRef
+    private function resolveCascade(SourceEntry $entry, string $apiBase, string $package): RemoteDonorRef
     {
         $tags = $this->listTags($entry, $apiBase, $package);
 
@@ -281,7 +281,7 @@ final readonly class GithubAdapter implements HostAdapter
      * @param non-empty-string $constraint
      */
     private function resolveCaret(
-        RemoteEntry $entry,
+        SourceEntry $entry,
         string $apiBase,
         string $package,
         string $constraint,
@@ -310,7 +310,7 @@ final readonly class GithubAdapter implements HostAdapter
      *
      * @return list<non-empty-string>
      */
-    private function listTags(RemoteEntry $entry, string $apiBase, string $package): array
+    private function listTags(SourceEntry $entry, string $apiBase, string $package): array
     {
         $url = \sprintf('%s/repos/%s/tags?per_page=%d', $apiBase, $package, self::TAGS_PER_PAGE);
         $response = $this->getOrThrow($entry, $url);
@@ -344,7 +344,7 @@ final readonly class GithubAdapter implements HostAdapter
      *
      * @return non-empty-string
      */
-    private function getDefaultBranch(RemoteEntry $entry, string $apiBase, string $package): string
+    private function getDefaultBranch(SourceEntry $entry, string $apiBase, string $package): string
     {
         $url = \sprintf('%s/repos/%s', $apiBase, $package);
         $response = $this->getOrThrow($entry, $url);
@@ -371,7 +371,7 @@ final readonly class GithubAdapter implements HostAdapter
      *
      * @param non-empty-string $url
      */
-    private function getOrThrow(RemoteEntry $entry, string $url): HttpResponse
+    private function getOrThrow(SourceEntry $entry, string $url): HttpResponse
     {
         try {
             $response = $this->http->get($url, [
@@ -396,7 +396,7 @@ final readonly class GithubAdapter implements HostAdapter
      *
      * @psalm-pure
      */
-    private function decodeJson(RemoteEntry $entry, HttpResponse $response, string $url): mixed
+    private function decodeJson(SourceEntry $entry, HttpResponse $response, string $url): mixed
     {
         try {
             /** @var mixed $decoded */

--- a/src/Discovery/Provider/Remote/Adapter/GitlabAdapter.php
+++ b/src/Discovery/Provider/Remote/Adapter/GitlabAdapter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpClient;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpException;
@@ -205,7 +205,7 @@ final readonly class GitlabAdapter implements HostAdapter
     }
 
     #[\Override]
-    public function resolve(RemoteEntry $entry): RemoteDonorRef
+    public function resolve(SourceEntry $entry): RemoteDonorRef
     {
         if ($entry->from !== self::ID) {
             throw new RemoteResolveException(
@@ -351,7 +351,7 @@ final readonly class GitlabAdapter implements HostAdapter
      *
      * @psalm-pure
      */
-    private static function authHint(RemoteEntry $entry): string
+    private static function authHint(SourceEntry $entry): string
     {
         $host = self::bareHost($entry->host);
         return \sprintf(
@@ -391,7 +391,7 @@ final readonly class GitlabAdapter implements HostAdapter
      * @param non-empty-string $apiBase
      * @param non-empty-string $package group/project
      */
-    private function resolveCascade(RemoteEntry $entry, string $apiBase, string $package): RemoteDonorRef
+    private function resolveCascade(SourceEntry $entry, string $apiBase, string $package): RemoteDonorRef
     {
         $tags = $this->listTags($entry, $apiBase, $package);
 
@@ -424,7 +424,7 @@ final readonly class GitlabAdapter implements HostAdapter
      * @param non-empty-string $constraint
      */
     private function resolveCaret(
-        RemoteEntry $entry,
+        SourceEntry $entry,
         string $apiBase,
         string $package,
         string $constraint,
@@ -453,7 +453,7 @@ final readonly class GitlabAdapter implements HostAdapter
      *
      * @return list<non-empty-string>
      */
-    private function listTags(RemoteEntry $entry, string $apiBase, string $package): array
+    private function listTags(SourceEntry $entry, string $apiBase, string $package): array
     {
         $url = \sprintf(
             '%s/projects/%s/repository/tags?per_page=%d',
@@ -492,7 +492,7 @@ final readonly class GitlabAdapter implements HostAdapter
      *
      * @return non-empty-string
      */
-    private function getDefaultBranch(RemoteEntry $entry, string $apiBase, string $package): string
+    private function getDefaultBranch(SourceEntry $entry, string $apiBase, string $package): string
     {
         $url = \sprintf('%s/projects/%s', $apiBase, self::projectId($package));
         $response = $this->getOrThrow($entry, $url);
@@ -519,7 +519,7 @@ final readonly class GitlabAdapter implements HostAdapter
      *
      * @param non-empty-string $url
      */
-    private function getOrThrow(RemoteEntry $entry, string $url): HttpResponse
+    private function getOrThrow(SourceEntry $entry, string $url): HttpResponse
     {
         try {
             $response = $this->http->get($url, [
@@ -556,7 +556,7 @@ final readonly class GitlabAdapter implements HostAdapter
      *
      * @psalm-pure
      */
-    private function decodeJson(RemoteEntry $entry, HttpResponse $response, string $url): mixed
+    private function decodeJson(SourceEntry $entry, HttpResponse $response, string $url): mixed
     {
         try {
             /** @var mixed $decoded */

--- a/src/Discovery/Provider/Remote/Adapter/HostAdapter.php
+++ b/src/Discovery/Provider/Remote/Adapter/HostAdapter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef;
 
 /**
@@ -13,7 +13,7 @@ use LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef;
  * One adapter per `from` value (see {@see \LLM\Skills\Discovery\Provider\ProviderId::REMOTE_IDS}).
  * Each adapter knows:
  *
- * - The id ({@see self::id()}) used in `skills.json` `remote[].from`
+ * - The id ({@see self::id()}) used in `skills.json` `sources[].from`
  *   and in the `--from=<id>` CLI flag.
  * - The default host URL ({@see self::defaultHost()}) used when an
  *   entry omits `host`.
@@ -47,7 +47,7 @@ interface HostAdapter
     public function id(): string;
 
     /**
-     * Default API/registry base URL when a `remote[]` entry omits
+     * Default API/registry base URL when a `sources[]` entry omits
      * `host`. For `github` this is `https://api.github.com`; for
      * `composer` it's the public Packagist URL; etc.
      *
@@ -59,7 +59,7 @@ interface HostAdapter
 
     /**
      * Parse `skills:add <input>` user input into a structured form
-     * the writer can turn into a `remote[]` entry.
+     * the writer can turn into a `sources[]` entry.
      *
      * The exact `$input` grammar is adapter-defined — `github`
      * accepts `owner/repo`, `https://github.com/owner/repo`, and
@@ -85,7 +85,7 @@ interface HostAdapter
     ): ParsedAddInput;
 
     /**
-     * Resolve a stored `remote[]` entry into a concrete
+     * Resolve a stored `sources[]` entry into a concrete
      * "what to download" descriptor.
      *
      * - When `$entry->ref` is an explicit tag / branch / SHA, the
@@ -107,5 +107,5 @@ interface HostAdapter
      *
      * @psalm-suppress MissingAbstractPureAnnotation
      */
-    public function resolve(RemoteEntry $entry): RemoteDonorRef;
+    public function resolve(SourceEntry $entry): RemoteDonorRef;
 }

--- a/src/Discovery/Provider/Remote/Adapter/HostAdapterRegistry.php
+++ b/src/Discovery/Provider/Remote/Adapter/HostAdapterRegistry.php
@@ -9,7 +9,7 @@ namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
  *
  * Two consumers go through this:
  *
- * - `SkillsJsonRemoteDonorSource` (Phase 3) — given a `remote[]`
+ * - `SkillsJsonRemoteDonorSource` (Phase 3) — given a `sources[]`
  *   entry, asks the registry for the adapter that knows how to
  *   `resolve()` it.
  * - `skills:add` CLI (Phase 4) — given `--from=<id>` (explicit) or

--- a/src/Discovery/Provider/Remote/Adapter/ParsedAddInput.php
+++ b/src/Discovery/Provider/Remote/Adapter/ParsedAddInput.php
@@ -8,7 +8,7 @@ namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
  * Output of {@see HostAdapter::parseAddInput()}.
  *
  * Carries the four fields that will land in `skills.json`'s
- * `remote[]` after `skills:add` runs:
+ * `sources[]` after `skills:add` runs:
  *
  * - `from`     — the adapter id (mandatory).
  * - `package`  — adapter-namespaced identifier (or `null` when
@@ -20,7 +20,7 @@ namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
  *                runs the ref cascade at sync time).
  *
  * Constructed by the adapter and consumed by the `skills:add` runner.
- * Kept separate from {@see \LLM\Skills\Config\RemoteEntry}
+ * Kept separate from {@see \LLM\Skills\Config\SourceEntry}
  * because the latter is the **stored** shape (carries adapter-specific
  * extras and is loaded by the mapper) while this is the **parsed-CLI**
  * shape that feeds the writer.

--- a/src/Discovery/Provider/Remote/Adapter/RemoteResolveException.php
+++ b/src/Discovery/Provider/Remote/Adapter/RemoteResolveException.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 
 /**
  * Raised when a {@see HostAdapter} cannot resolve a stored
- * `remote[]` entry into a fetchable {@see \LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef}.
+ * `sources[]` entry into a fetchable {@see \LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef}.
  *
  * Examples:
  *
@@ -32,7 +32,7 @@ final class RemoteResolveException extends \RuntimeException
      * @psalm-mutation-free
      */
     public function __construct(
-        public readonly RemoteEntry $entry,
+        public readonly SourceEntry $entry,
         string $reason,
         ?\Throwable $previous = null,
     ) {

--- a/src/Discovery/Provider/Remote/CachePathBuilder.php
+++ b/src/Discovery/Provider/Remote/CachePathBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Discovery\Provider\Remote;
 
 use Internal\Path;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 
 /**
  * Computes deterministic cache paths for fetched remote archives.
@@ -112,7 +112,7 @@ final readonly class CachePathBuilder
      *
      * @psalm-mutation-free
      */
-    public function buildForEntry(Path $projectRoot, RemoteEntry $entry, string $resolvedRef): Path
+    public function buildForEntry(Path $projectRoot, SourceEntry $entry, string $resolvedRef): Path
     {
         $fromSegment = self::encode($entry->from);
         $hostSegment = self::hostSegment($entry->host);
@@ -135,7 +135,7 @@ final readonly class CachePathBuilder
     /**
      * URL-only variant: cache key derived purely from a download URL
      * plus a ref label. Used by {@see HttpArchiveFetcher}, which only
-     * has the resolved fetch URL (the {@see RemoteEntry} stays with
+     * has the resolved fetch URL (the {@see SourceEntry} stays with
      * the source layer).
      *
      * Layout:

--- a/src/Discovery/Provider/Remote/HttpArchiveFetcher.php
+++ b/src/Discovery/Provider/Remote/HttpArchiveFetcher.php
@@ -248,7 +248,7 @@ final readonly class HttpArchiveFetcher implements RemoteFetcher
         string $scratch,
     ): string {
         // Zip-slip guard: validate every entry name BEFORE extraction.
-        // The archive comes from a user-configurable {@see RemoteEntry::$host}
+        // The archive comes from a user-configurable {@see SourceEntry::$host}
         // and a single rogue entry like `../../../etc/passwd` or
         // `/etc/passwd` would let the underlying extractor drop files
         // anywhere on disk. Reject anything that does not lexically

--- a/src/Discovery/Provider/Remote/RemoteDonorRef.php
+++ b/src/Discovery/Provider/Remote/RemoteDonorRef.php
@@ -32,7 +32,7 @@ final readonly class RemoteDonorRef
      *         (e.g. `github`). Used downstream as the donor's
      *         {@see \LLM\Skills\Config\VendorConfig::$provenance}, which drives
      *         the `--from` CLI filter. `null` means "unknown" — the provider
-     *         will tag the donor with a generic `remote` provenance.
+     *         will tag the donor with a generic `source` provenance.
      * @param list<non-empty-string>|null $skillFilter explicit allowlist of skill directory
      *         names to keep from the fetched donor. `null` means "no filter — sync every
      *         skill the donor ships". A non-null list is propagated into the resulting

--- a/src/Discovery/Provider/Remote/RemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/RemoteDonorSource.php
@@ -44,7 +44,7 @@ interface RemoteDonorSource
      * subsequently iterates the same source.
      *
      * Implementations should answer by inspecting their config surface
-     * directly (e.g. "does skills.json declare any `remote[]` entries"),
+     * directly (e.g. "does skills.json declare any `sources[]` entries"),
      * not by producing refs.
      *
      * @psalm-suppress MissingAbstractPureAnnotation

--- a/src/Discovery/Provider/Remote/RemoteProvider.php
+++ b/src/Discovery/Provider/Remote/RemoteProvider.php
@@ -90,7 +90,7 @@ final readonly class RemoteProvider implements DonorProvider
             try {
                 $path = $this->fetcher->fetch($ref);
             } catch (RemoteFetchException $e) {
-                $warnings[] = \sprintf('remote %s: %s', $ref->describe(), $e->getMessage());
+                $warnings[] = \sprintf('source %s: %s', $ref->describe(), $e->getMessage());
                 continue;
             }
 
@@ -168,7 +168,7 @@ final readonly class RemoteProvider implements DonorProvider
         $rejection = $inspection->rejection;
         if ($rejection !== null) {
             $warnings[] = \sprintf(
-                'remote %s: %s',
+                'source %s: %s',
                 $ref->describe(),
                 $this->describeRejection($rejection, $inspection->detail),
             );
@@ -220,7 +220,7 @@ final readonly class RemoteProvider implements DonorProvider
 
     /**
      * Phrase a {@see DonorArchiveRejection} for a per-ref sync warning.
-     * The inspector owns the *classification*; the `remote <ref>:`
+     * The inspector owns the *classification*; the `source <ref>:`
      * framing is added by the caller.
      *
      * @psalm-pure
@@ -251,7 +251,7 @@ final readonly class RemoteProvider implements DonorProvider
      */
     private function decorate(VendorConfig $donor, RemoteDonorRef $ref): VendorConfig
     {
-        $provenance = $ref->provenance ?? 'remote';
+        $provenance = $ref->provenance ?? 'source';
         // `remote[]` entries are user-declared and therefore
         // implicit-trusted, regardless of `from` value. The planner's
         // trust list applies to local-provider transitive discoveries

--- a/src/Discovery/Provider/Remote/RemoteProvider.php
+++ b/src/Discovery/Provider/Remote/RemoteProvider.php
@@ -119,7 +119,7 @@ final readonly class RemoteProvider implements DonorProvider
      * Remote refs are external donors, not Composer dependencies of
      * the consumer project, so the `directDependencies` channel
      * (rooted in Composer's `require` / `require-dev` semantics)
-     * does not apply. Implicit-trust for `remote[]` entries flows
+     * does not apply. Implicit-trust for `sources[]` entries flows
      * through {@see \LLM\Skills\Config\VendorConfig::$implicitTrust}
      * instead — set in {@see self::discover()} on every donor this
      * provider emits — which the planner checks before consulting
@@ -252,7 +252,7 @@ final readonly class RemoteProvider implements DonorProvider
     private function decorate(VendorConfig $donor, RemoteDonorRef $ref): VendorConfig
     {
         $provenance = $ref->provenance ?? 'source';
-        // `remote[]` entries are user-declared and therefore
+        // `sources[]` entries are user-declared and therefore
         // implicit-trusted, regardless of `from` value. The planner's
         // trust list applies to local-provider transitive discoveries
         // only. The optional skill allowlist carries through to the

--- a/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
@@ -12,14 +12,14 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\UnknownAdapterException;
 
 /**
  * {@see RemoteDonorSource} backed by the project's `skills.json`
- * `remote[]` list.
+ * `sources[]` list.
  *
  * Pipeline:
  *
  * 1. Resolve project config (best-effort — malformed config produces
  *    an empty stream; the {@see \LLM\Skills\Sync\SyncRunner} surfaces
  *    the real error on its own config read).
- * 2. For each {@see \LLM\Skills\Config\RemoteEntry}, look up the
+ * 2. For each {@see \LLM\Skills\Config\SourceEntry}, look up the
  *    adapter via {@see HostAdapterRegistry}.
  * 3. Ask the adapter to {@see \LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter::resolve()}
  *    the entry into a fetchable {@see RemoteDonorRef} — concrete
@@ -63,7 +63,7 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
             return;
         }
 
-        foreach ($config->remote as $entry) {
+        foreach ($config->sources as $entry) {
             try {
                 $adapter = $this->registry->get($entry->from);
             } catch (UnknownAdapterException $e) {
@@ -114,7 +114,7 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
     }
 
     /**
-     * Config-level check: does `skills.json` declare any `remote[]`
+     * Config-level check: does `skills.json` declare any `sources[]`
      * entry? Cheap by design — runs the mapper but **never resolves**
      * refs (no adapter calls, no HTTP). Both `RemoteProvider::isActive()`
      * (every sync / show invocation) and the standalone bootstrap rely
@@ -128,6 +128,6 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
         } catch (\Throwable) {
             return false;
         }
-        return $config->remote !== [];
+        return $config->sources !== [];
     }
 }

--- a/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
@@ -68,7 +68,7 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
                 $adapter = $this->registry->get($entry->from);
             } catch (UnknownAdapterException $e) {
                 $this->lastWarnings[] = \sprintf(
-                    'remote %s:%s skipped — %s',
+                    'source %s:%s skipped — %s',
                     $entry->from,
                     $entry->identifier(),
                     $e->getMessage(),

--- a/src/Filesystem/AtomicFileWriter.php
+++ b/src/Filesystem/AtomicFileWriter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Filesystem;
+
+/**
+ * Writes a file by staging the content in a sibling temp file and
+ * renaming it into place. The rename is atomic on most filesystems
+ * (POSIX + NTFS), so a concurrent reader never observes a
+ * half-written file.
+ *
+ * Shared by every component that rewrites a project file in one shot
+ * ({@see \LLM\Skills\Add\SkillsJsonWriter} on `skills:add`,
+ * {@see \LLM\Skills\Config\Mapper\ProjectConfigMigrator} on the
+ * in-place key rename) so the Windows-overwrite quirk lives in one
+ * place.
+ */
+final class AtomicFileWriter
+{
+    /**
+     * Stage `$content` in a sibling temp file, then rename it onto
+     * `$filePath`.
+     *
+     * Windows quirk: {@see \rename()} refuses to overwrite an existing
+     * destination on Windows (returns false / triggers a warning),
+     * even though NTFS itself supports atomic replace via
+     * `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`. PHP's `rename` does not
+     * pass that flag. So when the destination already exists we unlink
+     * it first and retry; this opens a sub-millisecond window where
+     * the file is gone, but the alternative — failing every second
+     * write — is worse. POSIX never enters the retry path because the
+     * initial rename overwrites cleanly.
+     *
+     * @throws \RuntimeException when the temp file cannot be written or renamed into place
+     */
+    public static function write(string $filePath, string $content): void
+    {
+        $tmp = $filePath . '.' . \bin2hex(\random_bytes(4)) . '.tmp';
+        if (\file_put_contents($tmp, $content) === false) {
+            throw new \RuntimeException('failed to write temp file at ' . $tmp);
+        }
+        if (@\rename($tmp, $filePath)) {
+            return;
+        }
+        // First rename failed. If the destination already exists, this
+        // is the Windows-overwrite case; unlink and retry once.
+        if (\file_exists($filePath) && @\unlink($filePath) && @\rename($tmp, $filePath)) {
+            return;
+        }
+        @\unlink($tmp);
+        throw new \RuntimeException('failed to rename temp file into ' . $filePath);
+    }
+}

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -136,6 +136,10 @@ final readonly class InitRunner
             return $this->runNonDefaultPath($projectRoot, $io, $options, $target);
         }
 
+        if ($this->migrator->renameSourcesKey($projectRoot, $io)->status === MigrationStatus::Failed) {
+            return Command::FAILURE;
+        }
+
         $result = $this->migrator->migrate($projectRoot, $io);
 
         switch ($result->status) {
@@ -222,18 +226,22 @@ final readonly class InitRunner
             $extra = \is_array($composerDecoded['extra'] ?? null) ? $composerDecoded['extra'] : [];
             /** @var array<string, mixed> $skills */
             $skills = \is_array($extra['skills'] ?? null) ? $extra['skills'] : [];
-            $inlineKeys = ProjectConfigMigrator::extractProjectKeys($skills);
+            // Defaults fold a `remote` alias into `sources`; the strip
+            // list keeps the original key names so composer.json editing
+            // targets the keys that are actually there.
+            $inlineDefaults = ProjectConfigMigrator::extractProjectKeys($skills);
+            $inlineKeys = ProjectConfigMigrator::presentProjectKeys($skills);
 
             if ($inlineKeys !== []) {
                 $io->write(\sprintf(
                     '<info>[init]</info> detected inline extra.skills in composer.json: %s',
-                    \implode(', ', \array_keys($inlineKeys)),
+                    \implode(', ', $inlineKeys),
                 ));
                 if ($io->askConfirmation(
                     '<info>Import these as defaults?</info> [<comment>Y/n</comment>]: ',
                     true,
                 )) {
-                    $defaults = $inlineKeys;
+                    $defaults = $inlineDefaults;
                 }
             }
         }
@@ -257,7 +265,7 @@ final readonly class InitRunner
         // residue (and an empty `"extra": {}`) after the strip.
         if ($composerJsonPath !== null && $inlineKeys !== []) {
             /** @var array<string, mixed> $skills */
-            if (!$this->stripInlineKeys($composerJsonPath, $skills, \array_keys($inlineKeys), $io)) {
+            if (!$this->stripInlineKeys($composerJsonPath, $skills, $inlineKeys, $io)) {
                 $io->write(
                     '<comment>[init] note: skills.json was written, but stripping '
                     . 'composer.json failed. skills.json wins from now on regardless.</comment>',
@@ -415,6 +423,10 @@ final readonly class InitRunner
     ): int {
         $canonical = (string) $projectRoot->join('skills.json');
         $canonicalExisted = \is_file($canonical);
+
+        if ($this->migrator->renameSourcesKey($projectRoot, $io)->status === MigrationStatus::Failed) {
+            return Command::FAILURE;
+        }
 
         $result = $this->migrator->migrate($projectRoot, $io);
 

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -508,14 +508,14 @@ final readonly class InitRunner
             return false;
         }
 
-        // Stub `skills.json` ships with the `local` and `remote`
+        // Stub `skills.json` ships with the `local` and `sources`
         // knobs visible so users discover them without reading docs.
         // `local.composer: true` is also the default, but we emit it
         // explicitly — hiding it would make the npm / go toggles seem
         // surprise-feature-y when they arrive.
         $content = ProjectConfigMigrator::renderSkillsJson([
             'local' => ['composer' => true],
-            'remote' => [],
+            'sources' => [],
         ]);
         if (\file_put_contents($target, $content) === false) {
             $io->writeError(\sprintf(

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -63,6 +63,16 @@ final readonly class ShowRunner
             );
         }
 
+        // Read-only surface: never rewrites the file, so a `remote`
+        // block stays on disk. Surface the deprecation at normal
+        // verbosity and point the user at the command that migrates it.
+        if ($resolution->usedDeprecatedSourcesKey) {
+            $io->writeError(
+                '<comment>[deprecated] config key "remote" was renamed to "sources"; '
+                . 'skills:update migrates the file automatically</comment>',
+            );
+        }
+
         // See SyncRunner: notice is provider-neutral, specifics flow
         // through `-v` warnings emitted at the entrypoint.
         if (!$provider->isActive($projectRoot)) {

--- a/src/Sync/SyncPlanner.php
+++ b/src/Sync/SyncPlanner.php
@@ -32,7 +32,7 @@ use LLM\Skills\Config\VendorConfig;
  *   the bouncer for *auto-discovered* donors, not for ones the user already
  *   asked for by name.
  * - A donor flagged {@see VendorConfig::$implicitTrust} is user-declared at
- *   the source level (today: every `remote[]` entry, regardless of `from`).
+ *   the source level (today: every `sources[]` entry, regardless of `from`).
  *   The trust list applies to local-provider transitive discoveries only,
  *   so the planner skips it for these donors.
  * - A package declared as a direct dependency in the consumer's root
@@ -76,7 +76,7 @@ final readonly class SyncPlanner
                 : \array_fill_keys($directDependencies, true);
             foreach ($filtered as $donor) {
                 // A donor flagged `implicitTrust` is user-declared
-                // (today: every `remote[]` entry); the trust list
+                // (today: every `sources[]` entry); the trust list
                 // applies only to local-provider transitive discoveries,
                 // so we skip the check entirely.
                 if (

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -94,6 +94,16 @@ final readonly class SyncRunner
         // `post-install-cmd` hook, which must not rewrite
         // `composer.json` mid-install.
         if ($options->autoMigrate) {
+            // Rename a legacy `remote` key to `sources` in an existing
+            // skills.json before mapping, so write-mode never maps the
+            // deprecated alias. Independent of the extra.skills → skills.json
+            // relocation below: the two act on mutually exclusive states
+            // (skills.json present vs absent).
+            $rename = $this->migrator->renameSourcesKey($projectRoot, $io);
+            if ($rename->status === MigrationStatus::Failed) {
+                return Command::FAILURE;
+            }
+
             $migration = $this->migrator->migrate($projectRoot, $io);
             if ($migration->status === MigrationStatus::Failed) {
                 return Command::FAILURE;
@@ -120,6 +130,7 @@ final readonly class SyncRunner
 
         $project = $configResolution->config;
         $this->emitShadowedKeysWarning($io, $configResolution->ignoredInlineKeys);
+        $this->emitDeprecatedSourcesKeyNotice($io, $configResolution->usedDeprecatedSourcesKey);
 
         // No donor provider can contribute. Reasons vary by provider —
         // {@see \LLM\Skills\Discovery\Provider\ComposerProvider} is
@@ -394,6 +405,25 @@ final readonly class SyncRunner
             '<comment>[warn] skills.json present; the following extra.skills keys in '
             . 'composer.json are ignored: ' . \implode(', ', $ignored) . '</comment>',
             verbosity: IOInterface::VERBOSE,
+        );
+    }
+
+    /**
+     * The winning config block declared its donor sources under the
+     * deprecated `remote` key. Surface a notice at normal verbosity —
+     * deprecations should be seen. In write mode the §2.1 in-place
+     * rename runs first, so this fires only when migration was
+     * suppressed (the `post-install-cmd` auto-sync hook).
+     */
+    private function emitDeprecatedSourcesKeyNotice(IOInterface $io, bool $used): void
+    {
+        if (!$used) {
+            return;
+        }
+
+        $io->writeError(
+            '<comment>[deprecated] config key "remote" was renamed to "sources"; '
+            . 'skills:update migrates the file automatically</comment>',
         );
     }
 

--- a/tests/Acceptance/SkillsAddGithubLiveTest.php
+++ b/tests/Acceptance/SkillsAddGithubLiveTest.php
@@ -130,12 +130,12 @@ final class SkillsAddGithubLiveTest
             associative: true,
             flags: \JSON_THROW_ON_ERROR,
         );
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) ($payload['remote'] ?? []);
-        Assert::count($remote, 1, 'exactly one remote entry must be registered');
-        Assert::same($remote[0]['from'] ?? null, 'github');
-        Assert::same($remote[0]['package'] ?? null, self::REPO);
-        Assert::same($remote[0]['ref'] ?? null, self::REF);
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) ($payload['sources'] ?? []);
+        Assert::count($sources, 1, 'exactly one source entry must be registered');
+        Assert::same($sources[0]['from'] ?? null, 'github');
+        Assert::same($sources[0]['package'] ?? null, self::REPO);
+        Assert::same($sources[0]['ref'] ?? null, self::REF);
 
         // The downstream sync ran as part of `skills:add` (no --no-sync
         // was passed), so the donor's skill directories must already

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -53,6 +53,38 @@ final class SkillsSchemaTest
         ]);
     }
 
+    public function sourcesDocumentIsAccepted(): void
+    {
+        $this->assertAccepts([
+            'sources' => [
+                ['from' => 'github', 'package' => 'acme/skills'],
+                ['from' => 'zip', 'url' => 'https://example.com/skills.zip'],
+            ],
+        ]);
+    }
+
+    public function deprecatedRemoteDocumentIsAccepted(): void
+    {
+        // `remote` is the deprecated alias of `sources`. The schema
+        // still accepts it so editors do not flag legacy files before
+        // skills:update migrates them.
+        $this->assertAccepts([
+            'remote' => [
+                ['from' => 'github', 'package' => 'acme/skills'],
+            ],
+        ]);
+    }
+
+    public function bothSourcesAndRemoteIsRejected(): void
+    {
+        // The PHP mapper treats both keys present as fatal; the schema's
+        // root `not` clause mirrors that.
+        $this->assertRejects([
+            'sources' => [['from' => 'github', 'package' => 'acme/skills']],
+            'remote' => [['from' => 'github', 'package' => 'acme/other']],
+        ]);
+    }
+
     public function unknownTopLevelKeyIsRejected(): void
     {
         $this->assertRejects([

--- a/tests/Acceptance/SkillsSourcesMigrationTest.php
+++ b/tests/Acceptance/SkillsSourcesMigrationTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSkillsJson;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance coverage for the `remote` → `sources` config-key rename in
+ * `skills.json`:
+ *
+ * - `skills:update` (write-mode) renames a legacy `remote` key to
+ *   `sources` in place, preserving every other key and its position,
+ *   announces the rewrite with a `[migrate]` notice, and syncs normally.
+ * - `skills:show` (read-only) reads the alias, emits the `[deprecated]`
+ *   notice, and never touches the file.
+ * - A file carrying BOTH keys is fatal: the command fails and the file
+ *   is left untouched, so the user resolves the ambiguity by hand.
+ *
+ * Sandbox already has `acme/skills-basic` installed and trusted, so a
+ * `sources: []` / `remote: []` list still produces a real Composer-donor
+ * sync — the rename behaviour is what is under test, not remote fetching.
+ */
+#[Test]
+final class SkillsSourcesMigrationTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const SKILLS_JSON = Info::PROJECT_DIR . '/skills.json';
+
+    #[BeforeTest]
+    public function clearSyncTarget(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+    }
+
+    #[AfterTest]
+    public function removeSkillsJson(): void
+    {
+        if (\is_file(self::SKILLS_JSON)) {
+            @\unlink(self::SKILLS_JSON);
+        }
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'remote' => [],
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function updateRenamesLegacyRemoteKeyInPlaceAndSyncs(): void
+    {
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+
+        // The renamed file keeps every sibling key in its original slot,
+        // with `remote` replaced by `sources` in place.
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            \array_keys($skills),
+            ['$schema', 'target', 'sources', 'trusted'],
+            'key order must be preserved with remote renamed to sources in place',
+        );
+        Assert::false(\array_key_exists('remote', $skills), 'the deprecated remote key must be gone');
+        Assert::same($skills['sources'], []);
+        Assert::same($skills['target'], '.agents/skills');
+        Assert::same($skills['trusted'], ['acme/skills-basic']);
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, '[migrate] renamed "remote" to "sources" in skills.json'),
+            'update must announce the in-place rename. Got: ' . $combined,
+        );
+
+        // The sync proceeded against the Composer donor with the renamed config.
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/greeting/SKILL.md'),
+            'skills must sync after the key rename',
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'remote' => [],
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function showReadsLegacyRemoteKeyWithoutRewritingTheFile(): void
+    {
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runShow();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'show is read-only and must not rewrite skills.json',
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, '[deprecated] config key "remote" was renamed to "sources"'),
+            'show must surface the deprecation notice for the legacy key. Got: ' . $combined,
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'sources' => [],
+        'remote' => [],
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function updateFailsWhenBothSourcesAndRemoteArePresent(): void
+    {
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runUpdate();
+
+        Assert::notSame(
+            $process->getExitCode(),
+            0,
+            'a file with both keys must fail the run; stderr: ' . $process->getErrorOutput(),
+        );
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, 'both "sources" and "remote" are present; keep "sources" only'),
+            'the both-keys error must name the conflict. Got: ' . $combined,
+        );
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'the ambiguous file must be left untouched for the user to resolve',
+        );
+    }
+
+    private function runUpdate(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:update',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    private function runShow(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:show',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(self::SKILLS_JSON),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+}

--- a/tests/Acceptance/StandaloneBinTest.php
+++ b/tests/Acceptance/StandaloneBinTest.php
@@ -222,8 +222,8 @@ final class StandaloneBinTest
         );
         Assert::same(
             \array_keys($decoded),
-            ['$schema', 'local', 'remote'],
-            'standalone init writes a stub with the local + remote knobs visible',
+            ['$schema', 'local', 'sources'],
+            'standalone init writes a stub with the local + sources knobs visible',
         );
     }
 }

--- a/tests/Feature/RemoteProviderEndToEndTest.php
+++ b/tests/Feature/RemoteProviderEndToEndTest.php
@@ -52,7 +52,7 @@ final class RemoteProviderEndToEndTest
 {
     private string $tmp;
 
-    public function remoteEntryResolvesFetchesAndProducesDonor(): void
+    public function SourceEntryResolvesFetchesAndProducesDonor(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
             // ext-zip is a soft dependency; without it the fetcher
@@ -117,7 +117,7 @@ final class RemoteProviderEndToEndTest
         Assert::true(\str_contains((string) \file_get_contents($skillFile), 'name: hello'));
     }
 
-    public function gitlabRemoteEntryResolvesFetchesAndProducesDonor(): void
+    public function gitlabSourceEntryResolvesFetchesAndProducesDonor(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');

--- a/tests/Unit/Add/AddRunnerTest.php
+++ b/tests/Unit/Add/AddRunnerTest.php
@@ -88,8 +88,8 @@ final class AddRunnerTest
         Assert::true(\str_contains($io->getOutput(), 'registered github:acme/skills @ v1.2.3'));
 
         $skills = $this->readSkillsJson();
-        Assert::count((array) $skills['remote'], 1);
-        Assert::same($skills['remote'][0]['ref'] ?? null, 'v1.2.3');
+        Assert::count((array) $skills['sources'], 1);
+        Assert::same($skills['sources'][0]['ref'] ?? null, 'v1.2.3');
     }
 
     public function inferredAdapterIsUsedWhenInputIsUrlAndFromIsAbsent(): void
@@ -129,7 +129,7 @@ final class AddRunnerTest
             ),
         );
 
-        Assert::same($this->readSkillsJson()['remote'][0]['ref'] ?? null, 'v1.2.3');
+        Assert::same($this->readSkillsJson()['sources'][0]['ref'] ?? null, 'v1.2.3');
     }
 
     public function noRefPlusStableResolutionStoresCaret(): void
@@ -148,7 +148,7 @@ final class AddRunnerTest
             new AddOptions(input: 'acme/skills', from: ProviderId::GITHUB),
         );
 
-        Assert::same($this->readSkillsJson()['remote'][0]['ref'] ?? null, '^2.5.7');
+        Assert::same($this->readSkillsJson()['sources'][0]['ref'] ?? null, '^2.5.7');
     }
 
     public function noRefPlusBranchResolutionOmitsRef(): void
@@ -169,7 +169,7 @@ final class AddRunnerTest
         );
 
         Assert::false(
-            \array_key_exists('ref', $this->readSkillsJson()['remote'][0]),
+            \array_key_exists('ref', $this->readSkillsJson()['sources'][0]),
             'no stable ref ⇒ ref field is omitted',
         );
     }

--- a/tests/Unit/Add/AddRunnerTest.php
+++ b/tests/Unit/Add/AddRunnerTest.php
@@ -8,7 +8,7 @@ use Composer\IO\BufferIO;
 use Internal\Path;
 use LLM\Skills\Add\AddRunner;
 use LLM\Skills\Config\AddOptions;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
@@ -557,7 +557,7 @@ final class StubAdapter implements HostAdapter
     }
 
     #[\Override]
-    public function resolve(RemoteEntry $entry): RemoteDonorRef
+    public function resolve(SourceEntry $entry): RemoteDonorRef
     {
         if ($this->resolveError !== null) {
             throw new RemoteResolveException($entry, $this->resolveError);

--- a/tests/Unit/Add/SkillsJsonWriterTest.php
+++ b/tests/Unit/Add/SkillsJsonWriterTest.php
@@ -47,14 +47,14 @@ final class SkillsJsonWriterTest
         // No skills.json yet → the writer creates one with the
         // canonical `$schema` URL so editors get autocompletion out
         // of the box.
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: '^1.0'),
         );
 
         $payload = $this->readSkillsJson();
         Assert::same($payload['$schema'] ?? null, ProjectConfigMigrator::SCHEMA_URL);
-        Assert::count((array) $payload['remote'], 1);
+        Assert::count((array) $payload['sources'], 1);
     }
 
     public function consecutiveUpsertsOverwriteExistingFile(): void
@@ -68,16 +68,16 @@ final class SkillsJsonWriterTest
         $writer = new SkillsJsonWriter();
         $root = Path::create($this->tmp);
 
-        $writer->upsertRemote($root, self::entry('acme/skills', ref: 'v1.0.0'));
-        $writer->upsertRemote($root, self::entry('acme/skills', ref: 'v2.0.0'));
-        $writer->upsertRemote($root, self::entry('acme/other', ref: 'v1.0.0'));
+        $writer->upsertSource($root, self::entry('acme/skills', ref: 'v1.0.0'));
+        $writer->upsertSource($root, self::entry('acme/skills', ref: 'v2.0.0'));
+        $writer->upsertSource($root, self::entry('acme/other', ref: 'v1.0.0'));
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 2);
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 2);
         $skills = \array_values(\array_filter(
-            $remote,
+            $sources,
             static fn(array $e): bool => ($e['package'] ?? null) === 'acme/skills',
         ));
         Assert::count($skills, 1);
@@ -87,14 +87,14 @@ final class SkillsJsonWriterTest
     public function preservesUnrelatedTopLevelKeys(): void
     {
         // The writer must NOT clobber `target` / `aliases` / `trusted`
-        // — only `remote[]` is its concern.
+        // — only `sources[]` is its concern.
         $this->writeSkillsJson([
             'target' => '.agents/skills',
             'aliases' => ['.claude/skills'],
             'trusted' => ['acme/*'],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills'),
         );
@@ -110,20 +110,20 @@ final class SkillsJsonWriterTest
         // Same (from, host, package) ⇒ overwrite in place, not append.
         // The new entry's optional fields (ref, extras) supersede the old.
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: '^2.0.0'),
         );
 
         $payload = $this->readSkillsJson();
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 1);
-        Assert::same($remote[0]['ref'] ?? null, '^2.0.0');
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['ref'] ?? null, '^2.0.0');
     }
 
     public function upsertDistinguishesByHost(): void
@@ -131,37 +131,37 @@ final class SkillsJsonWriterTest
         // Same package on github.com vs corp GHE are distinct
         // entries — composite key includes host.
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', host: 'https://github.corp.example.com', ref: 'v1.0.0'),
         );
 
         $payload = $this->readSkillsJson();
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 2);
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 2);
     }
 
     public function appendsWhenCompositeKeyIsNew(): void
     {
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'acme/x'],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('beta/y'),
         );
 
         $payload = $this->readSkillsJson();
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 2);
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 2);
     }
 
     public function stableSortIsAppliedAfterUpsert(): void
@@ -169,26 +169,26 @@ final class SkillsJsonWriterTest
         // Composite key sort order: ascii ordering of `from|host|id`.
         // Reverse-input order should come out sorted.
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'zeta/last'],
                 ['from' => 'github', 'package' => 'beta/middle'],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('alpha/first'),
         );
 
         $payload = $this->readSkillsJson();
-        $packages = \array_map(static fn(array $e) => $e['package'], (array) $payload['remote']);
+        $packages = \array_map(static fn(array $e) => $e['package'], (array) $payload['sources']);
         Assert::same($packages, ['alpha/first', 'beta/middle', 'zeta/last']);
     }
 
     public function writtenEntryHasFixedKeyOrder(): void
     {
         // Fixed key order: from → host → package → ref → extras.
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             new RemoteEntry(
                 from: 'github',
@@ -202,7 +202,7 @@ final class SkillsJsonWriterTest
 
         $raw = (string) \file_get_contents($this->tmp . '/skills.json');
 
-        // Snapshot the order of keys inside the remote entry. We
+        // Snapshot the order of keys inside the source entry. We
         // can't trust unordered JSON associative-array comparison —
         // the file order is what diffs and users see.
         $fromPos = \strpos($raw, '"from"');
@@ -226,26 +226,26 @@ final class SkillsJsonWriterTest
         // must collapse duplicates into a single normalised entry,
         // not insert a copy next to each.
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v0.9.0'],
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v0.9.1'],
                 ['from' => 'github', 'package' => 'acme/other', 'ref' => 'v2.0.0'],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v1.2.3'),
         );
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
 
-        Assert::count($remote, 2);
+        Assert::count($sources, 2);
 
         $acmeSkills = \array_values(\array_filter(
-            $remote,
+            $sources,
             static fn(array $e): bool => ($e['package'] ?? null) === 'acme/skills',
         ));
         Assert::count($acmeSkills, 1);
@@ -254,16 +254,16 @@ final class SkillsJsonWriterTest
 
     public function freshEntryStoresSkillsAllowlistVerbatim(): void
     {
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v1.0.0', skills: ['code-review', 'refactor']),
         );
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 1);
-        Assert::same($remote[0]['skills'] ?? null, ['code-review', 'refactor']);
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['skills'] ?? null, ['code-review', 'refactor']);
     }
 
     public function freshEntryOmitsSkillsKeyWhenAllowlistIsNull(): void
@@ -271,15 +271,15 @@ final class SkillsJsonWriterTest
         // Skipping the field is meaningfully different from `"skills": []`:
         // it means "sync every skill" and must produce a clean entry
         // without an empty array forcing the user to delete it.
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v1.0.0'),
         );
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::false(\array_key_exists('skills', $remote[0]));
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::false(\array_key_exists('skills', $sources[0]));
     }
 
     public function consecutiveUpsertsMergeSkillsAllowlists(): void
@@ -290,14 +290,14 @@ final class SkillsJsonWriterTest
         $writer = new SkillsJsonWriter();
         $root = Path::create($this->tmp);
 
-        $writer->upsertRemote($root, self::entry('acme/skills', skills: ['alpha', 'beta']));
-        $writer->upsertRemote($root, self::entry('acme/skills', skills: ['beta', 'gamma']));
+        $writer->upsertSource($root, self::entry('acme/skills', skills: ['alpha', 'beta']));
+        $writer->upsertSource($root, self::entry('acme/skills', skills: ['beta', 'gamma']));
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 1);
-        Assert::same($remote[0]['skills'] ?? null, ['alpha', 'beta', 'gamma']);
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['skills'] ?? null, ['alpha', 'beta', 'gamma']);
     }
 
     public function freshEntryRoundtripsEmptySkillsList(): void
@@ -305,16 +305,16 @@ final class SkillsJsonWriterTest
         // An empty allowlist is a meaningful state ("donor on file, no
         // skills pulled"). Distinct from omitting the field. The writer
         // must emit `"skills": []` verbatim.
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v1.0.0', skills: []),
         );
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::true(\array_key_exists('skills', $remote[0]));
-        Assert::same($remote[0]['skills'], []);
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::true(\array_key_exists('skills', $sources[0]));
+        Assert::same($sources[0]['skills'], []);
     }
 
     public function upsertWithoutSkillsPreservesEmptyAllowlist(): void
@@ -324,21 +324,21 @@ final class SkillsJsonWriterTest
         // otherwise running `skills:add ... --ref=v2` on a temporarily
         // disabled entry would silently re-enable every skill.
         $this->writeSkillsJson([
-            'remote' => [
+            'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0', 'skills' => []],
             ],
         ]);
 
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v2.0.0'),
         );
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::same($remote[0]['skills'] ?? null, []);
-        Assert::same($remote[0]['ref'] ?? null, 'v2.0.0');
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::same($sources[0]['skills'] ?? null, []);
+        Assert::same($sources[0]['ref'] ?? null, 'v2.0.0');
     }
 
     public function upsertWithoutSkillsPreservesExistingAllowlist(): void
@@ -350,20 +350,20 @@ final class SkillsJsonWriterTest
         $writer = new SkillsJsonWriter();
         $root = Path::create($this->tmp);
 
-        $writer->upsertRemote($root, self::entry('acme/skills', skills: ['alpha']));
-        $writer->upsertRemote($root, self::entry('acme/skills', ref: 'v2.0.0'));
+        $writer->upsertSource($root, self::entry('acme/skills', skills: ['alpha']));
+        $writer->upsertSource($root, self::entry('acme/skills', ref: 'v2.0.0'));
 
         $payload = $this->readSkillsJson();
-        /** @var list<array<string, mixed>> $remote */
-        $remote = (array) $payload['remote'];
-        Assert::count($remote, 1);
-        Assert::same($remote[0]['skills'] ?? null, ['alpha']);
-        Assert::same($remote[0]['ref'] ?? null, 'v2.0.0');
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['skills'] ?? null, ['alpha']);
+        Assert::same($sources[0]['ref'] ?? null, 'v2.0.0');
     }
 
     public function skillsFieldIsEmittedAfterRefInTheCanonicalKeyOrder(): void
     {
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills', ref: 'v1.0.0', skills: ['hello']),
         );
@@ -379,7 +379,7 @@ final class SkillsJsonWriterTest
     {
         // The temp file pattern is `skills.json.<hex>.tmp`. After a
         // successful write, only the canonical name should remain.
-        (new SkillsJsonWriter())->upsertRemote(
+        (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
             self::entry('acme/skills'),
         );
@@ -390,6 +390,40 @@ final class SkillsJsonWriterTest
             static fn($e) => $e !== '.' && $e !== '..',
         ));
         Assert::same($names, ['skills.json']);
+    }
+
+    public function upsertIntoLegacyRemoteFileProducesSourcesOnlyFile(): void
+    {
+        // A file still on the deprecated `remote` key is normalised on
+        // write: its entries move under `sources`, the old key is
+        // dropped, unrelated keys survive, and the additive
+        // allowlist-merge behaviour is preserved across the rename.
+        $this->writeSkillsJson([
+            'target' => '.agents/skills',
+            'remote' => [
+                ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0', 'skills' => ['alpha']],
+            ],
+        ]);
+
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::entry('acme/skills', ref: 'v2.0.0', skills: ['beta']),
+        );
+
+        $payload = $this->readSkillsJson();
+        Assert::false(\array_key_exists('remote', $payload), 'deprecated key must be dropped from the output');
+        Assert::true(\array_key_exists('sources', $payload));
+        Assert::same($payload['target'] ?? null, '.agents/skills', 'unrelated keys must survive');
+
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['ref'] ?? null, 'v2.0.0');
+        Assert::same(
+            $sources[0]['skills'] ?? null,
+            ['alpha', 'beta'],
+            'the legacy entry allowlist must merge with the new one',
+        );
     }
 
     /**

--- a/tests/Unit/Add/SkillsJsonWriterTest.php
+++ b/tests/Unit/Add/SkillsJsonWriterTest.php
@@ -7,7 +7,7 @@ namespace LLM\Skills\Tests\Unit\Add;
 use Internal\Path;
 use LLM\Skills\Add\SkillsJsonWriter;
 use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Tests\Testo\Filesystem;
 use Testo\Assert;
@@ -190,7 +190,7 @@ final class SkillsJsonWriterTest
         // Fixed key order: from → host → package → ref → extras.
         (new SkillsJsonWriter())->upsertSource(
             Path::create($this->tmp),
-            new RemoteEntry(
+            new SourceEntry(
                 from: 'github',
                 package: 'acme/skills',
                 url: null,
@@ -462,8 +462,8 @@ final class SkillsJsonWriterTest
         ?string $host = null,
         ?string $ref = null,
         ?array $skills = null,
-    ): RemoteEntry {
-        return new RemoteEntry(
+    ): SourceEntry {
+        return new SourceEntry(
             from: ProviderId::GITHUB,
             package: $package,
             url: null,

--- a/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
+++ b/tests/Unit/Config/Mapper/ExternalProjectConfigLoaderTest.php
@@ -83,6 +83,38 @@ final class ExternalProjectConfigLoaderTest
         ]);
     }
 
+    public function allowsSourcesKey(): void
+    {
+        $this->writeFile([
+            'target' => '.agents/skills',
+            'sources' => [['from' => 'github', 'package' => 'acme/skills']],
+        ]);
+
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::same($result, [
+            'target' => '.agents/skills',
+            'sources' => [['from' => 'github', 'package' => 'acme/skills']],
+        ]);
+    }
+
+    public function allowsDeprecatedRemoteKey(): void
+    {
+        // `remote` stays a recognised key for back-compat; it is read as
+        // a deprecated alias of `sources`.
+        $this->writeFile([
+            'target' => '.agents/skills',
+            'remote' => [['from' => 'github', 'package' => 'acme/skills']],
+        ]);
+
+        $result = (new ExternalProjectConfigLoader())->load(Path::create($this->tmp));
+
+        Assert::same($result, [
+            'target' => '.agents/skills',
+            'remote' => [['from' => 'github', 'package' => 'acme/skills']],
+        ]);
+    }
+
     public function emptyObjectDecodesAsEmptyArray(): void
     {
         // `{}` is a valid (if uninteresting) skills.json — it means "no

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -617,7 +617,7 @@ final class ProjectConfigMapperTest
         // must fail at load so a typo never reaches the fetcher (which
         // would otherwise give a less helpful error).
         Expect::exception(MalformedProjectConfig::class)
-            ->withMessageContaining('not a known remote adapter');
+            ->withMessageContaining('not a known source adapter');
 
         (new ProjectConfigMapper())->fromExtra([
             'skills' => [

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -551,7 +551,7 @@ final class ProjectConfigMapperTest
     {
         $cfg = (new ProjectConfigMapper())->fromExtra(['skills' => []]);
 
-        Assert::same($cfg->remote, []);
+        Assert::same($cfg->sources, []);
     }
 
     public function remotePackageAdapterParses(): void
@@ -564,8 +564,8 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::count($cfg->remote, 1);
-        $entry = $cfg->remote[0];
+        Assert::count($cfg->sources, 1);
+        $entry = $cfg->sources[0];
         Assert::same($entry->from, 'github');
         Assert::same($entry->package, 'acme/skills');
         Assert::same($entry->ref, '^1.0');
@@ -590,7 +590,7 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::same($cfg->remote[0]->host, 'https://github.corp.example.com');
+        Assert::same($cfg->sources[0]->host, 'https://github.corp.example.com');
     }
 
     public function remoteUrlAdapterParses(): void
@@ -603,8 +603,8 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::count($cfg->remote, 1);
-        $entry = $cfg->remote[0];
+        Assert::count($cfg->sources, 1);
+        $entry = $cfg->sources[0];
         Assert::same($entry->from, 'zip');
         Assert::same($entry->url, 'https://example.com/x.zip');
         Assert::same($entry->package, null);
@@ -717,7 +717,7 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::count($cfg->remote, 2);
+        Assert::count($cfg->sources, 2);
     }
 
     public function remoteSkillsAllowlistIsParsed(): void
@@ -734,7 +734,7 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::same($cfg->remote[0]->skills, ['code-review', 'refactor']);
+        Assert::same($cfg->sources[0]->skills, ['code-review', 'refactor']);
     }
 
     public function remoteWithoutSkillsKeyDefaultsToNull(): void
@@ -749,7 +749,7 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::same($cfg->remote[0]->skills, null);
+        Assert::same($cfg->sources[0]->skills, null);
     }
 
     public function remoteSkillsAcceptsEmptyList(): void
@@ -766,7 +766,7 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::same($cfg->remote[0]->skills, []);
+        Assert::same($cfg->sources[0]->skills, []);
     }
 
     public function remoteSkillsMustBeAList(): void
@@ -813,8 +813,8 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::same($cfg->remote[0]->skills, ['hello']);
-        Assert::same($cfg->remote[0]->extras, []);
+        Assert::same($cfg->sources[0]->skills, ['hello']);
+        Assert::same($cfg->sources[0]->extras, []);
     }
 
     public function remoteAsObjectThrows(): void
@@ -827,7 +827,7 @@ final class ProjectConfigMapperTest
         ]);
     }
 
-    public function remoteEntryAsScalarThrows(): void
+    public function SourceEntryAsScalarThrows(): void
     {
         Expect::exception(MalformedProjectConfig::class)
             ->withMessageContaining('must be an object');
@@ -861,8 +861,8 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::count($cfg->remote, 1);
-        $entry = $cfg->remote[0];
+        Assert::count($cfg->sources, 1);
+        $entry = $cfg->sources[0];
         Assert::same($entry->from, 'github');
         Assert::same($entry->package, 'acme/skills');
         Assert::same($entry->ref, '^1.0');
@@ -878,8 +878,8 @@ final class ProjectConfigMapperTest
             ],
         ]);
 
-        Assert::count($cfg->remote, 1);
-        $entry = $cfg->remote[0];
+        Assert::count($cfg->sources, 1);
+        $entry = $cfg->sources[0];
         Assert::same($entry->from, 'zip');
         Assert::same($entry->url, 'https://example.com/x.zip');
         Assert::same($entry->extras, ['sha256' => 'abc']);

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -849,6 +849,157 @@ final class ProjectConfigMapperTest
         ]);
     }
 
+    // ── sources: canonical key, `remote` as deprecated alias ────────────
+
+    public function sourcesPackageAdapterParsesLikeRemote(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'github', 'package' => 'acme/skills', 'ref' => '^1.0'],
+                ],
+            ],
+        ]);
+
+        Assert::count($cfg->remote, 1);
+        $entry = $cfg->remote[0];
+        Assert::same($entry->from, 'github');
+        Assert::same($entry->package, 'acme/skills');
+        Assert::same($entry->ref, '^1.0');
+    }
+
+    public function sourcesUrlAdapterParsesLikeRemote(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'zip', 'url' => 'https://example.com/x.zip', 'sha256' => 'abc'],
+                ],
+            ],
+        ]);
+
+        Assert::count($cfg->remote, 1);
+        $entry = $cfg->remote[0];
+        Assert::same($entry->from, 'zip');
+        Assert::same($entry->url, 'https://example.com/x.zip');
+        Assert::same($entry->extras, ['sha256' => 'abc']);
+    }
+
+    public function bothSourcesAndRemoteInlineThrows(): void
+    {
+        // Both keys in one block is fatal — no merge, no precedence.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills: both "sources" and "remote" are present; keep "sources" only');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'github', 'package' => 'acme/x']],
+                'remote' => [['from' => 'github', 'package' => 'acme/y']],
+            ],
+        ]);
+    }
+
+    public function bothSourcesAndRemoteInSkillsJsonThrows(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'github', 'package' => 'acme/x']],
+            'remote' => [['from' => 'github', 'package' => 'acme/y']],
+        ]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: both "sources" and "remote" are present; keep "sources" only');
+
+        (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+    }
+
+    public function sourcesErrorMessagesUseSourcesKey(): void
+    {
+        // A bad entry parsed from `sources` reports the `sources` path.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.sources[0]');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'mystery', 'package' => 'acme/x']],
+            ],
+        ]);
+    }
+
+    public function remoteErrorMessagesKeepRemoteKey(): void
+    {
+        // A bad entry parsed from the legacy `remote` key keeps saying
+        // `remote` so the user sees the key they actually wrote.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.remote[0]');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'remote' => [['from' => 'mystery', 'package' => 'acme/x']],
+            ],
+        ]);
+    }
+
+    // ── deprecation flag on ProjectConfigResolution ─────────────────────
+
+    public function forProjectInlineSourcesDoesNotFlagDeprecation(): void
+    {
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['sources' => [['from' => 'github', 'package' => 'acme/x']]]],
+        );
+
+        Assert::same($resolution->usedDeprecatedSourcesKey, false);
+    }
+
+    public function forProjectInlineRemoteFlagsDeprecation(): void
+    {
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['remote' => [['from' => 'github', 'package' => 'acme/x']]]],
+        );
+
+        Assert::same($resolution->usedDeprecatedSourcesKey, true);
+    }
+
+    public function forProjectExternalSourcesDoesNotFlagDeprecation(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'github', 'package' => 'acme/x']],
+        ]);
+
+        $resolution = (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+
+        Assert::same($resolution->usedDeprecatedSourcesKey, false);
+    }
+
+    public function forProjectExternalRemoteFlagsDeprecation(): void
+    {
+        $this->writeSkillsJson([
+            'remote' => [['from' => 'github', 'package' => 'acme/x']],
+        ]);
+
+        $resolution = (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+
+        Assert::same($resolution->usedDeprecatedSourcesKey, true);
+    }
+
+    public function forProjectShadowedInlineKeysIncludeSourcesAndRemote(): void
+    {
+        // Both the canonical key and its deprecated alias remain
+        // project-level keys, so a shadowed inline block reports either.
+        $this->writeSkillsJson(['target' => 'external/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => [
+                'sources' => [['from' => 'github', 'package' => 'acme/x']],
+                'remote' => [['from' => 'github', 'package' => 'acme/y']],
+            ]],
+        );
+
+        Assert::same($resolution->ignoredInlineKeys, ['sources', 'remote']);
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
@@ -287,6 +287,157 @@ final class ProjectConfigMigratorTest
         Assert::true(\str_contains($io->getOutput(), 'cannot auto-migrate'));
     }
 
+    public function migratesRemoteInlineBlockUnderSourcesKey(): void
+    {
+        // Inline `extra.skills.remote` migrates into skills.json under
+        // the canonical `sources` key — the written file never carries
+        // the deprecated alias — and composer.json is stripped of the
+        // key the user actually wrote (`remote`).
+        $this->writeComposerJson([
+            'name' => 'demo/consumer',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'remote' => [
+                        ['from' => 'github', 'package' => 'acme/skills'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+
+        $skills = $this->readSkillsJson();
+        Assert::false(\array_key_exists('remote', $skills), 'written file must not carry the deprecated key');
+        Assert::same(
+            $skills['sources'] ?? null,
+            [['from' => 'github', 'package' => 'acme/skills']],
+        );
+
+        // composer.json had `remote` stripped (not `sources`).
+        $composer = $this->readComposerJson();
+        $remaining = $composer['extra']['skills'] ?? [];
+        Assert::false(\array_key_exists('remote', $remaining));
+        Assert::false(\array_key_exists('target', $remaining));
+    }
+
+    public function renamesRemoteKeyToSourcesInPlace(): void
+    {
+        // A skills.json still on the deprecated key is rewritten with
+        // the key renamed, its slot and every sibling key preserved,
+        // and a normal-verbosity notice emitted.
+        $this->writeSkillsJson([
+            '$schema' => 'https://example.com/skills.schema.json',
+            'target' => 'custom/skills',
+            'remote' => [
+                ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
+            ],
+            'trusted' => ['acme/*'],
+        ]);
+
+        $io = new BufferIO();
+        $result = (new ProjectConfigMigrator())->renameSourcesKey(
+            Path::create($this->tmp),
+            $io,
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+
+        $skills = $this->readSkillsJson();
+        Assert::false(\array_key_exists('remote', $skills), 'deprecated key must be gone');
+        Assert::same(
+            $skills['sources'] ?? null,
+            [['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0']],
+        );
+        // Position preserved: `sources` sits exactly where `remote` was,
+        // and every unrelated key stays put in order.
+        Assert::same(
+            \array_keys($skills),
+            ['$schema', 'target', 'sources', 'trusted'],
+            'the renamed key must keep its slot and all siblings must be preserved',
+        );
+        Assert::same($skills['target'] ?? null, 'custom/skills');
+        Assert::same($skills['trusted'] ?? null, ['acme/*']);
+
+        Assert::true(
+            \str_contains($io->getOutput(), 'renamed "remote" to "sources" in skills.json'),
+            'a [migrate] notice must be emitted; got: ' . $io->getOutput(),
+        );
+    }
+
+    public function renameIsNoOpWhenFileAlreadyUsesSources(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'github', 'package' => 'acme/skills']],
+        ]);
+        $before = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $io = new BufferIO();
+        $result = (new ProjectConfigMigrator())->renameSourcesKey(
+            Path::create($this->tmp),
+            $io,
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            $before,
+            'a file already on sources must not be rewritten',
+        );
+        Assert::false(\str_contains($io->getOutput(), 'renamed'));
+    }
+
+    public function renameIsNoOpWhenFileAbsent(): void
+    {
+        $result = (new ProjectConfigMigrator())->renameSourcesKey(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::false(\is_file($this->tmp . '/skills.json'));
+    }
+
+    public function renameLeavesFileWithBothKeysUntouched(): void
+    {
+        // A file carrying both keys is rejected by the mapper's fatal
+        // "both present" check; the migrator must not guess which list
+        // wins, so it leaves the bytes exactly as they are.
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'github', 'package' => 'acme/keep']],
+            'remote' => [['from' => 'github', 'package' => 'acme/drop']],
+        ]);
+        $before = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $result = (new ProjectConfigMigrator())->renameSourcesKey(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            $before,
+            'a both-keys file must be left byte-for-byte untouched',
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeSkillsJson(array $data): void
+    {
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n",
+        );
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/tests/Unit/Config/SourceEntryTest.php
+++ b/tests/Unit/Config/SourceEntryTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Config;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use Testo\Assert;
 use Testo\Codecov\Covers;
 use Testo\Test;
 
 #[Test]
-#[Covers(RemoteEntry::class)]
-final class RemoteEntryTest
+#[Covers(SourceEntry::class)]
+final class SourceEntryTest
 {
     public function identifierReturnsPackageWhenSet(): void
     {
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: ProviderId::GITHUB,
             package: 'acme/skills',
             url: null,
@@ -29,7 +29,7 @@ final class RemoteEntryTest
 
     public function identifierReturnsUrlWhenPackageNull(): void
     {
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: ProviderId::ZIP,
             package: null,
             url: 'https://example.com/x.zip',
@@ -42,7 +42,7 @@ final class RemoteEntryTest
 
     public function compositeKeyCombinesFromHostAndIdentifier(): void
     {
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: ProviderId::GITHUB,
             package: 'acme/skills',
             url: null,
@@ -62,8 +62,8 @@ final class RemoteEntryTest
         // entries differ only if both omit host or both spell the
         // same host — the adapter's default-host fill-in is a runtime
         // concern, not a config-load concern.
-        $a = new RemoteEntry(ProviderId::GITHUB, 'acme/skills', null, null, null);
-        $b = new RemoteEntry(ProviderId::GITHUB, 'acme/skills', null, '', null);
+        $a = new SourceEntry(ProviderId::GITHUB, 'acme/skills', null, null, null);
+        $b = new SourceEntry(ProviderId::GITHUB, 'acme/skills', null, '', null);
 
         Assert::same($a->compositeKey(), 'github||acme/skills');
         // (b cannot be constructed via mapper — non-empty-string — but
@@ -73,7 +73,7 @@ final class RemoteEntryTest
 
     public function extrasDefaultToEmptyMap(): void
     {
-        $entry = new RemoteEntry(ProviderId::GITHUB, 'acme/skills', null, null, null);
+        $entry = new SourceEntry(ProviderId::GITHUB, 'acme/skills', null, null, null);
 
         Assert::same($entry->extras, []);
     }
@@ -83,7 +83,7 @@ final class RemoteEntryTest
         // Adapter-specific keys are stored as-is; the mapper does not
         // validate them. `zip` adapter's `sha256` is the canonical
         // example.
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: ProviderId::ZIP,
             package: null,
             url: 'https://example.com/x.zip',
@@ -103,7 +103,7 @@ final class RemoteEntryTest
         // — the mapper's pre-flight check is one of several lines of
         // defence, not the only one.
         try {
-            new RemoteEntry('github', null, null, null, null);
+            new SourceEntry('github', null, null, null, null);
             Assert::fail('expected InvalidArgumentException');
         } catch (\InvalidArgumentException $e) {
             Assert::true(\str_contains($e->getMessage(), 'neither set'));
@@ -113,7 +113,7 @@ final class RemoteEntryTest
     public function constructorRejectsBothPackageAndUrlSet(): void
     {
         try {
-            new RemoteEntry('github', 'acme/skills', 'https://example.com/x.zip', null, null);
+            new SourceEntry('github', 'acme/skills', 'https://example.com/x.zip', null, null);
             Assert::fail('expected InvalidArgumentException');
         } catch (\InvalidArgumentException $e) {
             Assert::true(\str_contains($e->getMessage(), 'both set'));
@@ -123,14 +123,14 @@ final class RemoteEntryTest
     public function skillsDefaultsToNull(): void
     {
         // No allowlist set ⇒ sync every skill the donor ships.
-        $entry = new RemoteEntry('github', 'acme/skills', null, null, null);
+        $entry = new SourceEntry('github', 'acme/skills', null, null, null);
 
         Assert::same($entry->skills, null);
     }
 
     public function skillsPreservesListWhenSet(): void
     {
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: 'github',
             package: 'acme/skills',
             url: null,
@@ -146,7 +146,7 @@ final class RemoteEntryTest
     {
         // Empty list = "donor registered, no skills pulled from it".
         // Distinct from `null` (= "sync every skill").
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: 'github',
             package: 'acme/skills',
             url: null,
@@ -161,7 +161,7 @@ final class RemoteEntryTest
     public function constructorRejectsSkillsWithEmptyName(): void
     {
         try {
-            new RemoteEntry(
+            new SourceEntry(
                 from: 'github',
                 package: 'acme/skills',
                 url: null,

--- a/tests/Unit/Console/AddCliDefinitionTest.php
+++ b/tests/Unit/Console/AddCliDefinitionTest.php
@@ -144,7 +144,7 @@ final class AddCliDefinitionTest
 
         Assert::same($cmd->getName(), 'skills:add');
         Assert::same($cmd->getAliases(), ['skills:a']);
-        Assert::true(\str_contains($cmd->getDescription(), 'Register a remote donor'));
+        Assert::true(\str_contains($cmd->getDescription(), 'Register a donor source'));
     }
 
     /**

--- a/tests/Unit/Discovery/Provider/Remote/Adapter/GithubAdapterTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/Adapter/GithubAdapterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
@@ -392,7 +392,7 @@ final class GithubAdapterTest
         Expect::exception(RemoteResolveException::class)
             ->withMessageContaining('adapter id mismatch');
 
-        $adapter->resolve(new RemoteEntry(
+        $adapter->resolve(new SourceEntry(
             from: 'gitlab',
             package: 'acme/x',
             url: null,
@@ -401,10 +401,10 @@ final class GithubAdapterTest
         ));
     }
 
-    public function remoteEntryConstructorRejectsBothPackageAndUrlNull(): void
+    public function SourceEntryConstructorRejectsBothPackageAndUrlNull(): void
     {
         // The "package required for github" check used to live in
-        // GithubAdapter::resolve(), but RemoteEntry's constructor now
+        // GithubAdapter::resolve(), but SourceEntry's constructor now
         // refuses entries where neither `package` nor `url` is set —
         // a malformed github entry can no longer reach the adapter.
         // Keep the test as the lower-tier invariant probe so the
@@ -412,7 +412,7 @@ final class GithubAdapterTest
         Expect::exception(\InvalidArgumentException::class)
             ->withMessageContaining('neither set');
 
-        new RemoteEntry(
+        new SourceEntry(
             from: 'github',
             package: null,
             url: null,
@@ -433,9 +433,9 @@ final class GithubAdapterTest
      * @param non-empty-string|null $host
      * @param non-empty-string|null $ref
      */
-    private static function entry(string $package, ?string $host = null, ?string $ref = null): RemoteEntry
+    private static function entry(string $package, ?string $host = null, ?string $ref = null): SourceEntry
     {
-        return new RemoteEntry(
+        return new SourceEntry(
             from: 'github',
             package: $package,
             url: null,

--- a/tests/Unit/Discovery/Provider/Remote/Adapter/GitlabAdapterTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/Adapter/GitlabAdapterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
@@ -493,7 +493,7 @@ final class GitlabAdapterTest
         Expect::exception(RemoteResolveException::class)
             ->withMessageContaining('adapter id mismatch');
 
-        $adapter->resolve(new RemoteEntry(
+        $adapter->resolve(new SourceEntry(
             from: 'github',
             package: 'acme/x',
             url: null,
@@ -514,9 +514,9 @@ final class GitlabAdapterTest
      * @param non-empty-string|null $host
      * @param non-empty-string|null $ref
      */
-    private static function entry(string $package, ?string $host = null, ?string $ref = null): RemoteEntry
+    private static function entry(string $package, ?string $host = null, ?string $ref = null): SourceEntry
     {
-        return new RemoteEntry(
+        return new SourceEntry(
             from: 'gitlab',
             package: $package,
             url: null,

--- a/tests/Unit/Discovery/Provider/Remote/Adapter/HostAdapterRegistryTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/Adapter/HostAdapterRegistryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote\Adapter;
 
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
@@ -115,7 +115,7 @@ final class HostAdapterRegistryTest
             }
 
             #[\Override]
-            public function resolve(RemoteEntry $entry): RemoteDonorRef
+            public function resolve(SourceEntry $entry): RemoteDonorRef
             {
                 throw new \LogicException('not used in registry tests');
             }

--- a/tests/Unit/Discovery/Provider/Remote/CachePathBuilderTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/CachePathBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote;
 
 use Internal\Path;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\CachePathBuilder;
 use Testo\Assert;
@@ -110,7 +110,7 @@ final class CachePathBuilderTest
         // The `zip` adapter has no `package`; the cache key falls back
         // to a URL hash, matching the URL-only layout.
         $b = new CachePathBuilder();
-        $entry = new RemoteEntry(
+        $entry = new SourceEntry(
             from: ProviderId::ZIP,
             package: null,
             url: 'https://example.com/x.zip',
@@ -160,9 +160,9 @@ final class CachePathBuilderTest
      * @param non-empty-string $package
      * @param non-empty-string|null $host
      */
-    private static function entry(string $package, ?string $host = null): RemoteEntry
+    private static function entry(string $package, ?string $host = null): SourceEntry
     {
-        return new RemoteEntry(
+        return new SourceEntry(
             from: ProviderId::GITHUB,
             package: $package,
             url: null,

--- a/tests/Unit/Discovery/Provider/Remote/SkillsJsonRemoteDonorSourceTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/SkillsJsonRemoteDonorSourceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote;
 
 use Internal\Path;
-use LLM\Skills\Config\RemoteEntry;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
@@ -63,7 +63,7 @@ final class SkillsJsonRemoteDonorSourceTest
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
             ],
         ]);
-        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (RemoteEntry $entry) {
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry) {
             return new RemoteDonorRef(
                 url: 'https://api.example.com/' . $entry->identifier() . '/zipball/' . $entry->ref,
                 ref: $entry->ref ?? 'main',
@@ -105,7 +105,7 @@ final class SkillsJsonRemoteDonorSourceTest
                 ['from' => 'github', 'package' => 'acme/missing', 'ref' => '^99.0'],
             ],
         ]);
-        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (RemoteEntry $entry) {
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry) {
             throw new RemoteResolveException($entry, 'no matching tag');
         }));
 
@@ -129,7 +129,7 @@ final class SkillsJsonRemoteDonorSourceTest
                 ['from' => 'gitlab', 'package' => 'acme/unknown'],
             ],
         ]);
-        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (RemoteEntry $entry) {
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry) {
             if ($entry->package === 'acme/bad') {
                 throw new RemoteResolveException($entry, 'simulated failure');
             }
@@ -155,7 +155,7 @@ final class SkillsJsonRemoteDonorSourceTest
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
             ],
         ]);
-        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (RemoteEntry $entry) {
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry) {
             // Note: stub returns provenance=null; the source must
             // re-tag with the entry's from-id.
             return new RemoteDonorRef('https://example.com/x', $entry->ref ?? 'main');
@@ -209,14 +209,14 @@ final class SkillsJsonRemoteDonorSourceTest
 
     /**
      * @param non-empty-string $id
-     * @param callable(RemoteEntry): RemoteDonorRef $resolver
+     * @param callable(SourceEntry): RemoteDonorRef $resolver
      */
     private static function stubAdapter(string $id, callable $resolver): HostAdapter
     {
         return new class($id, $resolver) implements HostAdapter {
             /**
              * @param non-empty-string $id
-             * @param callable(RemoteEntry): RemoteDonorRef $resolver
+             * @param callable(SourceEntry): RemoteDonorRef $resolver
              */
             public function __construct(
                 private readonly string $id,
@@ -245,9 +245,9 @@ final class SkillsJsonRemoteDonorSourceTest
             }
 
             #[\Override]
-            public function resolve(RemoteEntry $entry): RemoteDonorRef
+            public function resolve(SourceEntry $entry): RemoteDonorRef
             {
-                /** @var callable(RemoteEntry): RemoteDonorRef $resolver */
+                /** @var callable(SourceEntry): RemoteDonorRef $resolver */
                 $resolver = $this->resolver;
                 return $resolver($entry);
             }

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -41,7 +41,7 @@ final class InitRunnerTest
 
     public function standaloneModeCreatesStubWithSchemaAndProviderDefaults(): void
     {
-        // The stub advertises the `local` and `remote` knobs explicitly,
+        // The stub advertises the `local` and `sources` knobs explicitly,
         // even when their values match the defaults, so users discover
         // them without reading docs.
         $io = new BufferIO();
@@ -54,14 +54,14 @@ final class InitRunnerTest
         Assert::same($code, Command::SUCCESS);
 
         $written = $this->readSkillsJson();
-        Assert::same(\array_keys($written), ['$schema', 'local', 'remote']);
+        Assert::same(\array_keys($written), ['$schema', 'local', 'sources']);
         Assert::same(
             $written['$schema'],
             InitRunner::SCHEMA_URL,
             '$schema pointer must use the published GitHub raw URL',
         );
         Assert::same($written['local'], ['composer' => true]);
-        Assert::same($written['remote'], []);
+        Assert::same($written['sources'], []);
 
         // Output advertises the mode so the user understands no composer.json
         // edits happened (because there is no composer.json).
@@ -279,7 +279,7 @@ final class InitRunnerTest
         );
 
         Assert::same($code, Command::SUCCESS);
-        Assert::same(\array_keys($this->readSkillsJson()), ['$schema', 'local', 'remote']);
+        Assert::same(\array_keys($this->readSkillsJson()), ['$schema', 'local', 'sources']);
         Assert::true(\str_contains($io->getOutput(), 'no project keys to migrate'));
     }
 


### PR DESCRIPTION
## What

The \`remote[]\` project-config key is renamed to **\`sources[]\`** — it holds the list of *explicit donor sources* (implicit trust, per-entry skill allowlist, provenance filter), and upcoming adapters (a \`dir\` adapter for local directories) are not "remote" at all. This is a **minor release**: full back-compat, no CLI changes.

## How it behaves

- \`sources\` is the canonical key in both \`skills.json\` and inline \`extra.skills\`; \`remote\` keeps being read as a **deprecated alias**.
- Both keys in one block is a **fatal config error** (\`both "sources" and "remote" are present; keep "sources" only\`) — no silent precedence.
- **Write-mode commands** (\`skills:update\`, \`skills:init\`, \`skills:add\`) migrate a legacy file in place: atomic write, key position and sibling keys preserved verbatim, \`[migrate] renamed "remote" to "sources" in skills.json\` notice. Idempotent; a both-keys file is left untouched.
- **Read-only surfaces** (\`skills:show\`, the \`post-install-cmd\` hook) never rewrite anything and emit a \`[deprecated]\` notice instead — same read-only/write split the \`extra.skills\` → \`skills.json\` migration established.
- The inline → \`skills.json\` migration writes \`sources\` (the generated file never carries the alias); \`composer.json\` key-stripping still targets the key names actually present.
- Error field-paths reflect the key the user wrote (\`sources[0].from\` vs \`remote[0].from\`).

## Compatibility

- **CLI**: no flag, argument, or command renames — only help texts (none of the flags ever mentioned "remote").
- **Schema**: \`sources\` documented; \`remote\` kept with \`"deprecated": true\`; root-level \`not\` mirrors the both-keys rejection.
- **Internals**: \`RemoteEntry\` → \`SourceEntry\`, \`ProjectConfig::$sources\`, \`mapSource*\` (pure rename, separate commit). The fetch layer (\`Provider\Remote\\` namespace, \`ProviderId::REMOTE_IDS\`) is intentionally untouched — those names describe network fetching and get revisited when the \`dir\` adapter lands.

## Tests

- Unit: alias parsing, both-keys fatal (both prefixes), in-place rename (happy path / idempotence / both-keys-untouched / key-order preservation), inline migration folding, writer normalisation with allowlist merge.
- Acceptance (\`SkillsSourcesMigrationTest\`): \`skills:update\` migrates the file and syncs; \`skills:show\` is byte-non-destructive and warns; both-keys file fails without being touched.
- \`composer test\`: 703 passed / 1 skipped (7 pre-existing \`StandaloneBinTest\` failures come from an unrelated local working-tree state, not this branch). \`composer psalm\` and \`composer cs:diff\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)