### PR TITLE
feat: `dir` source adapter — local directories as explicit donors

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Shipped in [`resources/trusted-composer.txt`](resources/trusted-composer.txt); e
 
 - **Local providers** — walk a manifest the project already owns. Today only `composer`; `npm` and `go` are reserved in the vocabulary but ship later.
 - **Remote providers** — fetch an explicit ref from a URL (currently GitHub and GitLab; the format is forward-compatible with Bitbucket, npm registry, Go module proxy, private Packagist, `http`/`zip`).
+- **Local directory donors** — the `dir` adapter reads a directory already on disk (a shared skills folder next to the repo, a monorepo sibling); no fetch, no cache. See [Local directory donors](#local-directory-donors-dir).
 
 Both axes coexist. When the same package name arrives via both, the **`sources` entry wins** (you typed it; the transitive Composer pickup is treated as stale) and the displaced donor is logged under `-v`.
 
@@ -434,6 +435,8 @@ composer skills:add team/skills --from=gitlab \
 composer skills:add acme/skills \
         --skill=code-review --skill=refactor                  # only these two skills
 composer skills:add acme/skills --no-sync                     # only edit skills.json
+composer skills:add ./skills                                  # local directory donor (dir)
+composer skills:add ../shared-skills --skill=deploy           # sibling folder, single skill
 ```
 
 `--from` defaults to `github` for shorthand input (`owner/repo`). Pass it explicitly only when targeting a different adapter, or override it when the URL host is ambiguous. Full URLs still resolve the adapter from the host — `--from` is only consulted as an override.
@@ -449,8 +452,8 @@ The command:
 
 | Option        | Description                                                                                                   |
 |---------------|---------------------------------------------------------------------------------------------------------------|
-| `<input>`     | Shorthand `owner/repo`, shorthand with `@ref`, or a full URL.                                                  |
-| `--from=ID`   | Adapter id. Required for shorthand; inferred from the URL host when omitted with a full URL.                   |
+| `<input>`     | Shorthand `owner/repo`, shorthand with `@ref`, a full URL, or a local directory path (`./skills`, `../shared`, an absolute path). |
+| `--from=ID`   | Adapter id (`github`, `gitlab`, `dir`, …). Defaults to `github` for shorthand; inferred from the URL host for a full URL; inferred as `dir` when the input opens with a path prefix. |
 | `--host=URL`  | Override the adapter's default host (GitHub Enterprise, self-hosted GitLab, private Packagist).               |
 | `--ref=REF`   | Pin a tag, branch, SHA, or Composer-style constraint (`^1.2.3`). Without this, the cascade above runs.        |
 | `--skill=NAME`| Restrict the donor to a specific skill directory. Repeatable. Names accumulate across consecutive `skills:add` calls. Without the flag, every skill the donor ships is synced. |
@@ -481,6 +484,33 @@ A donor often ships more skills than you want in a given project. The optional `
 - Names that do not exist in the fetched archive emit a `-v` warning (`skill "X" declared in the skill allowlist but not found in the donor`) so typos surface without aborting the sync.
 
 `skills:add --skill=NAME` is the CLI surface: pass `--skill` repeatedly to build the list. The flag is **additive on upsert** — running `skills:add` again on the same entry adds the new names to whatever was already stored. A follow-up `skills:add` without `--skill` does **not** touch the existing allowlist (whether it was a populated list or an explicit empty one). Removing a name or clearing the allowlist entirely is a manual edit of `skills.json`.
+
+### Local directory donors (`dir`)
+
+The `dir` adapter registers a directory already on disk as an explicit donor — a shared skills folder next to the repo, a monorepo sibling, or a working copy you are iterating on. There is no fetch, no cache, and no ref: the directory is read live on every sync, so edits show up on the next `skills:update` with nothing to invalidate.
+
+```jsonc
+{
+  "sources": [
+    { "from": "dir", "path": "./skills" },
+    { "from": "dir", "path": "../shared-skills", "package": "myorg/shared", "skills": ["deploy"] }
+  ]
+}
+```
+
+`skills:add` selects the adapter from the input shape — a path opening with `./`, `../`, `/`, `\`, or a Windows drive letter (`X:`) is treated as a directory; `--from=dir` forces it for a bare name:
+
+```bash
+composer skills:add ./skills                       # relative to the project root
+composer skills:add ../shared-skills --skill=deploy
+composer skills:add /srv/team/skills               # absolute path
+composer skills:add D:\team\skills --from=dir
+```
+
+- **Path resolution.** A relative `path` resolves from the project root (the same anchor `target` uses); absolute paths (including Windows drive letters) are honoured as-is. `..` segments and locations outside the project root are allowed — a `sources[]` entry is an explicit act of trust. The stored `path` is kept as typed (normalised to forward slashes).
+- **Package name.** The donor's name is the entry's `package` override if present, else the directory's own `composer.json` `name`, else it is derived from the resolved path as `<parent>/<basename>` lowercased (e.g. `.../testo/skills` → `testo/skills`).
+- **Implicit trust.** Like every `sources[]` entry, a `dir` donor is trusted by declaration — you typed the path, so its skills sync without a `trusted` listing.
+- `url`, `host`, and `ref` are not applicable and are rejected (there is no host and no version concept); the per-entry `skills` allowlist behaves exactly as for other adapters. A `path` that does not exist at sync time degrades to a `-v` warning and is skipped, but an explicit `skills:add` of a missing directory is refused up front (a missing directory at add time is a typo).
 
 ### Authentication
 

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -84,7 +84,8 @@
             "items": {
                 "oneOf": [
                     { "$ref": "#/$defs/sourceByPackage" },
-                    { "$ref": "#/$defs/sourceByUrl" }
+                    { "$ref": "#/$defs/sourceByUrl" },
+                    { "$ref": "#/$defs/sourceByDir" }
                 ]
             }
         },
@@ -96,7 +97,8 @@
             "items": {
                 "oneOf": [
                     { "$ref": "#/$defs/sourceByPackage" },
-                    { "$ref": "#/$defs/sourceByUrl" }
+                    { "$ref": "#/$defs/sourceByUrl" },
+                    { "$ref": "#/$defs/sourceByDir" }
                 ]
             }
         }
@@ -173,6 +175,35 @@
                     "type": "string",
                     "minLength": 1,
                     "description": "Optional integrity hash (zip adapter)."
+                }
+            }
+        },
+        "sourceByDir": {
+            "type": "object",
+            "description": "Donor source entry for the path-based adapter (dir): a local directory declared as an explicit donor. url/host/ref are not applicable — the PHP mapper rejects them; the oneOf dispatch on the from enum keeps documents honest without an additionalProperties constraint here.",
+            "required": ["from", "path"],
+            "properties": {
+                "from": {
+                    "type": "string",
+                    "enum": ["dir"]
+                },
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Filesystem path to the donor directory. Relative paths resolve from the project root; absolute paths (including Windows drive letters) are honoured as-is. \"..\" segments and locations outside the project root are allowed — a sources entry is an explicit act of trust."
+                },
+                "package": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional donor package-name override. Absent → derived from the directory's own composer.json name, falling back to <parent>/<basename> of the resolved path (lowercased)."
+                },
+                "skills": {
+                    "type": "array",
+                    "description": "Optional allowlist of skill directory names to sync from this donor. Absent / omitted → sync every skill the donor ships; empty list → donor is registered but no skills are pulled (matches `sourceByPackage` semantics).",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
                 }
             }
         }

--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -318,7 +318,9 @@ final readonly class AddRunner
         // with its own composer.json name is registered under that name
         // downstream, so this derived fallback only matches a bare skill
         // directory; the add path skips the composer.json probe by
-        // design, trading a scoped sync for a full one in that case.
+        // design, so for a composer-shaped directory the scoped sync
+        // matches nothing and copies nothing — the entry is registered
+        // and a plain `skills:update` picks it up.
         $onRegistered?->__invoke($entry, DirDonorRef::derivePackageName($resolved));
 
         return Command::SUCCESS;

--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -14,6 +14,7 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\UnknownAdapterException;
+use LLM\Skills\Discovery\Provider\Remote\DirDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\DonorArchiveInspector;
 use LLM\Skills\Discovery\Provider\Remote\DonorArchiveRejection;
 use LLM\Skills\Discovery\Provider\Remote\RefResolver;
@@ -51,6 +52,12 @@ use Symfony\Component\Console\Command\Command;
  *
  * Errors at any step return {@see Command::FAILURE} with a clear
  * message via the {@see IOInterface}.
+ *
+ * A path-only `dir` input short-circuits this flow: it has no host,
+ * ref, or archive to fetch, so {@see self::runDir()} handles it ahead
+ * of adapter selection — normalise the path, check the directory
+ * exists, upsert the entry, and hand the derived donor name to
+ * `$onRegistered` for the scoped sync.
  */
 final readonly class AddRunner
 {
@@ -86,6 +93,14 @@ final readonly class AddRunner
         AddOptions $options,
         ?\Closure $onRegistered = null,
     ): int {
+        // A `dir` input never flows through a HostAdapter — there is no
+        // host, no ref cascade, and no network — so it takes a dedicated
+        // branch ahead of adapter selection instead of a synthetic
+        // adapter that would have nothing to resolve.
+        if (self::isDirInput($options)) {
+            return $this->runDir($projectRoot, $io, $options, $onRegistered);
+        }
+
         // Step 1: adapter selection.
         $adapter = $this->selectAdapter($options, $io);
         if ($adapter === null) {
@@ -165,6 +180,41 @@ final readonly class AddRunner
     }
 
     /**
+     * Whether the input selects the path-only `dir` adapter. Explicit
+     * `--from=dir` forces it (even for a bare name that happens to be a
+     * directory); otherwise, with no `--from`, an input that opens with
+     * a path prefix (`./`, `../`, `/`, `\`, a drive letter `X:`, or the
+     * backslash spellings of those) is treated as a local directory.
+     * A shorthand like `owner/repo` lacks a path prefix, so it never
+     * collides with this heuristic.
+     *
+     * @psalm-pure
+     */
+    private static function isDirInput(AddOptions $options): bool
+    {
+        if ($options->from === ProviderId::DIR) {
+            return true;
+        }
+        if ($options->from !== null) {
+            return false;
+        }
+        return self::looksLikePath($options->input);
+    }
+
+    /**
+     * Path-shape heuristic: the input starts with `./`, `../`, a bare
+     * separator (`/` or `\`), or a Windows drive-letter prefix (`X:`).
+     * The `./` and `../` forms accept either separator so a Windows
+     * `.\skills` spelling is recognised too.
+     *
+     * @psalm-pure
+     */
+    private static function looksLikePath(string $input): bool
+    {
+        return \preg_match('~^(\.\.?[/\\\\]|[/\\\\]|[a-zA-Z]:)~', $input) === 1;
+    }
+
+    /**
      * Build a {@see SourceEntry} from the parsed input for the
      * adapter's `resolve()` call. The synthesised entry differs
      * from what will eventually land in `skills.json` only in that
@@ -195,6 +245,83 @@ final readonly class AddRunner
     private static function looksLikeUrl(string $input): bool
     {
         return \preg_match('~^https?://~i', $input) === 1;
+    }
+
+    /**
+     * Register a local directory donor. No adapter, no ref resolution,
+     * no fetch: the input is normalised to forward slashes and kept as
+     * typed (relative stays relative, absolute stays absolute), the
+     * directory's existence is checked once — an explicit add of a
+     * missing directory is a typo worth refusing loudly — and the entry
+     * is upserted into `skills.json`. The follow-up sync reads the live
+     * directory through the same pipeline every other donor uses.
+     *
+     * @param \Closure(SourceEntry, non-empty-string):void|null $onRegistered
+     */
+    private function runDir(
+        Path $projectRoot,
+        IOInterface $io,
+        AddOptions $options,
+        ?\Closure $onRegistered,
+    ): int {
+        // `--ref` / `--host` carry no meaning for a directory; reject
+        // them up front with the same framing the mapper uses when it
+        // finds `ref`/`host` on a stored `dir` entry.
+        if ($options->ref !== null) {
+            $io->writeError('<error>[llm/skills] --ref is not allowed for adapter "dir"</error>');
+            return Command::INVALID;
+        }
+        if ($options->host !== null) {
+            $io->writeError('<error>[llm/skills] --host is not allowed for adapter "dir"</error>');
+            return Command::INVALID;
+        }
+
+        /** @var non-empty-string $spelling forward-slash spelling of a non-empty input */
+        $spelling = \str_replace('\\', '/', $options->input);
+
+        $typed = Path::create($spelling);
+        $resolved = $typed->isAbsolute() ? $typed : $projectRoot->join($typed);
+
+        if (!$resolved->isDir()) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] dir %s: directory does not exist</error>',
+                $spelling,
+            ));
+            return Command::FAILURE;
+        }
+
+        $entry = new SourceEntry(
+            from: ProviderId::DIR,
+            package: null,
+            url: null,
+            host: null,
+            ref: null,
+            skills: $options->skills,
+            path: $spelling,
+        );
+
+        try {
+            $this->writer->upsertSource($projectRoot, $entry);
+        } catch (\Throwable $e) {
+            $io->writeError('<error>[llm/skills] failed to update skills.json: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        $io->write(\sprintf(
+            '<info>[llm/skills] registered %s:%s</info>',
+            $entry->from,
+            $entry->identifier(),
+        ));
+
+        // Scope the follow-up sync on the same package name the sync
+        // pipeline will derive for this directory (§4.1). A directory
+        // with its own composer.json name is registered under that name
+        // downstream, so this derived fallback only matches a bare skill
+        // directory; the add path skips the composer.json probe by
+        // design, trading a scoped sync for a full one in that case.
+        $onRegistered?->__invoke($entry, DirDonorRef::derivePackageName($resolved));
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Add/AddRunner.php
+++ b/src/Add/AddRunner.php
@@ -55,9 +55,10 @@ use Symfony\Component\Console\Command\Command;
  *
  * A path-only `dir` input short-circuits this flow: it has no host,
  * ref, or archive to fetch, so {@see self::runDir()} handles it ahead
- * of adapter selection — normalise the path, check the directory
- * exists, upsert the entry, and hand the derived donor name to
- * `$onRegistered` for the scoped sync.
+ * of adapter selection — normalise the path, inspect the directory
+ * (refusing a missing or non-donor shape, just as the remote path
+ * refuses an unusable archive), upsert the entry, and hand the
+ * inspected donor name to `$onRegistered` for the scoped sync.
  */
 final readonly class AddRunner
 {
@@ -250,11 +251,19 @@ final readonly class AddRunner
     /**
      * Register a local directory donor. No adapter, no ref resolution,
      * no fetch: the input is normalised to forward slashes and kept as
-     * typed (relative stays relative, absolute stays absolute), the
+     * typed (relative stays relative, absolute stays absolute), and the
      * directory's existence is checked once — an explicit add of a
-     * missing directory is a typo worth refusing loudly — and the entry
-     * is upserted into `skills.json`. The follow-up sync reads the live
-     * directory through the same pipeline every other donor uses.
+     * missing directory is a typo worth refusing loudly.
+     *
+     * The directory is then inspected through the shared
+     * {@see DonorArchiveInspector} — a cheap local read, no network —
+     * with the same package hint the sync source derives. A non-donor
+     * shape (no composer.json donor declaration, no SKILL.md files) is
+     * refused before anything is written, mirroring the remote path's
+     * "refuse to register a donor we cannot actually use" contract.
+     * On success the inspection yields the donor's true package name,
+     * which scopes the follow-up sync so it filters on the same name
+     * the sync pipeline registers this directory under.
      *
      * @param \Closure(SourceEntry, non-empty-string):void|null $onRegistered
      */
@@ -290,6 +299,27 @@ final readonly class AddRunner
             return Command::FAILURE;
         }
 
+        // Inspect the live directory with the same shared inspector the
+        // sync path runs, using the package hint the sync source derives
+        // (§4.1). Refusing a non-donor shape here keeps `skills:add` from
+        // writing an entry the sync would then ignore — a skill declared
+        // but never copied.
+        $inspection = $this->inspector->inspect(
+            $resolved,
+            DirDonorRef::derivePackageName($resolved),
+        );
+
+        $rejection = $inspection->rejection;
+        if ($rejection !== null) {
+            $io->writeError('<error>[llm/skills] '
+                . $this->describeDirRejection($rejection, $inspection->detail, $spelling)
+                . '</error>');
+            return Command::FAILURE;
+        }
+
+        /** @var non-empty-string $donorPackageName the inspector always names an accepted donor */
+        $donorPackageName = $inspection->packageName;
+
         $entry = new SourceEntry(
             from: ProviderId::DIR,
             package: null,
@@ -313,15 +343,13 @@ final readonly class AddRunner
             $entry->identifier(),
         ));
 
-        // Scope the follow-up sync on the same package name the sync
-        // pipeline will derive for this directory (§4.1). A directory
-        // with its own composer.json name is registered under that name
-        // downstream, so this derived fallback only matches a bare skill
-        // directory; the add path skips the composer.json probe by
-        // design, so for a composer-shaped directory the scoped sync
-        // matches nothing and copies nothing — the entry is registered
-        // and a plain `skills:update` picks it up.
-        $onRegistered?->__invoke($entry, DirDonorRef::derivePackageName($resolved));
+        // Scope the follow-up sync on the donor's true package name: for
+        // a composer-shaped directory the inspection returns its
+        // composer.json `name`; for a bare skill directory it returns the
+        // derived hint. Either way it matches the name the sync pipeline
+        // registers this directory under (§4.1), so the scoped sync finds
+        // the donor and copies its skills.
+        $onRegistered?->__invoke($entry, $donorPackageName);
 
         return Command::SUCCESS;
     }
@@ -484,5 +512,39 @@ final readonly class AddRunner
                 $adapterId,
             ),
         };
+    }
+
+    /**
+     * Phrase a {@see DonorArchiveRejection} for a `dir` add. Mirrors
+     * {@see self::describeRejection()} but frames the reason against the
+     * inspected directory (`dir <spelling>: …`) rather than a fetched
+     * archive. `NoPackageName` is unreachable for a directory — the hint
+     * derived from the path is always present — but is phrased for
+     * completeness so the match stays exhaustive.
+     *
+     * @param non-empty-string $spelling
+     *
+     * @psalm-pure
+     */
+    private function describeDirRejection(
+        DonorArchiveRejection $rejection,
+        ?string $detail,
+        string $spelling,
+    ): string {
+        $reason = match ($rejection) {
+            DonorArchiveRejection::ComposerJsonUnreadable =>
+                'failed to read composer.json',
+            DonorArchiveRejection::ComposerJsonInvalidJson =>
+                'composer.json is not valid JSON: ' . ($detail ?? ''),
+            DonorArchiveRejection::ComposerJsonNotObject =>
+                'composer.json must be a JSON object',
+            DonorArchiveRejection::NoDonorShape =>
+                'directory ships neither a composer.json with extra.skills.source '
+                . 'nor any SKILL.md files — cannot register as a skill donor',
+            DonorArchiveRejection::NoPackageName =>
+                'directory ships SKILL.md files but no package name to register it under',
+        };
+
+        return \sprintf('dir %s: %s', $spelling, $reason);
     }
 }

--- a/src/Add/SkillsJsonWriter.php
+++ b/src/Add/SkillsJsonWriter.php
@@ -17,7 +17,7 @@ use LLM\Skills\Filesystem\AtomicFileWriter;
  *
  * Three guarantees:
  *
- * - **Upsert by composite key** — `(from, host ?? '', package | url)`.
+ * - **Upsert by composite key** — `(from, host ?? '', path | package | url)`.
  *   Same key ⇒ overwrite in place; new key ⇒ append.
  * - **Stable sort** — after the upsert the whole `sources[]` is
  *   reordered by composite key so diffs are deterministic across
@@ -326,8 +326,9 @@ final readonly class SkillsJsonWriter
     /**
      * Render an entry as the JSON-serialisable map for storage. Key
      * order is fixed for stable diffs: `from` → `host` (if present) →
-     * `package` or `url` → `ref` (if present) → `skills` (if present)
-     * → extras.
+     * `path` or `package` or `url` → `ref` (if present) → `skills`
+     * (if present) → extras. `path` and `package` may co-exist on a
+     * `dir` entry (path is the identifier, package a name override).
      *
      * @param SourceEntry|array<string, mixed> $entry
      *
@@ -341,6 +342,9 @@ final readonly class SkillsJsonWriter
             $out = ['from' => $entry->from];
             if ($entry->host !== null) {
                 $out['host'] = $entry->host;
+            }
+            if ($entry->path !== null) {
+                $out['path'] = $entry->path;
             }
             if ($entry->package !== null) {
                 $out['package'] = $entry->package;
@@ -384,15 +388,24 @@ final readonly class SkillsJsonWriter
         $fromStr = \is_string($from) ? $from : '';
         $hostStr = \is_string($host) ? $host : '';
         $identifier = '';
-        /** @var mixed $package */
-        $package = $entry['package'] ?? null;
-        if (\is_string($package)) {
-            $identifier = $package;
+        // Mirror SourceEntry::identifier(): `path` wins for dir entries
+        // (where `package` may also be present as a name override),
+        // then `package`, then `url`.
+        /** @var mixed $path */
+        $path = $entry['path'] ?? null;
+        if (\is_string($path)) {
+            $identifier = $path;
         } else {
-            /** @var mixed $url */
-            $url = $entry['url'] ?? null;
-            if (\is_string($url)) {
-                $identifier = $url;
+            /** @var mixed $package */
+            $package = $entry['package'] ?? null;
+            if (\is_string($package)) {
+                $identifier = $package;
+            } else {
+                /** @var mixed $url */
+                $url = $entry['url'] ?? null;
+                if (\is_string($url)) {
+                    $identifier = $url;
+                }
             }
         }
         return $fromStr . '|' . $hostStr . '|' . $identifier;

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -193,9 +193,9 @@ final readonly class ProjectConfigMapper
     /**
      * Pick adapter-specific extras out of a `sources[]` entry — anything
      * that is not one of the well-known keys (`from`, `package`, `url`,
-     * `host`, `ref`). Stored verbatim so adapters can read their own
-     * keys (`sha256` on `zip`, custom proxy options on `go`, …) without
-     * a mapper-level schema for every adapter.
+     * `host`, `ref`, `skills`, `path`). Stored verbatim so adapters can
+     * read their own keys (`sha256` on `zip`, custom proxy options on
+     * `go`, …) without a mapper-level schema for every adapter.
      *
      * @param array<array-key, mixed> $entry
      *
@@ -219,6 +219,7 @@ final readonly class ProjectConfigMapper
                 || $key === 'host'
                 || $key === 'ref'
                 || $key === 'skills'
+                || $key === 'path'
             ) {
                 continue;
             }
@@ -496,11 +497,12 @@ final readonly class ProjectConfigMapper
 
     /**
      * Parse and validate the `sources[]` list. Each entry is structurally
-     * an object with a mandatory `from` (adapter id), exactly one of
-     * `package` / `url`, and optional `host` / `ref` plus
+     * an object with a mandatory `from` (adapter id), an identifier
+     * matching the adapter kind (`path` for dir, `url` for URL-only,
+     * `package` otherwise), and optional `host` / `ref` plus
      * adapter-specific extras. Composite uniqueness on
-     * `(from, host, package|url)` is enforced inside this method so the
-     * caller does not have to.
+     * `(from, host, path|package|url)` is enforced inside this method so
+     * the caller does not have to.
      *
      * @param non-empty-string $prefix
      * @param non-empty-string $key config key the list was read from (`sources` or its
@@ -588,33 +590,65 @@ final readonly class ProjectConfigMapper
         $url = self::optionalNonEmptyString($entry['url'] ?? null, $field, 'url');
         $host = self::optionalNonEmptyString($entry['host'] ?? null, $field, 'host');
         $ref = self::optionalNonEmptyString($entry['ref'] ?? null, $field, 'ref');
+        $path = self::optionalNonEmptyString($entry['path'] ?? null, $field, 'path');
 
-        // Identifier rules: URL-only adapters take `url`; name-based
-        // adapters take `package`. Exactly one of the two must be set
-        // and it must be the one the adapter expects — a typo here
-        // (e.g. `package` on a `zip` entry) is a silent footgun if we
-        // accept it, so it surfaces as a load-time error instead.
-        if (ProviderId::isUrlOnlyRemote($from)) {
-            if ($url === null) {
+        // Identifier rules by adapter kind: path-only adapters (dir)
+        // take `path`; URL-only adapters take `url`; name-based adapters
+        // take `package`. The identifier must be the one the adapter
+        // expects — a typo (e.g. `package` on a `zip` entry, or `url`
+        // on a `dir` entry) is a silent footgun if we accept it, so it
+        // surfaces as a load-time error instead.
+        if (ProviderId::isPathOnlySource($from)) {
+            // `path` is the identifier; `package` stays optional as a
+            // donor-name override; `url`/`host`/`ref` are meaningless.
+            if ($path === null) {
                 throw new MalformedProjectConfig(
-                    $field . '.url is required for adapter "' . $from . '"',
-                );
-            }
-            if ($package !== null) {
-                throw new MalformedProjectConfig(
-                    $field . '.package is not allowed for adapter "' . $from . '" (use url)',
-                );
-            }
-        } else {
-            if ($package === null) {
-                throw new MalformedProjectConfig(
-                    $field . '.package is required for adapter "' . $from . '"',
+                    $field . '.path is required for adapter "' . $from . '"',
                 );
             }
             if ($url !== null) {
                 throw new MalformedProjectConfig(
-                    $field . '.url is not allowed for adapter "' . $from . '" (use package)',
+                    $field . '.url is not allowed for adapter "' . $from . '" (use path)',
                 );
+            }
+            if ($host !== null) {
+                throw new MalformedProjectConfig(
+                    $field . '.host is not allowed for adapter "' . $from . '"',
+                );
+            }
+            if ($ref !== null) {
+                throw new MalformedProjectConfig(
+                    $field . '.ref is not allowed for adapter "' . $from . '"',
+                );
+            }
+        } else {
+            if ($path !== null) {
+                throw new MalformedProjectConfig(
+                    $field . '.path is not allowed for adapter "' . $from . '" (dir only)',
+                );
+            }
+            if (ProviderId::isUrlOnlyRemote($from)) {
+                if ($url === null) {
+                    throw new MalformedProjectConfig(
+                        $field . '.url is required for adapter "' . $from . '"',
+                    );
+                }
+                if ($package !== null) {
+                    throw new MalformedProjectConfig(
+                        $field . '.package is not allowed for adapter "' . $from . '" (use url)',
+                    );
+                }
+            } else {
+                if ($package === null) {
+                    throw new MalformedProjectConfig(
+                        $field . '.package is required for adapter "' . $from . '"',
+                    );
+                }
+                if ($url !== null) {
+                    throw new MalformedProjectConfig(
+                        $field . '.url is not allowed for adapter "' . $from . '" (use package)',
+                    );
+                }
             }
         }
 
@@ -630,6 +664,7 @@ final readonly class ProjectConfigMapper
             ref: $ref,
             extras: $extras,
             skills: $skills,
+            path: $path,
         );
     }
 

--- a/src/Config/SourceEntry.php
+++ b/src/Config/SourceEntry.php
@@ -4,32 +4,44 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Config;
 
+use LLM\Skills\Discovery\Provider\ProviderId;
+
 /**
  * One entry of the `sources[]` list in `skills.json`.
  *
  * Each entry tells the remote provider what to fetch and where from:
- * `from` is the adapter id (a value from {@see \LLM\Skills\Discovery\Provider\ProviderId}),
- * `package` or `url` is the identifier inside that adapter's namespace,
- * `host` overrides the adapter's default registry (private Packagist /
- * GitHub Enterprise / self-hosted GitLab / …), `ref` is an
- * adapter-specific version pin, and `extras` carries adapter-specific
- * optional keys (e.g. `sha256` on `zip`).
+ * `from` is the adapter id (a value from {@see ProviderId}),
+ * the identifier inside that adapter's namespace is `package`, `url`,
+ * or `path` depending on the adapter kind, `host` overrides the
+ * adapter's default registry (private Packagist / GitHub Enterprise /
+ * self-hosted GitLab / …), `ref` is an adapter-specific version pin,
+ * and `extras` carries adapter-specific optional keys (e.g. `sha256`
+ * on `zip`).
  *
- * Exactly one of `package` and `url` is set — the mapper enforces this
- * up-front; downstream code can rely on {@see self::identifier()}
- * never being empty.
+ * The identifier field depends on the adapter kind:
+ *
+ * - path-only adapters ({@see ProviderId::DIR}) identify the donor by
+ *   `path`; `url` is forbidden and `package` is only an optional name
+ *   override;
+ * - URL-only adapters ({@see ProviderId::HTTP}, {@see ProviderId::ZIP})
+ *   identify it by `url`;
+ * - name-based adapters identify it by `package`.
+ *
+ * The mapper enforces the adapter-specific rules up-front; downstream
+ * code can rely on {@see self::identifier()} never being empty.
  *
  * @psalm-immutable
  */
 final readonly class SourceEntry
 {
     /**
-     * @param non-empty-string $from adapter id, e.g. {@see \LLM\Skills\Discovery\Provider\ProviderId::GITHUB}
+     * @param non-empty-string $from adapter id, e.g. {@see ProviderId::GITHUB}
      * @param non-empty-string|null $package adapter-namespaced identifier (`acme/skills`,
-     *         `@scope/pkg`, `github.com/owner/mod`, …). Mutually exclusive with `$url`.
+     *         `@scope/pkg`, `github.com/owner/mod`, …). The identifier for name-based
+     *         adapters; an optional donor-name override for path-only adapters.
      * @param non-empty-string|null $url full URL — used by URL-only adapters
-     *         ({@see \LLM\Skills\Discovery\Provider\ProviderId::HTTP},
-     *         {@see \LLM\Skills\Discovery\Provider\ProviderId::ZIP}). Mutually exclusive with `$package`.
+     *         ({@see ProviderId::HTTP}, {@see ProviderId::ZIP}). Mutually exclusive
+     *         with `$package`; forbidden for path-only adapters.
      * @param non-empty-string|null $host explicit registry / API host override; absent means
      *         "use the adapter's default" (e.g. `https://api.github.com` for github).
      * @param non-empty-string|null $ref adapter-specific version pin (`^1.2.3`, `v1.2.3`,
@@ -44,9 +56,14 @@ final readonly class SourceEntry
      *         — useful for staging a donor before opting into its content or for temporarily
      *         disabling a donor without deleting the entry. Names that do not exist in the
      *         fetched archive surface as `-v` warnings without aborting the sync.
+     * @param non-empty-string|null $path filesystem path to the donor directory — the
+     *         identifier for path-only adapters ({@see ProviderId::DIR}). Non-null exactly
+     *         when `$from` is a path-only adapter; null for every other adapter kind.
      *
-     * @throws \InvalidArgumentException unless exactly one of `$package` and `$url` is non-null,
-     *         or if `$skills` contains a non-string / contains an empty string
+     * @throws \InvalidArgumentException on an identifier shape that violates the adapter kind
+     *         (path-only requires `$path` and forbids `$url`; every other adapter requires
+     *         exactly one of `$package` / `$url` and forbids `$path`), or if `$skills`
+     *         contains a non-string / contains an empty string
      *
      * @psalm-mutation-free
      * @psalm-pure
@@ -59,19 +76,41 @@ final readonly class SourceEntry
         public ?string $ref,
         public array $extras = [],
         public ?array $skills = null,
+        public ?string $path = null,
     ) {
-        // The "exactly one of package/url" invariant is the contract
-        // every downstream method relies on (identifier(),
-        // compositeKey(), the cache-path builder). Enforce it in the
-        // constructor so a direct caller cannot smuggle a half-built
-        // VO past the mapper.
-        $hasPackage = $package !== null;
-        $hasUrl = $url !== null;
-        if ($hasPackage === $hasUrl) {
-            throw new \InvalidArgumentException(
-                'SourceEntry requires exactly one of $package or $url to be non-null; got '
-                . ($hasPackage ? 'both set' : 'neither set'),
-            );
+        // The identifier-shape invariant is the contract every
+        // downstream method relies on (identifier(), compositeKey(),
+        // the cache-path builder). Enforce it in the constructor so a
+        // direct caller cannot smuggle a half-built VO past the mapper.
+        if (ProviderId::isPathOnlySource($from)) {
+            // Path-only adapters (dir) identify the donor by $path;
+            // $url is meaningless and $package is only an optional
+            // name override, so the exactly-one-of-package/url rule
+            // does not apply.
+            if ($path === null) {
+                throw new \InvalidArgumentException(
+                    'SourceEntry requires $path for path-only adapter "' . $from . '".',
+                );
+            }
+            if ($url !== null) {
+                throw new \InvalidArgumentException(
+                    'SourceEntry does not allow $url for path-only adapter "' . $from . '".',
+                );
+            }
+        } else {
+            if ($path !== null) {
+                throw new \InvalidArgumentException(
+                    'SourceEntry does not allow $path for adapter "' . $from . '".',
+                );
+            }
+            $hasPackage = $package !== null;
+            $hasUrl = $url !== null;
+            if ($hasPackage === $hasUrl) {
+                throw new \InvalidArgumentException(
+                    'SourceEntry requires exactly one of $package or $url to be non-null; got '
+                    . ($hasPackage ? 'both set' : 'neither set'),
+                );
+            }
         }
 
         // The psalm-level annotation already says `list<non-empty-string>|null`,
@@ -92,9 +131,10 @@ final readonly class SourceEntry
     }
 
     /**
-     * Identifier inside the adapter's namespace — `$package` when set,
-     * `$url` otherwise. The constructor enforces "exactly one is
-     * non-null", so the return value is always a non-empty string.
+     * Identifier inside the adapter's namespace — `$path` for path-only
+     * adapters, else `$package` when set, else `$url`. The constructor
+     * enforces that exactly one of these is populated for the adapter
+     * kind, so the return value is always a non-empty string.
      *
      * @return non-empty-string
      *
@@ -103,13 +143,16 @@ final readonly class SourceEntry
     public function identifier(): string
     {
         /** @var non-empty-string */
-        return $this->package ?? $this->url ?? '';
+        return $this->path ?? $this->package ?? $this->url ?? '';
     }
 
     /**
-     * Composite uniqueness key: `(from, host, package|url)`.
+     * Composite uniqueness key: `(from, host, path|package|url)`.
      * Used by the mapper to reject duplicate entries and by `skills:add`
-     * to detect upsert vs insert.
+     * to detect upsert vs insert. For `dir` entries the identifier is
+     * the raw `path` string (`dir||./skills`) — two entries with the
+     * same path are duplicates; the same directory reached via two
+     * different spellings is not deduplicated (lexical identity only).
      *
      * `host` is rendered as the empty string when absent — the adapter's
      * default-host fill-in happens at resolve time, not at config-load

--- a/src/Console/AddCliDefinition.php
+++ b/src/Console/AddCliDefinition.php
@@ -37,16 +37,20 @@ final class AddCliDefinition
                 'input',
                 InputArgument::REQUIRED,
                 'Adapter-specific identifier: shorthand (owner/repo), a full URL, '
-                . 'or shorthand@ref. The adapter (selected via --from or inferred '
-                . 'from a URL) decides how to interpret it.',
+                . 'shorthand@ref, or a local directory path (./skills, ../shared, '
+                . 'an absolute path). The adapter (selected via --from, inferred '
+                . 'from a URL, or inferred from a path prefix) decides how to '
+                . 'interpret it.',
             )
             ->addOption(
                 'from',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Adapter id (github, gitlab, …). Defaults to "github" for shorthand '
-                . 'input. When a full URL is passed, the adapter is selected from '
-                . 'the URL\'s host (and `--from` is only needed to override).',
+                'Adapter id (github, gitlab, dir, …). Defaults to "github" for '
+                . 'shorthand input. A path-shaped input (./skills, ../shared, an '
+                . 'absolute path) selects "dir" automatically. When a full URL is '
+                . 'passed, the adapter is selected from the URL\'s host (and '
+                . '`--from` is only needed to override).',
             )
             ->addOption(
                 'host',

--- a/src/Discovery/Provider/ProviderId.php
+++ b/src/Discovery/Provider/ProviderId.php
@@ -32,6 +32,7 @@ final class ProviderId
     public const SKILLS_SH = 'skills.sh';
     public const HTTP = 'http';
     public const ZIP = 'zip';
+    public const DIR = 'dir';
 
     /**
      * Identifiers that may appear as keys under `local`. Today only
@@ -63,6 +64,7 @@ final class ProviderId
         self::SKILLS_SH,
         self::HTTP,
         self::ZIP,
+        self::DIR,
     ];
 
     /**
@@ -73,6 +75,19 @@ final class ProviderId
     public const URL_ONLY_REMOTE_IDS = [
         self::HTTP,
         self::ZIP,
+    ];
+
+    /**
+     * Adapters that identify the donor by a filesystem `path` — neither
+     * URL-only nor name-based. A path-only entry is an explicit local
+     * directory declaration; it requires `path`, forbids `url`, and
+     * treats `package` as an optional name override rather than the
+     * identifier.
+     *
+     * @var list<non-empty-string>
+     */
+    public const PATH_ONLY_SOURCE_IDS = [
+        self::DIR,
     ];
 
     /**
@@ -101,6 +116,19 @@ final class ProviderId
     public static function isUrlOnlyRemote(string $id): bool
     {
         return \in_array($id, self::URL_ONLY_REMOTE_IDS, true);
+    }
+
+    /**
+     * Whether the adapter identifies its donor by a filesystem `path`
+     * (rather than by package name or URL). Path-only adapters require
+     * `path`, reject `url`, and accept `package` only as an optional
+     * name override.
+     *
+     * @psalm-pure
+     */
+    public static function isPathOnlySource(string $id): bool
+    {
+        return \in_array($id, self::PATH_ONLY_SOURCE_IDS, true);
     }
 
     /**

--- a/src/Discovery/Provider/Remote/DirDonorRef.php
+++ b/src/Discovery/Provider/Remote/DirDonorRef.php
@@ -52,6 +52,36 @@ final readonly class DirDonorRef
     ) {}
 
     /**
+     * Derive a donor package name from a resolved directory:
+     * `<parent-basename>/<basename>`, lowercased (e.g.
+     * `D:\git\testo\testo\skills` → `testo/skills`). When the resolved
+     * path has no usable parent segment (a filesystem root), fall back
+     * to `dir/<basename>`.
+     *
+     * The precedence rule of spec §4.1 lives at the call sites: an
+     * entry `package` override and a directory's own `composer.json`
+     * name both win over this derivation, which is the last fallback.
+     * `skills:add` and the sync source both call this so the name they
+     * scope on stays identical.
+     *
+     * @return non-empty-string
+     */
+    public static function derivePackageName(Path $resolved): string
+    {
+        /** @psalm-suppress ImpureMethodCall Path::name()/parent() only read the path string */
+        $basename = $resolved->name();
+        /** @psalm-suppress ImpureMethodCall Path::name()/parent() only read the path string */
+        $parent = $resolved->parent()->name();
+        // `name()` never returns an empty string; a filesystem root
+        // still yields a `.`/`..` segment with no usable vendor part.
+        $vendor = ($parent === '.' || $parent === '..') ? 'dir' : $parent;
+
+        /** @var non-empty-string $name */
+        $name = \strtolower($vendor . '/' . $basename);
+        return $name;
+    }
+
+    /**
      * Stable identifier for diagnostics, echoing the user's spelling:
      * `dir ./skills`. Mirrors {@see RemoteDonorRef::describe()} so the
      * `source <ref>: <reason>` warning framing reads uniformly across

--- a/src/Discovery/Provider/Remote/DirDonorRef.php
+++ b/src/Discovery/Provider/Remote/DirDonorRef.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider\Remote;
+
+use Internal\Path;
+
+/**
+ * A single local-directory donor request: a resolved directory on the
+ * filesystem, declared through a `sources[]` entry with `from: "dir"`.
+ *
+ * The sibling of {@see RemoteDonorRef} for the path-only adapter. Where
+ * a {@see RemoteDonorRef} names something to download (URL + ref), a
+ * dir ref names a directory that already exists locally — no fetch, no
+ * cache, no unpacker. {@see RemoteProvider} reads the live directory
+ * each sync, so there is no snapshot to go stale.
+ *
+ * The two shapes share the surface {@see RemoteProvider} consumes
+ * — `provenance`, `skillFilter`, `packageHint`, and {@see describe()} —
+ * so the provider handles both through the same
+ * inspect-and-decorate tail; only the "how do we get a `Path`" head
+ * differs (fetch vs. read the directory in place).
+ *
+ * @psalm-mutation-free
+ */
+final readonly class DirDonorRef
+{
+    /**
+     * @param Path $directory resolved absolute directory the donor lives in — relative
+     *        `sources[].path` values are resolved against the project root by the source,
+     *        absolute ones are honoured as-is. Read live on every sync.
+     * @param non-empty-string $spelling the `path` exactly as the user typed it in
+     *        `skills.json`, used only by {@see describe()} so diagnostics echo the
+     *        user's spelling rather than the resolved absolute form.
+     * @param non-empty-string|null $provenance adapter id that produced this ref
+     *        (`dir`). Becomes the donor's {@see \LLM\Skills\Config\VendorConfig::$provenance},
+     *        which drives the `--from` CLI filter.
+     * @param list<non-empty-string>|null $skillFilter explicit allowlist of skill directory
+     *        names to keep. `null` means "sync every skill the directory ships".
+     * @param non-empty-string|null $packageHint donor package name to register the
+     *        directory under when it ships skills without its own `composer.json` name —
+     *        the entry's `package` override when present, else a name derived from the
+     *        resolved path (`<parent>/<basename>`).
+     */
+    public function __construct(
+        public Path $directory,
+        public string $spelling,
+        public ?string $provenance = null,
+        public ?array $skillFilter = null,
+        public ?string $packageHint = null,
+    ) {}
+
+    /**
+     * Stable identifier for diagnostics, echoing the user's spelling:
+     * `dir ./skills`. Mirrors {@see RemoteDonorRef::describe()} so the
+     * `source <ref>: <reason>` warning framing reads uniformly across
+     * both ref shapes.
+     *
+     * @return non-empty-string
+     *
+     * @psalm-mutation-free
+     */
+    public function describe(): string
+    {
+        return 'dir ' . $this->spelling;
+    }
+}

--- a/src/Discovery/Provider/Remote/RemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/RemoteDonorSource.php
@@ -26,7 +26,7 @@ use Internal\Path;
 interface RemoteDonorSource
 {
     /**
-     * @return iterable<RemoteDonorRef>
+     * @return iterable<RemoteDonorRef|DirDonorRef>
      *
      * @psalm-suppress MissingAbstractPureAnnotation
      *         implementations talk to filesystem / config and are not pure

--- a/src/Discovery/Provider/Remote/RemoteProvider.php
+++ b/src/Discovery/Provider/Remote/RemoteProvider.php
@@ -18,15 +18,21 @@ use LLM\Skills\Discovery\Provider\DonorProvider;
  * (GitHub/GitLab/Bitbucket HTTPS or SSH, plain `git://`, Mercurial,
  * etc.).
  *
- * Pipeline: the {@see RemoteDonorSource} produces {@see RemoteDonorRef}s
- * (the "what to fetch" list — sourced from `skills.json`, vendor
- * declarations, or a future `skills:add` lockfile), the
- * {@see RemoteFetcher} resolves each into a local extracted archive
- * (the "how to fetch" — HTTP archive download, full `git clone`, etc.),
- * and this provider then treats every extracted root identically to a
- * Composer-installed package: parses its `composer.json`, runs
- * {@see VendorConfigMapper} against `extra.skills`, emits the same
- * {@see DonorDiscoveryResult} shape as
+ * Pipeline: the {@see RemoteDonorSource} produces the "what to fetch"
+ * list (sourced from `skills.json`, vendor declarations, or a future
+ * `skills:add` lockfile) as one of two ref shapes, and this provider
+ * turns each into a local directory:
+ *
+ * - {@see RemoteDonorRef} (URL + ref) → the {@see RemoteFetcher}
+ *   resolves it into a local extracted archive ("how to fetch" — HTTP
+ *   archive download, full `git clone`, etc.).
+ * - {@see DirDonorRef} (a resolved local path, `from: "dir"`) → the
+ *   directory is read in place; no fetcher, no cache, no unpacker.
+ *
+ * From there both shapes share the same tail: this provider treats the
+ * directory identically to a Composer-installed package — parses its
+ * `composer.json`, runs {@see VendorConfigMapper} against `extra.skills`,
+ * and emits the same {@see DonorDiscoveryResult} shape as
  * {@see \LLM\Skills\Discovery\Provider\ComposerProvider}.
  *
  * Each failure mode degrades gracefully:
@@ -75,18 +81,29 @@ final readonly class RemoteProvider implements DonorProvider
         $warnings = [];
         $malformed = [];
 
-        if ($this->fetcher === null) {
-            // Active source but no fetcher wired — one warning is more
-            // useful than one-per-ref, since the misconfiguration is
-            // global, not per-donor.
-            foreach ($this->source->refs($projectRoot) as $_ref) {
-                $warnings[] = 'remote donor source declared refs but no fetcher is configured';
-                break;
-            }
-            return new DonorDiscoveryResult(donors: [], warnings: $warnings);
-        }
+        // Active source but no fetcher wired — one warning is more
+        // useful than one-per-ref, since the misconfiguration is global,
+        // not per-donor. Dir refs need no fetcher (they read the live
+        // directory), so they are still processed in that case.
+        $fetcherWarned = false;
 
         foreach ($this->source->refs($projectRoot) as $ref) {
+            if ($ref instanceof DirDonorRef) {
+                $donor = $this->resolveDirRef($ref, $warnings, $malformed);
+                if ($donor !== null) {
+                    $donors[] = $donor;
+                }
+                continue;
+            }
+
+            if ($this->fetcher === null) {
+                if (!$fetcherWarned) {
+                    $warnings[] = 'remote donor source declared refs but no fetcher is configured';
+                    $fetcherWarned = true;
+                }
+                continue;
+            }
+
             try {
                 $path = $this->fetcher->fetch($ref);
             } catch (RemoteFetchException $e) {
@@ -135,6 +152,37 @@ final readonly class RemoteProvider implements DonorProvider
     }
 
     /**
+     * Resolve a `dir` ref into a `VendorConfig`, or `null` when the
+     * directory is absent or not a donor. The "fetch" for a dir ref is
+     * simply confirming the directory exists — no download, no cache,
+     * no unpacker — and then running the shared inspector against the
+     * live directory, exactly as the remote path does against an
+     * extracted archive.
+     *
+     * A missing / non-directory path is graceful degradation, matching
+     * a failed remote fetch: a per-entry warning, and the entry is
+     * skipped without touching its siblings.
+     *
+     * @param list<string>             $warnings  appended to in place
+     * @param list<MalformedDonor>     $malformed appended to in place
+     *
+     * @param-out list<string>         $warnings
+     * @param-out list<MalformedDonor> $malformed
+     */
+    private function resolveDirRef(
+        DirDonorRef $ref,
+        array &$warnings,
+        array &$malformed,
+    ): ?VendorConfig {
+        if (!$ref->directory->isDir()) {
+            $warnings[] = \sprintf('source %s: directory does not exist', $ref->describe());
+            return null;
+        }
+
+        return $this->buildDonor($ref, $ref->directory, $warnings, $malformed);
+    }
+
+    /**
      * Resolve a single ref into a `VendorConfig`, or `null` when the
      * archive cannot be turned into a donor. Accumulates per-ref
      * warnings + malformed entries into the caller's lists.
@@ -158,7 +206,7 @@ final readonly class RemoteProvider implements DonorProvider
      * @param-out list<MalformedDonor> $malformed
      */
     private function buildDonor(
-        RemoteDonorRef $ref,
+        RemoteDonorRef|DirDonorRef $ref,
         Path $path,
         array &$warnings,
         array &$malformed,
@@ -249,7 +297,7 @@ final readonly class RemoteProvider implements DonorProvider
      *
      * @psalm-mutation-free
      */
-    private function decorate(VendorConfig $donor, RemoteDonorRef $ref): VendorConfig
+    private function decorate(VendorConfig $donor, RemoteDonorRef|DirDonorRef $ref): VendorConfig
     {
         $provenance = $ref->provenance ?? 'source';
         // `sources[]` entries are user-declared and therefore

--- a/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
@@ -143,28 +143,6 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
     }
 
     /**
-     * Derive a donor package name from a resolved directory:
-     * `<parent-basename>/<basename>`, lowercased (e.g.
-     * `D:\git\testo\testo\skills` → `testo/skills`). When the resolved
-     * path has no usable parent segment (a filesystem root), fall back
-     * to `dir/<basename>`.
-     *
-     * @return non-empty-string
-     */
-    private static function deriveDirPackageName(Path $resolved): string
-    {
-        $basename = $resolved->name();
-        $parent = $resolved->parent()->name();
-        // `name()` never returns an empty string; a filesystem root
-        // still yields a `.`/`..` segment with no usable vendor part.
-        $vendor = ($parent === '.' || $parent === '..') ? 'dir' : $parent;
-
-        /** @var non-empty-string $name */
-        $name = \strtolower($vendor . '/' . $basename);
-        return $name;
-    }
-
-    /**
      * Resolve a `dir` entry into a {@see DirDonorRef}.
      *
      * Path resolution: a relative `path` is anchored at the project
@@ -194,7 +172,7 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
             spelling: $spelling,
             provenance: $entry->from,
             skillFilter: $entry->skills,
-            packageHint: $entry->package ?? self::deriveDirPackageName($resolved),
+            packageHint: $entry->package ?? DirDonorRef::derivePackageName($resolved),
         );
     }
 }

--- a/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
+++ b/src/Discovery/Provider/Remote/SkillsJsonRemoteDonorSource.php
@@ -6,6 +6,8 @@ namespace LLM\Skills\Discovery\Provider\Remote;
 
 use Internal\Path;
 use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use LLM\Skills\Config\SourceEntry;
+use LLM\Skills\Discovery\Provider\ProviderId;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\UnknownAdapterException;
@@ -50,7 +52,7 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
     ) {}
 
     /**
-     * @return iterable<RemoteDonorRef>
+     * @return iterable<RemoteDonorRef|DirDonorRef>
      */
     #[\Override]
     public function refs(Path $projectRoot): iterable
@@ -64,6 +66,15 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
         }
 
         foreach ($config->sources as $entry) {
+            // Path-only adapters (dir) never hit the host-adapter
+            // registry: there is nothing to download or version-resolve,
+            // so the entry becomes a {@see DirDonorRef} pointing at a
+            // directory the provider reads in place.
+            if (ProviderId::isPathOnlySource($entry->from)) {
+                yield $this->resolveDirEntry($projectRoot, $entry);
+                continue;
+            }
+
             try {
                 $adapter = $this->registry->get($entry->from);
             } catch (UnknownAdapterException $e) {
@@ -129,5 +140,61 @@ final class SkillsJsonRemoteDonorSource implements RemoteDonorSource
             return false;
         }
         return $config->sources !== [];
+    }
+
+    /**
+     * Derive a donor package name from a resolved directory:
+     * `<parent-basename>/<basename>`, lowercased (e.g.
+     * `D:\git\testo\testo\skills` → `testo/skills`). When the resolved
+     * path has no usable parent segment (a filesystem root), fall back
+     * to `dir/<basename>`.
+     *
+     * @return non-empty-string
+     */
+    private static function deriveDirPackageName(Path $resolved): string
+    {
+        $basename = $resolved->name();
+        $parent = $resolved->parent()->name();
+        // `name()` never returns an empty string; a filesystem root
+        // still yields a `.`/`..` segment with no usable vendor part.
+        $vendor = ($parent === '.' || $parent === '..') ? 'dir' : $parent;
+
+        /** @var non-empty-string $name */
+        $name = \strtolower($vendor . '/' . $basename);
+        return $name;
+    }
+
+    /**
+     * Resolve a `dir` entry into a {@see DirDonorRef}.
+     *
+     * Path resolution: a relative `path` is anchored at the project
+     * root (the same anchor `target` uses); an absolute `path`
+     * (including a Windows drive letter) is honoured as-is. `..`
+     * segments and locations outside the project root are allowed — a
+     * `sources[]` entry is an explicit act of trust — so no containment
+     * check runs here. Existence is NOT checked at resolve time; the
+     * provider decides whether the resolved directory is present when
+     * it reads it (a per-entry warning if not).
+     *
+     * The donor's package name (the {@see DirDonorRef::$packageHint})
+     * is the entry's `package` override when present, else a name
+     * derived from the resolved absolute path.
+     */
+    private function resolveDirEntry(Path $projectRoot, SourceEntry $entry): DirDonorRef
+    {
+        // For a dir entry the identifier IS the path (the constructor
+        // guarantees `path` is set), so `identifier()` hands back the
+        // spelling as a non-empty string without a redundant null check.
+        $spelling = $entry->identifier();
+        $typed = Path::create($spelling);
+        $resolved = $typed->isAbsolute() ? $typed : $projectRoot->join($typed);
+
+        return new DirDonorRef(
+            directory: $resolved,
+            spelling: $spelling,
+            provenance: $entry->from,
+            skillFilter: $entry->skills,
+            packageHint: $entry->package ?? self::deriveDirPackageName($resolved),
+        );
     }
 }

--- a/src/Discovery/SkillTreeScanner.php
+++ b/src/Discovery/SkillTreeScanner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Discovery;
 
 use Internal\Path;
+use LLM\Skills\Filesystem\LinkGuard;
 
 /**
  * Locates skill directories inside a package that does **not** declare
@@ -27,10 +28,12 @@ use Internal\Path;
  *    {@see self::SKIP_DIRS}) to find `SKILL.md` files in non-conventional
  *    locations.
  *
- * Junction safety: every accepted skill directory must resolve (via
- * {@see \realpath()}) to a path still contained within the package root. A
- * symlink/junction escaping the package boundary is silently rejected — we
- * never follow such pointers, even read-only.
+ * Junction safety: the scan never traverses a symlinked or junctioned
+ * subdirectory ({@see self::immediateSubdirs()}), so a linked subtree cannot
+ * be discovered as skills and a link cycle cannot outlast the depth ceiling.
+ * As a second line, every accepted skill directory must still resolve (via
+ * {@see \realpath()}) to a path contained within the package root; anything
+ * escaping the boundary is silently rejected.
  */
 final readonly class SkillTreeScanner
 {
@@ -204,7 +207,14 @@ final readonly class SkillTreeScanner
             if ($entry === '.' || $entry === '..') {
                 continue;
             }
-            if (\is_dir($dir . \DIRECTORY_SEPARATOR . $entry)) {
+            $child = $dir . \DIRECTORY_SEPARATOR . $entry;
+            // A symlink or junction is not first-party package content and
+            // could point anywhere; never descend through one, and never let
+            // a link cycle defeat the recursion's depth ceiling.
+            if (LinkGuard::isLink($child)) {
+                continue;
+            }
+            if (\is_dir($child)) {
                 /** @var non-empty-string $entry */
                 $out[] = $entry;
             }

--- a/src/Filesystem/LinkGuard.php
+++ b/src/Filesystem/LinkGuard.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Filesystem;
+
+/**
+ * Detects filesystem links — native symlinks and NTFS junctions — so
+ * traversal code can refuse to follow them.
+ *
+ * Following a link while copying or scanning a skill tree is a security
+ * hazard: a link inside a donor can point at a large or sensitive tree
+ * outside the skill, dragging unrelated content into the target, and a
+ * link cycle can spin traversal forever. Callers skip any entry this
+ * reports as a link.
+ *
+ * Detection has to cope with an NTFS directory junction (`mklink /J`),
+ * which a vendor package can ship without administrator rights. On the
+ * Windows PHP build this project targets a junction returns `false` from
+ * {@see \is_link()}, {@see \is_dir()} and {@see \is_file()} alike, and
+ * {@see \readlink()} on an ordinary directory returns the directory's own
+ * path rather than `false` — so neither of those is a reliable signal.
+ * The dependable one is that {@see \realpath()} resolves a junction to a
+ * path other than its own literal location.
+ */
+final class LinkGuard
+{
+    /**
+     * `true` when `$path` is a symlink or an NTFS junction.
+     */
+    public static function isLink(string $path): bool
+    {
+        if (\is_link($path)) {
+            return true;
+        }
+
+        $parent = \realpath(\dirname($path));
+        $resolved = \realpath($path);
+        if ($parent === false || $resolved === false) {
+            return false;
+        }
+
+        $expected = $parent . \DIRECTORY_SEPARATOR . \basename($path);
+
+        return \strcasecmp($resolved, $expected) !== 0;
+    }
+}

--- a/src/Show/InspectionBuilder.php
+++ b/src/Show/InspectionBuilder.php
@@ -292,9 +292,15 @@ final readonly class InspectionBuilder
                 );
             }
 
+            // A user-declared donor (`sources[]` entry) is trusted by the
+            // declaration itself — the planner never consults the trust
+            // lists for it, so the attributor must not credit one either
+            // (the name could coincidentally match, e.g. built-in).
             $result[] = new DonorInspection(
                 donor: $donor,
-                trustSource: $attributor->attribute($donor->packageName),
+                trustSource: $donor->implicitTrust
+                    ? TrustSource::Declared
+                    : $attributor->attribute($donor->packageName),
                 skills: $skillInspections,
             );
         }

--- a/src/Show/ReportFormatter.php
+++ b/src/Show/ReportFormatter.php
@@ -186,6 +186,7 @@ final readonly class ReportFormatter
             foreach ($donors as $donor) {
                 [, $pkgTail] = $this->splitName($donor->donor->packageName);
                 $trustNote = match ($donor->trustSource) {
+                    TrustSource::Declared => '    [declared in skills.json]',
                     TrustSource::Builtin => '    [via built-in trust]',
                     TrustSource::DirectDep => '    [via direct dependency]',
                     default => '',

--- a/src/Show/TrustSource.php
+++ b/src/Show/TrustSource.php
@@ -5,21 +5,27 @@ declare(strict_types=1);
 namespace LLM\Skills\Show;
 
 /**
- * Identifies which trust list approved a donor package.
+ * Identifies which trust mechanism approved a donor package.
  *
  * Used by `skills:show` to optionally annotate an approved donor with
- * `[via built-in trust]` or `[via direct dependency]`, so the user can
- * audit where their trust decisions come from at a glance.
+ * `[declared in skills.json]`, `[via built-in trust]`, or
+ * `[via direct dependency]`, so the user can audit where their trust
+ * decisions come from at a glance.
  *
- * Priority order when multiple lists match: project > cli > builtin >
- * direct-dep. Project wins because it's the durable, version-controlled
- * answer to "do we trust this vendor"; the implicit sources (built-in
- * and direct-dep) sit at the bottom because they exist to silently
- * cover the common case, and a more explicit decision should always
- * take credit when it applies.
+ * Priority order when multiple mechanisms apply: declared > project >
+ * cli > builtin > direct-dep. A donor the user declared as a
+ * `sources[]` entry is trusted by that declaration itself
+ * ({@see \LLM\Skills\Config\VendorConfig::$implicitTrust}) — no list
+ * is even consulted for it, so no list may take credit. Project wins
+ * among the lists because it's the durable, version-controlled answer
+ * to "do we trust this vendor"; the implicit sources (built-in and
+ * direct-dep) sit at the bottom because they exist to silently cover
+ * the common case, and a more explicit decision should always take
+ * credit when it applies.
  */
 enum TrustSource: string
 {
+    case Declared = 'declared';
     case Project = 'project';
     case Cli = 'cli';
     case Builtin = 'builtin';

--- a/src/Sync/SyncEngine.php
+++ b/src/Sync/SyncEngine.php
@@ -6,6 +6,7 @@ namespace LLM\Skills\Sync;
 
 use Internal\Path;
 use LLM\Skills\Discovery\Skill;
+use LLM\Skills\Filesystem\LinkGuard;
 
 /**
  * Writes a curated list of skills into a target directory.
@@ -26,6 +27,15 @@ use LLM\Skills\Discovery\Skill;
 final readonly class SyncEngine
 {
     /**
+     * Directory depth {@see self::copyTree()} descends into a single skill
+     * tree before giving up. Real skills are shallow, so this generous cap
+     * never bites legitimate content; it is a defence-in-depth backstop so
+     * an undetected reparse-point cycle terminates deterministically rather
+     * than recursing until the stack or the path length gives out.
+     */
+    private const MAX_COPY_DEPTH = 32;
+
+    /**
      * @param list<Skill> $skills the skills to write (post-trust, post-enumeration)
      * @param Path $target absolute destination directory; created if missing
      * @param bool $dryRun when `true`, do everything except writing files — conflict detection still runs,
@@ -38,16 +48,19 @@ final readonly class SyncEngine
             return new SyncReport(copied: [], conflicts: $conflicts);
         }
 
+        $skippedLinks = [];
         if (!$dryRun) {
             foreach ($skills as $skill) {
                 $this->copyTree(
                     (string) $skill->sourceDir,
                     (string) $target->join($skill->name),
+                    0,
+                    $skippedLinks,
                 );
             }
         }
 
-        return new SyncReport(copied: $skills, conflicts: []);
+        return new SyncReport(copied: $skills, conflicts: [], skippedLinks: $skippedLinks);
     }
 
     /**
@@ -79,9 +92,26 @@ final readonly class SyncEngine
      * Recursively copy `$src` into `$dst`. Existing files in `$dst` that are
      * also in `$src` are overwritten (vendor is source of truth). Files in
      * `$dst` not present in `$src` are left untouched (non-destructive merge).
+     *
+     * Symlinks and NTFS junctions are never followed or copied. A link inside
+     * a donor could point at a large or sensitive tree beyond the skill —
+     * dragging unrelated content into the target — and a link cycle would
+     * recurse forever. Each skipped link's source path is appended to
+     * `$skippedLinks` so the caller can explain why a file did not arrive; a
+     * silent security skip is a debugging trap.
+     *
+     * @param int $depth levels below the skill root for `$src`; the recursion
+     *        stops at {@see self::MAX_COPY_DEPTH} as a cycle backstop
+     * @param list<string> $skippedLinks source paths of skipped links, accumulated across the tree
+     *
+     * @param-out list<string> $skippedLinks
      */
-    private function copyTree(string $src, string $dst): void
+    private function copyTree(string $src, string $dst, int $depth, array &$skippedLinks): void
     {
+        if ($depth >= self::MAX_COPY_DEPTH) {
+            return;
+        }
+
         $this->ensureDirectory($dst);
 
         $entries = \scandir($src);
@@ -96,8 +126,13 @@ final readonly class SyncEngine
             $s = $src . \DIRECTORY_SEPARATOR . $entry;
             $d = $dst . \DIRECTORY_SEPARATOR . $entry;
 
+            if (LinkGuard::isLink($s)) {
+                $skippedLinks[] = $s;
+                continue;
+            }
+
             if (\is_dir($s)) {
-                $this->copyTree($s, $d);
+                $this->copyTree($s, $d, $depth + 1, $skippedLinks);
             } else {
                 \copy($s, $d);
             }

--- a/src/Sync/SyncEngine.php
+++ b/src/Sync/SyncEngine.php
@@ -49,6 +49,7 @@ final readonly class SyncEngine
         }
 
         $skippedLinks = [];
+        $truncatedDirs = [];
         if (!$dryRun) {
             foreach ($skills as $skill) {
                 $this->copyTree(
@@ -56,11 +57,17 @@ final readonly class SyncEngine
                     (string) $target->join($skill->name),
                     0,
                     $skippedLinks,
+                    $truncatedDirs,
                 );
             }
         }
 
-        return new SyncReport(copied: $skills, conflicts: [], skippedLinks: $skippedLinks);
+        return new SyncReport(
+            copied: $skills,
+            conflicts: [],
+            skippedLinks: $skippedLinks,
+            truncatedDirs: $truncatedDirs,
+        );
     }
 
     /**
@@ -100,15 +107,28 @@ final readonly class SyncEngine
      * `$skippedLinks` so the caller can explain why a file did not arrive; a
      * silent security skip is a debugging trap.
      *
+     * When the {@see self::MAX_COPY_DEPTH} backstop trips, the directory whose
+     * contents were left uncopied is appended to `$truncatedDirs` for the same
+     * reason: a truncated copy the user cannot see is a debugging trap too.
+     *
      * @param int $depth levels below the skill root for `$src`; the recursion
      *        stops at {@see self::MAX_COPY_DEPTH} as a cycle backstop
      * @param list<string> $skippedLinks source paths of skipped links, accumulated across the tree
+     * @param list<string> $truncatedDirs source paths where recursion stopped at the depth cap,
+     *        accumulated across the tree
      *
      * @param-out list<string> $skippedLinks
+     * @param-out list<string> $truncatedDirs
      */
-    private function copyTree(string $src, string $dst, int $depth, array &$skippedLinks): void
-    {
+    private function copyTree(
+        string $src,
+        string $dst,
+        int $depth,
+        array &$skippedLinks,
+        array &$truncatedDirs,
+    ): void {
         if ($depth >= self::MAX_COPY_DEPTH) {
+            $truncatedDirs[] = $src;
             return;
         }
 
@@ -132,7 +152,7 @@ final readonly class SyncEngine
             }
 
             if (\is_dir($s)) {
-                $this->copyTree($s, $d, $depth + 1, $skippedLinks);
+                $this->copyTree($s, $d, $depth + 1, $skippedLinks, $truncatedDirs);
             } else {
                 \copy($s, $d);
             }

--- a/src/Sync/SyncReport.php
+++ b/src/Sync/SyncReport.php
@@ -20,6 +20,10 @@ use LLM\Skills\Discovery\Skill;
  *                    to follow (for security — a link could point outside the
  *                    skill). Surfaced by the caller so the skip is never
  *                    silent; empty on a clean, link-free copy.
+ * - `truncatedDirs` — source paths where the copy hit its depth backstop and
+ *                    left the contents below uncopied. Surfaced alongside the
+ *                    skipped links so a truncated tree is never silent; empty
+ *                    on a normal, shallow copy.
  *
  * Discovery-time warnings (missing source dir, malformed extra, etc.) are
  * **not** part of this report — they happen earlier in the pipeline and
@@ -33,6 +37,7 @@ final readonly class SyncReport
      * @param list<Skill> $copied
      * @param list<SkillConflict> $conflicts
      * @param list<string> $skippedLinks
+     * @param list<string> $truncatedDirs
      *
      * @psalm-mutation-free
      */
@@ -40,6 +45,7 @@ final readonly class SyncReport
         public array $copied,
         public array $conflicts,
         public array $skippedLinks = [],
+        public array $truncatedDirs = [],
     ) {}
 
     /**

--- a/src/Sync/SyncReport.php
+++ b/src/Sync/SyncReport.php
@@ -9,13 +9,17 @@ use LLM\Skills\Discovery\Skill;
 /**
  * Structured outcome of one {@see SyncEngine::sync()} call.
  *
- * Two channels:
+ * Three channels:
  *
- * - `copied`    — skills successfully written into the target directory
- *                 (or that *would* have been written, in dry-run mode).
- * - `conflicts` — skill-name collisions detected up front; when non-empty,
- *                 the engine aborted **before** any file write, so `copied`
- *                 is always `[]` in that case.
+ * - `copied`       — skills successfully written into the target directory
+ *                    (or that *would* have been written, in dry-run mode).
+ * - `conflicts`    — skill-name collisions detected up front; when non-empty,
+ *                    the engine aborted **before** any file write, so `copied`
+ *                    is always `[]` in that case.
+ * - `skippedLinks` — source paths of symlinks/junctions the copy step refused
+ *                    to follow (for security — a link could point outside the
+ *                    skill). Surfaced by the caller so the skip is never
+ *                    silent; empty on a clean, link-free copy.
  *
  * Discovery-time warnings (missing source dir, malformed extra, etc.) are
  * **not** part of this report — they happen earlier in the pipeline and
@@ -28,12 +32,14 @@ final readonly class SyncReport
     /**
      * @param list<Skill> $copied
      * @param list<SkillConflict> $conflicts
+     * @param list<string> $skippedLinks
      *
      * @psalm-mutation-free
      */
     public function __construct(
         public array $copied,
         public array $conflicts,
+        public array $skippedLinks = [],
     ) {}
 
     /**

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -231,6 +231,7 @@ final readonly class SyncRunner
         }
 
         $this->emitCopyReport($io, $report->copied, $options->dryRun);
+        $this->emitSkippedLinkWarnings($io, $report->skippedLinks);
 
         $verb = $options->dryRun ? 'would sync' : 'synced';
         $io->write(\sprintf(
@@ -384,6 +385,26 @@ final readonly class SyncRunner
     {
         foreach ($warnings as $warning) {
             $io->writeError('<comment>[warn] ' . $warning . '</comment>', verbosity: IOInterface::VERBOSE);
+        }
+    }
+
+    /**
+     * Surface the symlinks and junctions the copy step refused to follow.
+     * They are skipped for security — a link inside a donor could drag in a
+     * tree beyond the skill — but a silent skip is a debugging trap: the user
+     * must be able to see why a file did not land. Shown under `-v`, matching
+     * the other non-fatal diagnostics.
+     *
+     * @param list<string> $skippedLinks
+     */
+    private function emitSkippedLinkWarnings(IOInterface $io, array $skippedLinks): void
+    {
+        foreach ($skippedLinks as $link) {
+            $io->writeError(
+                '<comment>[warn] skipped symlink/junction (not followed for security): '
+                . $link . '</comment>',
+                verbosity: IOInterface::VERBOSE,
+            );
         }
     }
 

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -232,6 +232,7 @@ final readonly class SyncRunner
 
         $this->emitCopyReport($io, $report->copied, $options->dryRun);
         $this->emitSkippedLinkWarnings($io, $report->skippedLinks);
+        $this->emitTruncatedDirWarnings($io, $report->truncatedDirs);
 
         $verb = $options->dryRun ? 'would sync' : 'synced';
         $io->write(\sprintf(
@@ -403,6 +404,25 @@ final readonly class SyncRunner
             $io->writeError(
                 '<comment>[warn] skipped symlink/junction (not followed for security): '
                 . $link . '</comment>',
+                verbosity: IOInterface::VERBOSE,
+            );
+        }
+    }
+
+    /**
+     * Surface the directories where the copy hit its depth backstop and left
+     * the nested contents uncopied. Like the skipped links, this is a
+     * non-fatal diagnostic shown under `-v`: a silently truncated tree would
+     * leave the user unable to see why deeply nested files did not land.
+     *
+     * @param list<string> $truncatedDirs
+     */
+    private function emitTruncatedDirWarnings(IOInterface $io, array $truncatedDirs): void
+    {
+        foreach ($truncatedDirs as $dir) {
+            $io->writeError(
+                '<comment>[warn] copy depth limit reached; contents below this directory '
+                . 'were not copied: ' . $dir . '</comment>',
                 verbosity: IOInterface::VERBOSE,
             );
         }

--- a/tests/Acceptance/SkillsAddDirTest.php
+++ b/tests/Acceptance/SkillsAddDirTest.php
@@ -16,9 +16,11 @@ use Testo\Test;
 /**
  * Acceptance coverage for `skills:add` against a local directory — the
  * first fully offline `skills:add` path (no network, no archive, no
- * cache). The sandbox ships a committed fixture directory at
- * `tests/Sandbox/project/local-skills/` with two bare skills
- * (`dir-hello`, `dir-extra`).
+ * cache). The sandbox ships committed fixture directories:
+ * `local-skills/` with two bare skills (`dir-hello`, `dir-extra`);
+ * `local-composer-skill/` — a composer-shaped donor (its composer.json
+ * `name` is `acme/dir-composer`) shipping one skill; and `not-a-donor/`
+ * — a directory with neither a donor manifest nor SKILL.md files.
  *
  * Each test runs the real `composer skills:add ./local-skills` in the
  * sandbox, then asserts on the `sources[]` entry it wrote and on what
@@ -101,6 +103,51 @@ final class SkillsAddDirTest
         Assert::false(
             \is_dir(self::TARGET_DIR),
             '--no-sync must leave the target untouched. ' . $this->diagnostics($process),
+        );
+    }
+
+    public function addComposerShapedDirSyncsUnderItsComposerJsonName(): void
+    {
+        // The `local-composer-skill` fixture carries its own composer.json
+        // (`name: acme/dir-composer`), so the sync pipeline registers it
+        // under that name — not the path-derived hint. The add-time
+        // inspection must hand that same name to the scoped follow-up
+        // sync, otherwise the sync filters on the wrong donor and copies
+        // nothing (the exact regression this test pins down).
+        $process = $this->runAdd('./local-composer-skill');
+
+        Assert::same($process->getExitCode(), 0, $this->diagnostics($process));
+
+        $sources = $this->readSources();
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['path'] ?? null, './local-composer-skill');
+
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/composer-hello/SKILL.md'),
+            'the composer-shaped dir donor must have its skill synced. ' . $this->diagnostics($process),
+        );
+    }
+
+    public function addNonDonorDirFailsCleanlyWithoutWritingSkillsJson(): void
+    {
+        // The `not-a-donor` fixture exists but ships no composer.json
+        // donor declaration and no SKILL.md files. The add-time inspection
+        // must refuse it with a clear error and leave no skills.json
+        // behind — a directory the sync would ignore never registers.
+        $process = $this->runAdd('./not-a-donor');
+
+        Assert::notSame($process->getExitCode(), 0, $this->diagnostics($process));
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'dir ./not-a-donor'),
+            'the error must name the refused path. ' . $this->diagnostics($process),
+        );
+        Assert::true(
+            \str_contains($process->getErrorOutput(), 'neither a composer.json'),
+            'the error must explain the non-donor shape. ' . $this->diagnostics($process),
+        );
+        Assert::false(
+            \is_file(self::SKILLS_JSON),
+            'a refused add writes no skills.json. ' . $this->diagnostics($process),
         );
     }
 

--- a/tests/Acceptance/SkillsAddDirTest.php
+++ b/tests/Acceptance/SkillsAddDirTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance coverage for `skills:add` against a local directory — the
+ * first fully offline `skills:add` path (no network, no archive, no
+ * cache). The sandbox ships a committed fixture directory at
+ * `tests/Sandbox/project/local-skills/` with two bare skills
+ * (`dir-hello`, `dir-extra`).
+ *
+ * Each test runs the real `composer skills:add ./local-skills` in the
+ * sandbox, then asserts on the `sources[]` entry it wrote and on what
+ * the follow-up sync copied into the default target. `skills.json` is
+ * managed by hand (deleted before and after) since the command under
+ * test is the one that creates it — the {@see WithSkillsJson} attribute
+ * would fight it.
+ */
+#[Test]
+final class SkillsAddDirTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const SKILLS_JSON = Info::PROJECT_DIR . '/skills.json';
+
+    #[BeforeTest]
+    public static function reset(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        if (\is_file(self::SKILLS_JSON)) {
+            @\unlink(self::SKILLS_JSON);
+        }
+    }
+
+    #[AfterTest]
+    public static function cleanup(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        if (\is_file(self::SKILLS_JSON)) {
+            @\unlink(self::SKILLS_JSON);
+        }
+    }
+
+    public function addWritesTheEntryAndSyncsTheDirSkills(): void
+    {
+        $process = $this->runAdd('./local-skills');
+
+        Assert::same($process->getExitCode(), 0, $this->diagnostics($process));
+
+        $sources = $this->readSources();
+        Assert::count($sources, 1, 'exactly one dir source must be registered');
+        Assert::same($sources[0]['from'] ?? null, 'dir');
+        Assert::same($sources[0]['path'] ?? null, './local-skills');
+        Assert::false(\array_key_exists('url', $sources[0]), 'dir entries carry no url');
+
+        // The follow-up sync ran (no --no-sync), so both fixture skills
+        // must sit in the default target.
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'),
+            'dir-hello must be synced. ' . $this->diagnostics($process),
+        );
+        Assert::true(\is_file(self::TARGET_DIR . '/dir-extra/SKILL.md'));
+    }
+
+    public function addWithAllowlistSyncsOnlyTheNamedSkill(): void
+    {
+        $process = $this->runAdd('./local-skills --skill=dir-hello');
+
+        Assert::same($process->getExitCode(), 0, $this->diagnostics($process));
+
+        $sources = $this->readSources();
+        Assert::same($sources[0]['skills'] ?? null, ['dir-hello']);
+
+        Assert::true(\is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'));
+        Assert::false(
+            \is_file(self::TARGET_DIR . '/dir-extra/SKILL.md'),
+            'dir-extra is not on the allowlist and must not be copied',
+        );
+    }
+
+    public function addWithNoSyncWritesTheEntryWithoutCopying(): void
+    {
+        $process = $this->runAdd('./local-skills --no-sync');
+
+        Assert::same($process->getExitCode(), 0, $this->diagnostics($process));
+
+        $sources = $this->readSources();
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['path'] ?? null, './local-skills');
+
+        Assert::false(
+            \is_dir(self::TARGET_DIR),
+            '--no-sync must leave the target untouched. ' . $this->diagnostics($process),
+        );
+    }
+
+    /**
+     * @param non-empty-string $args
+     */
+    private function runAdd(string $args): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:add ' . $args,
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function readSources(): array
+    {
+        Assert::true(\is_file(self::SKILLS_JSON), 'skills:add must create skills.json');
+        /** @var array<string, mixed> $payload */
+        $payload = \json_decode(
+            (string) \file_get_contents(self::SKILLS_JSON),
+            associative: true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) ($payload['sources'] ?? []);
+        return $sources;
+    }
+
+    private function diagnostics(Process $process): string
+    {
+        return 'stdout: ' . $process->getOutput() . "\nstderr: " . $process->getErrorOutput();
+    }
+}

--- a/tests/Acceptance/SkillsDirSourceTest.php
+++ b/tests/Acceptance/SkillsDirSourceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSkillsJson;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance coverage for the `dir` source adapter — the offline path
+ * `skills:update` never had before.
+ *
+ * The sandbox ships a committed fixture directory at
+ * `tests/Sandbox/project/local-skills/` with two bare skills
+ * (`dir-hello`, `dir-extra`). Each test injects a `skills.json` whose
+ * `sources[]` declares that directory as a `from: "dir"` donor and runs
+ * the real `composer skills:update` / `skills:show` against it — no
+ * network, no archive, no cache.
+ */
+#[Test]
+final class SkillsDirSourceTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+
+    #[BeforeTest]
+    public function clearTargetDir(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'sources' => [
+            ['from' => 'dir', 'path' => './local-skills'],
+        ],
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function updateCopiesSkillsFromDirSource(): void
+    {
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'),
+            'dir source skill must be copied into the target. stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::true(\is_file(self::TARGET_DIR . '/dir-extra/SKILL.md'));
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'sources' => [
+            ['from' => 'dir', 'path' => './local-skills', 'skills' => ['dir-hello']],
+        ],
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function updateWithAllowlistSyncsOnlyTheNamedSkill(): void
+    {
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(\is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'));
+        Assert::false(
+            \is_file(self::TARGET_DIR . '/dir-extra/SKILL.md'),
+            'dir-extra is not on the allowlist and must not be copied',
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'sources' => [
+            ['from' => 'dir', 'path' => './no-such-dir'],
+        ],
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function missingDirSourceWarnsUnderVerboseAndStillSucceeds(): void
+    {
+        $process = $this->runUpdate('-v');
+        $combined = $process->getOutput() . $process->getErrorOutput();
+
+        // A missing directory degrades gracefully: the run still exits 0.
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \str_contains($combined, 'dir ./no-such-dir')
+            && \str_contains($combined, 'directory does not exist'),
+            'the per-entry warning must name the missing directory. Got: ' . $combined,
+        );
+        Assert::false(\is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'));
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'sources' => [
+            ['from' => 'dir', 'path' => './local-skills'],
+        ],
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function showListsTheDirDonorAndItsSkills(): void
+    {
+        $process = $this->runShow();
+        $out = $process->getOutput();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        // The derived donor name is `<project-basename>/local-skills`.
+        Assert::true(
+            \str_contains($out, 'local-skills'),
+            'show must list the dir donor. Got: ' . $out,
+        );
+        Assert::true(
+            \str_contains($out, 'dir-hello'),
+            'show must list the dir donor skills. Got: ' . $out,
+        );
+    }
+
+    private function runUpdate(string ...$args): Process
+    {
+        $command = 'skills:update';
+        if ($args !== []) {
+            $command .= ' ' . \implode(' ', $args);
+        }
+
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            $command,
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    private function runShow(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:show',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+}

--- a/tests/Acceptance/SkillsDirSourceTest.php
+++ b/tests/Acceptance/SkillsDirSourceTest.php
@@ -117,6 +117,10 @@ final class SkillsDirSourceTest
             \str_contains($out, 'dir-hello'),
             'show must list the dir donor skills. Got: ' . $out,
         );
+        Assert::true(
+            \str_contains($out, '[declared in skills.json]'),
+            'a sources[] donor is trusted by its declaration, not by a trust list. Got: ' . $out,
+        );
     }
 
     private function runUpdate(string ...$args): Process

--- a/tests/Acceptance/SkillsDirSymlinkSkipTest.php
+++ b/tests/Acceptance/SkillsDirSymlinkSkipTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSkillsJson;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Core\Exception\SkipTest;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * End-to-end proof that `skills:update` never follows a symlink or NTFS
+ * junction living inside a donor skill directory.
+ *
+ * The sandbox's committed `dir` fixture donor
+ * (`tests/Sandbox/project/local-skills/`) is reused. The test plants a
+ * directory link inside the `dir-hello` skill that points at a tree
+ * outside the donor, runs the real sync, and asserts the linked content
+ * never lands in the target while the run still exits 0. The link is
+ * created honestly at runtime (junction on Windows, symlink elsewhere)
+ * and removed in teardown; if the platform refuses link creation the
+ * test skips cleanly rather than fake the fixture.
+ */
+#[Test]
+final class SkillsDirSymlinkSkipTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const LINK_PATH = Info::PROJECT_DIR . '/local-skills/dir-hello/leaked-link';
+
+    private string $secretDir;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        Filesystem::removeRecursive(self::LINK_PATH);
+        $this->secretDir = \sys_get_temp_dir() . '/llm-skills-leak-' . \bin2hex(\random_bytes(6));
+    }
+
+    #[AfterTest]
+    public function cleanUp(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+        Filesystem::removeRecursive(self::LINK_PATH);
+        Filesystem::removeRecursive($this->secretDir);
+    }
+
+    #[WithSkillsJson([
+        'target' => '.agents/skills',
+        'sources' => [
+            ['from' => 'dir', 'path' => './local-skills'],
+        ],
+        'trusted' => ['acme/skills-basic', 'acme/skills-pro'],
+    ])]
+    public function updateSkipsALinkedDirectoryInsideADonorSkill(): void
+    {
+        \mkdir($this->secretDir, 0o777, true);
+        \file_put_contents($this->secretDir . '/secret.txt', 'must not leak');
+
+        if (!Filesystem::makeDirLink($this->secretDir, self::LINK_PATH)) {
+            throw new SkipTest('platform refuses both symlink and junction creation');
+        }
+
+        $process = $this->runUpdate();
+
+        // The link is skipped for security, but the sync itself still succeeds.
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+
+        // The regular skill content arrives...
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/dir-hello/SKILL.md'),
+            'the donor skill must still be copied. stderr: ' . $process->getErrorOutput(),
+        );
+        // ...but nothing was dragged through the link.
+        Assert::false(
+            \is_dir(self::TARGET_DIR . '/dir-hello/leaked-link'),
+            'the linked directory must not be traversed into the target',
+        );
+        Assert::false(
+            \is_file(self::TARGET_DIR . '/dir-hello/leaked-link/secret.txt'),
+            'content behind the link must never leak into the target',
+        );
+    }
+
+    private function runUpdate(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:update',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+}

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -63,6 +63,43 @@ final class SkillsSchemaTest
         ]);
     }
 
+    public function dirSourceDocumentIsAccepted(): void
+    {
+        $this->assertAccepts([
+            'sources' => [
+                ['from' => 'dir', 'path' => './skills'],
+                ['from' => 'dir', 'path' => '../shared-skills', 'package' => 'myorg/shared', 'skills' => ['deploy']],
+            ],
+        ]);
+    }
+
+    public function dirSourceMissingPathIsRejected(): void
+    {
+        // `path` is required for the dir adapter; without it the entry
+        // matches none of the oneOf branches.
+        $this->assertRejects([
+            'sources' => [
+                ['from' => 'dir'],
+            ],
+        ]);
+    }
+
+    public function dirSourceWithUrlIsAcceptedBySchemaButRejectedByMapper(): void
+    {
+        // Matrix note: the schema is deliberately lenient here. A dir
+        // entry carrying `url` still matches `sourceByDir` (which does
+        // not set additionalProperties:false, mirroring its siblings)
+        // and matches no other oneOf branch, so the document validates.
+        // The PHP mapper is the authoritative validator and rejects it
+        // with `url is not allowed for adapter "dir" (use path)` — see
+        // ProjectConfigMapperTest::dirRejectsUrl().
+        $this->assertAccepts([
+            'sources' => [
+                ['from' => 'dir', 'path' => './skills', 'url' => 'https://example.com/x.zip'],
+            ],
+        ]);
+    }
+
     public function deprecatedRemoteDocumentIsAccepted(): void
     {
         // `remote` is the deprecated alias of `sources`. The schema

--- a/tests/Feature/RemoteProviderEndToEndTest.php
+++ b/tests/Feature/RemoteProviderEndToEndTest.php
@@ -8,9 +8,12 @@ use Internal\Path;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GithubAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\GitlabAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
+use LLM\Skills\Discovery\Provider\Remote\DirDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpClient;
 use LLM\Skills\Discovery\Provider\Remote\Http\HttpResponse;
 use LLM\Skills\Discovery\Provider\Remote\HttpArchiveFetcher;
+use LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef;
+use LLM\Skills\Discovery\Provider\Remote\RemoteFetcher;
 use LLM\Skills\Discovery\Provider\Remote\RemoteProvider;
 use LLM\Skills\Discovery\Provider\Remote\SkillsJsonRemoteDonorSource;
 use LLM\Skills\Tests\Testo\Filesystem;
@@ -45,6 +48,7 @@ use Testo\Test;
 #[Test]
 #[Covers(RemoteProvider::class)]
 #[Covers(SkillsJsonRemoteDonorSource::class)]
+#[Covers(DirDonorRef::class)]
 #[Covers(GithubAdapter::class)]
 #[Covers(GitlabAdapter::class)]
 #[Covers(HttpArchiveFetcher::class)]
@@ -374,6 +378,130 @@ final class RemoteProviderEndToEndTest
             ->contains('SKILL.md');
     }
 
+    // ── dir source adapter (offline, no HTTP) ─────────────────────────────────
+
+    public function dirSourceEntryReadsLiveComposerShapedDirectoryEndToEnd(): void
+    {
+        // skills.json declares one `dir` donor pointing at a local
+        // directory carrying its own composer.json. No network, no
+        // archive, no cache — the provider reads the directory in place.
+        \file_put_contents($this->tmp . '/skills.json', \json_encode([
+            'sources' => [
+                ['from' => 'dir', 'path' => './local-skills'],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $this->writeDirSkill('local-skills/skills/hello', 'hello');
+        \file_put_contents($this->tmp . '/local-skills/composer.json', \json_encode([
+            'name' => 'acme/local',
+            'extra' => ['skills' => ['source' => 'skills']],
+        ], \JSON_THROW_ON_ERROR));
+
+        $provider = new RemoteProvider(
+            new SkillsJsonRemoteDonorSource(new HostAdapterRegistry()),
+            self::neverFetch(),
+        );
+
+        Assert::true($provider->isActive(Path::create($this->tmp)));
+
+        $result = $provider->discover(Path::create($this->tmp));
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->packageName, 'acme/local');
+        Assert::same($result->donors[0]->provenance, 'dir');
+        Assert::true($result->donors[0]->implicitTrust);
+
+        $skillFile = (string) $result->donors[0]->sourcePath()->join('hello/SKILL.md');
+        Assert::true(\is_file($skillFile), 'skill file must be read from the live directory');
+    }
+
+    public function dirSourceEntryDerivesNameWhenDirectoryHasNoComposerJson(): void
+    {
+        // A bare skill directory (no composer.json) is registered under
+        // the derived `<parent>/<basename>` name and its nested skill is
+        // enumerated through discoveredSkillDirs.
+        \file_put_contents($this->tmp . '/skills.json', \json_encode([
+            'sources' => [
+                ['from' => 'dir', 'path' => './local-skills'],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $this->writeDirSkill('local-skills/skills/triage', 'triage');
+
+        $provider = new RemoteProvider(
+            new SkillsJsonRemoteDonorSource(new HostAdapterRegistry()),
+            self::neverFetch(),
+        );
+
+        $result = $provider->discover(Path::create($this->tmp));
+
+        Assert::count($result->donors, 1);
+        // Derived name is `<tmp-basename>/local-skills`, lowercased.
+        Assert::true(
+            \str_ends_with($result->donors[0]->packageName, '/local-skills'),
+            'derived name must end with /local-skills; got ' . $result->donors[0]->packageName,
+        );
+        Assert::false($result->donors[0]->discovered);
+
+        $enum = (new \LLM\Skills\Discovery\SkillEnumerator())->enumerate($result->donors);
+        $names = \array_map(static fn($s) => $s->name, $enum->skills);
+        Assert::same($names, ['triage']);
+    }
+
+    public function missingDirSourceEntryWarnsAndProducesNoDonor(): void
+    {
+        // The declared directory does not exist — graceful degradation:
+        // a per-entry warning, no donor, and the run still succeeds.
+        \file_put_contents($this->tmp . '/skills.json', \json_encode([
+            'sources' => [
+                ['from' => 'dir', 'path' => './nope'],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $provider = new RemoteProvider(
+            new SkillsJsonRemoteDonorSource(new HostAdapterRegistry()),
+            self::neverFetch(),
+        );
+
+        $result = $provider->discover(Path::create($this->tmp));
+
+        Assert::same($result->donors, []);
+        Assert::count($result->warnings, 1);
+        Assert::string($result->warnings[0])
+            ->contains('dir ./nope')
+            ->contains('directory does not exist');
+    }
+
+    public function dirSourceEntryAllowlistSyncsOnlyTheNamedSkill(): void
+    {
+        \file_put_contents($this->tmp . '/skills.json', \json_encode([
+            'sources' => [
+                ['from' => 'dir', 'path' => './local-skills', 'skills' => ['hello']],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $this->writeDirSkill('local-skills/skills/hello', 'hello');
+        $this->writeDirSkill('local-skills/skills/other', 'other');
+        \file_put_contents($this->tmp . '/local-skills/composer.json', \json_encode([
+            'name' => 'acme/local',
+            'extra' => ['skills' => ['source' => 'skills']],
+        ], \JSON_THROW_ON_ERROR));
+
+        $provider = new RemoteProvider(
+            new SkillsJsonRemoteDonorSource(new HostAdapterRegistry()),
+            self::neverFetch(),
+        );
+
+        $result = $provider->discover(Path::create($this->tmp));
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->skillFilter, ['hello']);
+
+        $enum = (new \LLM\Skills\Discovery\SkillEnumerator())->enumerate($result->donors);
+        $names = \array_map(static fn($s) => $s->name, $enum->skills);
+        Assert::same($names, ['hello']);
+    }
+
     #[BeforeTest]
     public function setUp(): void
     {
@@ -385,6 +513,33 @@ final class RemoteProviderEndToEndTest
     public function tearDown(): void
     {
         Filesystem::removeRecursive($this->tmp);
+    }
+
+    /**
+     * A fetcher that fails loudly if invoked — dir refs must never reach
+     * the fetcher (no download, no cache, no unpacker). Wiring it proves
+     * the provider handles dir refs entirely on the read-in-place path.
+     */
+    private static function neverFetch(): RemoteFetcher
+    {
+        return new class implements RemoteFetcher {
+            #[\Override]
+            public function fetch(RemoteDonorRef $ref): Path
+            {
+                throw new \LogicException('dir refs must not reach the fetcher');
+            }
+        };
+    }
+
+    /**
+     * Write a `SKILL.md` (with minimal frontmatter) at `$relDir` under
+     * the temp project root, creating parent directories as needed.
+     */
+    private function writeDirSkill(string $relDir, string $name): void
+    {
+        $dir = $this->tmp . '/' . $relDir;
+        \mkdir($dir, 0o777, true);
+        \file_put_contents($dir . '/SKILL.md', "---\nname: " . $name . "\n---\nbody");
     }
 
     /**

--- a/tests/Sandbox/project/local-composer-skill/composer.json
+++ b/tests/Sandbox/project/local-composer-skill/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "acme/dir-composer",
+    "description": "A composer-shaped local directory donor fixture (not an installed package).",
+    "extra": {
+        "skills": {
+            "source": "skills"
+        }
+    }
+}

--- a/tests/Sandbox/project/local-composer-skill/skills/composer-hello/SKILL.md
+++ b/tests/Sandbox/project/local-composer-skill/skills/composer-hello/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: composer-hello
+description: A skill shipped by a composer-shaped local directory donor.
+---
+
+This skill proves that a `dir` donor carrying its own composer.json is
+registered under that composer.json `name`, so the scoped post-add sync
+resolves it and copies the skill.

--- a/tests/Sandbox/project/local-skills/dir-extra/SKILL.md
+++ b/tests/Sandbox/project/local-skills/dir-extra/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: dir-extra
+description: A second local-directory skill used to prove the allowlist filter.
+---
+
+This skill exists only to be filtered out when the `dir` entry declares a
+`skills` allowlist that does not include it.

--- a/tests/Sandbox/project/local-skills/dir-hello/SKILL.md
+++ b/tests/Sandbox/project/local-skills/dir-hello/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: dir-hello
+description: A skill served from a local directory source.
+---
+
+When greeted, respond warmly and confirm the local `dir` source resolved
+correctly.

--- a/tests/Sandbox/project/not-a-donor/README.md
+++ b/tests/Sandbox/project/not-a-donor/README.md
@@ -1,0 +1,5 @@
+# Not a donor
+
+This directory exists as a `skills:add` fixture: it carries no
+composer.json donor declaration and no `SKILL.md` files, so the add-time
+inspection must refuse it as a non-donor shape.

--- a/tests/Testo/Filesystem.php
+++ b/tests/Testo/Filesystem.php
@@ -55,6 +55,48 @@ final class Filesystem
     }
 
     /**
+     * Create a directory link at `$link` pointing at `$target`, honestly — a
+     * native symlink where the platform allows it, otherwise an NTFS junction
+     * (`mklink /J`, which needs no elevation and is exactly the reparse point
+     * a vendor package can ship unprivileged). Returns `false` when neither
+     * works, so a link-dependent test can skip cleanly instead of faking the
+     * fixture.
+     */
+    public static function makeDirLink(string $target, string $link): bool
+    {
+        if (@\symlink($target, $link)) {
+            return true;
+        }
+
+        if (\DIRECTORY_SEPARATOR !== '\\' || !\function_exists('exec')) {
+            return false;
+        }
+
+        // Quote the paths by hand rather than via escapeshellarg(): on Windows
+        // that helper strips `%` (env-var neutralisation), which corrupts the
+        // percent-encoded package directories these fixtures build. cmd leaves
+        // a lone `%…` literal, so plain double quotes are both safe and exact.
+        $cmd = \sprintf(
+            'cmd /c mklink /J "%s" "%s"',
+            \str_replace('/', '\\', $link),
+            \str_replace('/', '\\', $target),
+        );
+        @\exec($cmd, $output, $code);
+
+        return $code === 0;
+    }
+
+    /**
+     * Create a file symlink at `$link` pointing at `$target`. Returns `false`
+     * when the platform refuses it (a Windows file symlink needs privilege),
+     * so the caller can skip cleanly rather than fake the fixture.
+     */
+    public static function makeFileLink(string $target, string $link): bool
+    {
+        return @\symlink($target, $link);
+    }
+
+    /**
      * Robust link detection for NTFS junctions.
      *
      * In this PHP build `is_link`, `is_dir` and `is_file` all return false for a

--- a/tests/Unit/Add/AddRunnerTest.php
+++ b/tests/Unit/Add/AddRunnerTest.php
@@ -404,6 +404,187 @@ final class AddRunnerTest
         Assert::true(\str_contains($io->getOutput(), 'neither a composer.json'));
     }
 
+    // ── dir adapter (path-only, offline) ───────────────────────────
+
+    public function dirInputByPathPrefixRegistersWithoutTouchingAdapterOrFetcher(): void
+    {
+        // A `./sub` input selects the dir branch: no adapter parse, no
+        // fetch (the ExplodingFetcher would throw if the remote path
+        // ran). The entry lands with from=dir and the path stored as
+        // typed.
+        \mkdir($this->tmp . '/sub', 0o777, true);
+        $io = new BufferIO();
+        $registered = null;
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: './sub'),
+            static function (SourceEntry $entry, string $name) use (&$registered): void {
+                $registered = [$entry, $name];
+            },
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::true(\str_contains($io->getOutput(), 'registered dir:./sub'));
+
+        $entry = $this->readSkillsJson()['sources'][0];
+        Assert::same($entry['from'] ?? null, 'dir');
+        Assert::same($entry['path'] ?? null, './sub');
+        Assert::false(\array_key_exists('url', $entry), 'dir entries carry no url');
+
+        // The scoped-sync name is derived from the resolved directory
+        // (<parent>/<basename>, lowercased) so the follow-up sync filters
+        // on the same donor the pipeline will produce.
+        Assert::true(\is_array($registered));
+        /** @var array{0: SourceEntry, 1: string} $registered */
+        Assert::true(\str_ends_with($registered[1], '/sub'));
+    }
+
+    public function fromDirForcesDirAdapterForABareName(): void
+    {
+        // `--from=dir` forces the dir branch even for a plain name that
+        // carries no path prefix, as long as it resolves to a directory.
+        \mkdir($this->tmp . '/plaindir', 0o777, true);
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: 'plaindir', from: ProviderId::DIR),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::same($this->readSkillsJson()['sources'][0]['path'] ?? null, 'plaindir');
+    }
+
+    public function relativeDirInputWithBackslashesIsStoredWithForwardSlashes(): void
+    {
+        // A Windows-style `.\a\b` spelling is normalised to forward
+        // slashes but otherwise kept verbatim (no `.` collapsing).
+        \mkdir($this->tmp . '/a/b', 0o777, true);
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: '.\\a\\b'),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::same($this->readSkillsJson()['sources'][0]['path'] ?? null, './a/b');
+    }
+
+    public function absoluteDirInputIsStoredAbsolute(): void
+    {
+        // An absolute input is honoured as-is (slashes normalised); the
+        // stored path stays absolute rather than being rebased.
+        \mkdir($this->tmp . '/abs-target', 0o777, true);
+        $absolute = $this->tmp . '/abs-target';
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: $absolute),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::same(
+            $this->readSkillsJson()['sources'][0]['path'] ?? null,
+            \str_replace('\\', '/', $absolute),
+        );
+    }
+
+    public function shorthandStillRoutesToTheRemoteAdapterNotDir(): void
+    {
+        // `owner/repo` has no path prefix, so it must NOT be captured by
+        // the dir heuristic — it flows through the github adapter (which
+        // needs a real fetch), proving the two paths stay disjoint.
+        $fetcher = $this->fetcherReturning($this->writeArchive('sh', 'acme/skills', 'skills'));
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), $fetcher)->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: 'acme/skills'),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::same($this->readSkillsJson()['sources'][0]['from'] ?? null, 'github');
+    }
+
+    public function missingDirInputIsRefused(): void
+    {
+        // An explicit add of a directory that does not exist is a typo;
+        // refuse with a non-zero exit and name the path.
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: './does-not-exist'),
+        );
+
+        Assert::same($code, Command::FAILURE);
+        Assert::true(\str_contains($io->getOutput(), 'dir ./does-not-exist'));
+        Assert::true(\str_contains($io->getOutput(), 'directory does not exist'));
+        Assert::false(\is_file($this->tmp . '/skills.json'), 'no entry is written on refusal');
+    }
+
+    public function refWithDirInputIsRejected(): void
+    {
+        \mkdir($this->tmp . '/sub', 0o777, true);
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: './sub', ref: 'v1'),
+        );
+
+        Assert::same($code, Command::INVALID);
+        Assert::true(\str_contains($io->getOutput(), '--ref is not allowed for adapter "dir"'));
+    }
+
+    public function hostWithDirInputIsRejected(): void
+    {
+        \mkdir($this->tmp . '/sub', 0o777, true);
+        $io = new BufferIO();
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: './sub', host: 'https://example.com'),
+        );
+
+        Assert::same($code, Command::INVALID);
+        Assert::true(\str_contains($io->getOutput(), '--host is not allowed for adapter "dir"'));
+    }
+
+    public function repeatedDirAddMergesAllowlistUnderThePathCompositeKey(): void
+    {
+        // Two adds of the same path collapse into one entry (the path is
+        // the composite key) with the allowlist merged additively.
+        \mkdir($this->tmp . '/sub', 0o777, true);
+        $runner = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher());
+
+        $runner->run(
+            Path::create($this->tmp),
+            new BufferIO(),
+            new AddOptions(input: './sub', skills: ['alpha']),
+        );
+        $runner->run(
+            Path::create($this->tmp),
+            new BufferIO(),
+            new AddOptions(input: './sub', skills: ['beta']),
+        );
+
+        $sources = (array) $this->readSkillsJson()['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['skills'] ?? null, ['alpha', 'beta']);
+    }
+
     // ── writer failure ─────────────────────────────────────────────
 
     public function writerFailureReturnsFailure(): void

--- a/tests/Unit/Add/AddRunnerTest.php
+++ b/tests/Unit/Add/AddRunnerTest.php
@@ -411,8 +411,9 @@ final class AddRunnerTest
         // A `./sub` input selects the dir branch: no adapter parse, no
         // fetch (the ExplodingFetcher would throw if the remote path
         // ran). The entry lands with from=dir and the path stored as
-        // typed.
-        \mkdir($this->tmp . '/sub', 0o777, true);
+        // typed. The directory ships a bare skill so the add-time
+        // inspection accepts it.
+        $this->seedBareSkill($this->tmp . '/sub');
         $io = new BufferIO();
         $registered = null;
 
@@ -445,7 +446,7 @@ final class AddRunnerTest
     {
         // `--from=dir` forces the dir branch even for a plain name that
         // carries no path prefix, as long as it resolves to a directory.
-        \mkdir($this->tmp . '/plaindir', 0o777, true);
+        $this->seedBareSkill($this->tmp . '/plaindir');
         $io = new BufferIO();
 
         $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
@@ -462,7 +463,7 @@ final class AddRunnerTest
     {
         // A Windows-style `.\a\b` spelling is normalised to forward
         // slashes but otherwise kept verbatim (no `.` collapsing).
-        \mkdir($this->tmp . '/a/b', 0o777, true);
+        $this->seedBareSkill($this->tmp . '/a/b');
         $io = new BufferIO();
 
         $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
@@ -479,7 +480,7 @@ final class AddRunnerTest
     {
         // An absolute input is honoured as-is (slashes normalised); the
         // stored path stays absolute rather than being rebased.
-        \mkdir($this->tmp . '/abs-target', 0o777, true);
+        $this->seedBareSkill($this->tmp . '/abs-target');
         $absolute = $this->tmp . '/abs-target';
         $io = new BufferIO();
 
@@ -566,7 +567,7 @@ final class AddRunnerTest
     {
         // Two adds of the same path collapse into one entry (the path is
         // the composite key) with the allowlist merged additively.
-        \mkdir($this->tmp . '/sub', 0o777, true);
+        $this->seedBareSkill($this->tmp . '/sub');
         $runner = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher());
 
         $runner->run(
@@ -583,6 +584,61 @@ final class AddRunnerTest
         $sources = (array) $this->readSkillsJson()['sources'];
         Assert::count($sources, 1);
         Assert::same($sources[0]['skills'] ?? null, ['alpha', 'beta']);
+    }
+
+    public function composerShapedDirPassesItsComposerJsonNameToOnRegistered(): void
+    {
+        // A directory carrying its own composer.json donor declaration is
+        // registered downstream under that composer.json `name`, not the
+        // path-derived hint. The scoped-sync name handed to $onRegistered
+        // must therefore be the composer.json name so the follow-up sync
+        // filters on the donor the pipeline will actually produce — the
+        // regression that left a composer-shaped dir declared but empty.
+        $dir = $this->writeArchive('cshape', 'acme/dir-donor', 'skills');
+        $io = new BufferIO();
+        $registered = null;
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: $dir, from: ProviderId::DIR),
+            static function (SourceEntry $entry, string $name) use (&$registered): void {
+                $registered = [$entry, $name];
+            },
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+        Assert::true(\is_array($registered));
+        /** @var array{0: SourceEntry, 1: string} $registered */
+        Assert::same($registered[1], 'acme/dir-donor');
+    }
+
+    public function nonDonorDirIsRefusedWithoutWritingAnEntry(): void
+    {
+        // An empty directory ships nothing to register — no composer.json
+        // donor declaration, no SKILL.md files — so the add is refused
+        // before any entry is written, mirroring the remote path refusing
+        // an unusable archive. The scoped-sync callback never fires.
+        \mkdir($this->tmp . '/empty', 0o777, true);
+        $io = new BufferIO();
+        $registered = null;
+
+        $code = $this->runner(StubAdapter::withDefaults(), new ExplodingFetcher())->run(
+            Path::create($this->tmp),
+            $io,
+            new AddOptions(input: './empty'),
+            static function (SourceEntry $entry, string $name) use (&$registered): void {
+                $registered = [$entry, $name];
+            },
+        );
+
+        Assert::same($code, Command::FAILURE);
+        $out = $io->getOutput();
+        Assert::true(\str_contains($out, 'dir ./empty'));
+        Assert::true(\str_contains($out, 'neither a composer.json'));
+        Assert::true(\str_contains($out, 'SKILL.md'));
+        Assert::false(\is_file($this->tmp . '/skills.json'), 'no entry is written on refusal');
+        Assert::null($registered, 'the scoped-sync callback never fires on refusal');
     }
 
     // ── writer failure ─────────────────────────────────────────────
@@ -644,6 +700,17 @@ final class AddRunnerTest
         $dir = $this->tmp . '/' . $label;
         \mkdir($dir, 0o777, true);
         return $dir;
+    }
+
+    /**
+     * Seed a directory with a single bare skill (`<dir>/greeting/SKILL.md`)
+     * so the add-time {@see \LLM\Skills\Discovery\Provider\Remote\DonorArchiveInspector}
+     * accepts it as a bare skill donor.
+     */
+    private function seedBareSkill(string $dir): void
+    {
+        \mkdir($dir . '/greeting', 0o777, true);
+        \file_put_contents($dir . '/greeting/SKILL.md', "---\nname: greeting\n---\nbody");
     }
 
     /**

--- a/tests/Unit/Add/SkillsJsonWriterTest.php
+++ b/tests/Unit/Add/SkillsJsonWriterTest.php
@@ -426,6 +426,81 @@ final class SkillsJsonWriterTest
         );
     }
 
+    public function dirEntryStoresPathAsIdentifier(): void
+    {
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::dirEntry('./skills'),
+        );
+
+        $payload = $this->readSkillsJson();
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['from'] ?? null, 'dir');
+        Assert::same($sources[0]['path'] ?? null, './skills');
+        Assert::false(\array_key_exists('package', $sources[0]));
+        Assert::false(\array_key_exists('url', $sources[0]));
+    }
+
+    public function dirEntryUpsertsByPathCompositeKey(): void
+    {
+        // Same `path` ⇒ same composite key (`dir||./skills`) ⇒ overwrite
+        // in place, not append. Here the second add adds a package
+        // override to the same path.
+        $this->writeSkillsJson([
+            'sources' => [
+                ['from' => 'dir', 'path' => './skills'],
+            ],
+        ]);
+
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::dirEntry('./skills', package: 'myorg/shared'),
+        );
+
+        $payload = $this->readSkillsJson();
+        /** @var list<array<string, mixed>> $sources */
+        $sources = (array) $payload['sources'];
+        Assert::count($sources, 1);
+        Assert::same($sources[0]['path'] ?? null, './skills');
+        Assert::same($sources[0]['package'] ?? null, 'myorg/shared');
+    }
+
+    public function dirDifferentPathsAppend(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [
+                ['from' => 'dir', 'path' => './skills'],
+            ],
+        ]);
+
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::dirEntry('../shared-skills'),
+        );
+
+        $payload = $this->readSkillsJson();
+        Assert::count((array) $payload['sources'], 2);
+    }
+
+    public function dirEntryEmitsPathInTheIdentifierSlot(): void
+    {
+        // Key order for a dir entry: from → path → package (override).
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::dirEntry('./skills', package: 'myorg/shared'),
+        );
+
+        $raw = (string) \file_get_contents($this->tmp . '/skills.json');
+        $fromPos = \strpos($raw, '"from"');
+        $pathPos = \strpos($raw, '"path"');
+        $packagePos = \strpos($raw, '"package"');
+
+        Assert::true(\is_int($fromPos) && \is_int($pathPos) && $fromPos < $pathPos);
+        Assert::true(\is_int($pathPos) && \is_int($packagePos) && $pathPos < $packagePos);
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -470,6 +545,27 @@ final class SkillsJsonWriterTest
             host: $host,
             ref: $ref,
             skills: $skills,
+        );
+    }
+
+    /**
+     * @param non-empty-string $path
+     * @param non-empty-string|null $package
+     * @param list<non-empty-string>|null $skills
+     */
+    private static function dirEntry(
+        string $path,
+        ?string $package = null,
+        ?array $skills = null,
+    ): SourceEntry {
+        return new SourceEntry(
+            from: ProviderId::DIR,
+            package: $package,
+            url: null,
+            host: null,
+            ref: null,
+            skills: $skills,
+            path: $path,
         );
     }
 }

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -1000,6 +1000,191 @@ final class ProjectConfigMapperTest
         Assert::same($resolution->ignoredInlineKeys, ['sources', 'remote']);
     }
 
+    // ── dir (path-only) adapter ─────────────────────────────────────────
+
+    public function dirAdapterParses(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => './skills'],
+                ],
+            ],
+        ]);
+
+        Assert::count($cfg->sources, 1);
+        $entry = $cfg->sources[0];
+        Assert::same($entry->from, 'dir');
+        Assert::same($entry->path, './skills');
+        Assert::same($entry->package, null);
+        Assert::same($entry->url, null);
+        Assert::same($entry->identifier(), './skills');
+    }
+
+    public function dirPathIsRequired(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('path is required for adapter "dir"');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'dir']],
+            ],
+        ]);
+    }
+
+    public function dirRejectsUrl(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('url is not allowed for adapter "dir" (use path)');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'dir', 'path' => './skills', 'url' => 'https://example.com/x.zip']],
+            ],
+        ]);
+    }
+
+    public function dirRejectsHost(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('host is not allowed for adapter "dir"');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'dir', 'path' => './skills', 'host' => 'https://example.com']],
+            ],
+        ]);
+    }
+
+    public function dirRejectsRef(): void
+    {
+        // A local directory has no version concept, so `ref` is
+        // forbidden rather than silently ignored.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('ref is not allowed for adapter "dir"');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'dir', 'path' => './skills', 'ref' => 'v1.0.0']],
+            ],
+        ]);
+    }
+
+    public function dirAcceptsPackageOverride(): void
+    {
+        // Unlike name-based adapters, `package` on a dir entry is an
+        // optional donor-name override and is not the identifier.
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => '../shared-skills', 'package' => 'myorg/shared'],
+                ],
+            ],
+        ]);
+
+        $entry = $cfg->sources[0];
+        Assert::same($entry->package, 'myorg/shared');
+        Assert::same($entry->path, '../shared-skills');
+        Assert::same($entry->identifier(), '../shared-skills');
+    }
+
+    public function dirAllowlistIsParsed(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => './skills', 'skills' => ['deploy']],
+                ],
+            ],
+        ]);
+
+        Assert::same($cfg->sources[0]->skills, ['deploy']);
+    }
+
+    public function dirCompositeKeyUsesPath(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'dir', 'path' => './skills']],
+            ],
+        ]);
+
+        Assert::same($cfg->sources[0]->compositeKey(), 'dir||./skills');
+    }
+
+    public function dirDuplicatePathThrows(): void
+    {
+        // Two entries with the same `path` share a composite key
+        // (`dir||./skills`) and are fatal, exactly like duplicate
+        // name-based entries.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('duplicates an earlier entry');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => './skills'],
+                    ['from' => 'dir', 'path' => './skills', 'package' => 'myorg/shared'],
+                ],
+            ],
+        ]);
+    }
+
+    public function dirDifferentPathsCoexist(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => './skills'],
+                    ['from' => 'dir', 'path' => '../shared-skills'],
+                ],
+            ],
+        ]);
+
+        Assert::count($cfg->sources, 2);
+    }
+
+    public function dirPathKeyIsNotSweptIntoExtras(): void
+    {
+        // collectExtras must skip `path` — otherwise the identifier
+        // would be duplicated into SourceEntry::extras.
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [
+                    ['from' => 'dir', 'path' => './skills', 'custom' => 'x'],
+                ],
+            ],
+        ]);
+
+        Assert::same($cfg->sources[0]->path, './skills');
+        Assert::same($cfg->sources[0]->extras, ['custom' => 'x']);
+    }
+
+    public function pathIsForbiddenOnNameBasedAdapter(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('path is not allowed for adapter "github" (dir only)');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'github', 'package' => 'acme/x', 'path' => './skills']],
+            ],
+        ]);
+    }
+
+    public function pathIsForbiddenOnUrlOnlyAdapter(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('path is not allowed for adapter "zip" (dir only)');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'sources' => [['from' => 'zip', 'url' => 'https://example.com/x.zip', 'path' => './skills']],
+            ],
+        ]);
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/tests/Unit/Config/SourceEntryTest.php
+++ b/tests/Unit/Config/SourceEntryTest.php
@@ -174,4 +174,119 @@ final class SourceEntryTest
             Assert::true(\str_contains($e->getMessage(), 'non-empty strings'));
         }
     }
+
+    public function identifierReturnsPathForDirEntry(): void
+    {
+        // Path-only adapters identify the donor by `path`, even when a
+        // `package` name override is also present.
+        $entry = new SourceEntry(
+            from: ProviderId::DIR,
+            package: null,
+            url: null,
+            host: null,
+            ref: null,
+            path: './skills',
+        );
+
+        Assert::same($entry->identifier(), './skills');
+    }
+
+    public function identifierPrefersPathOverPackageOverride(): void
+    {
+        $entry = new SourceEntry(
+            from: ProviderId::DIR,
+            package: 'myorg/shared',
+            url: null,
+            host: null,
+            ref: null,
+            path: '../shared-skills',
+        );
+
+        Assert::same($entry->identifier(), '../shared-skills');
+    }
+
+    public function compositeKeyUsesPathForDirEntry(): void
+    {
+        // Shape: `dir||<path>`. Two entries with the same path collide;
+        // the identifier is the raw path string (lexical identity only).
+        $entry = new SourceEntry(
+            from: ProviderId::DIR,
+            package: null,
+            url: null,
+            host: null,
+            ref: null,
+            path: './skills',
+        );
+
+        Assert::same($entry->compositeKey(), 'dir||./skills');
+    }
+
+    public function constructorRejectsDirWithoutPath(): void
+    {
+        // `path` is mandatory for path-only adapters.
+        try {
+            new SourceEntry(
+                from: ProviderId::DIR,
+                package: null,
+                url: null,
+                host: null,
+                ref: null,
+            );
+            Assert::fail('expected InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
+            Assert::true(\str_contains($e->getMessage(), 'requires $path'));
+        }
+    }
+
+    public function constructorRejectsDirWithUrl(): void
+    {
+        try {
+            new SourceEntry(
+                from: ProviderId::DIR,
+                package: null,
+                url: 'https://example.com/x.zip',
+                host: null,
+                ref: null,
+                path: './skills',
+            );
+            Assert::fail('expected InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
+            Assert::true(\str_contains($e->getMessage(), 'does not allow $url'));
+        }
+    }
+
+    public function constructorRejectsPathOnNonDirAdapter(): void
+    {
+        // `path` is meaningless for every non-path-only adapter.
+        try {
+            new SourceEntry(
+                from: ProviderId::GITHUB,
+                package: 'acme/skills',
+                url: null,
+                host: null,
+                ref: null,
+                path: './skills',
+            );
+            Assert::fail('expected InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
+            Assert::true(\str_contains($e->getMessage(), 'does not allow $path'));
+        }
+    }
+
+    public function dirEntryAcceptsPackageOverride(): void
+    {
+        // Unlike name-based adapters, `package` on a dir entry is an
+        // optional donor-name override and coexists with `path`.
+        $entry = new SourceEntry(
+            from: ProviderId::DIR,
+            package: 'myorg/shared',
+            url: null,
+            host: null,
+            ref: null,
+            path: '../shared-skills',
+        );
+
+        Assert::same($entry->package, 'myorg/shared');
+        Assert::same($entry->path, '../shared-skills');
+    }
 }

--- a/tests/Unit/Discovery/Provider/ProviderIdTest.php
+++ b/tests/Unit/Discovery/Provider/ProviderIdTest.php
@@ -39,6 +39,7 @@ final class ProviderIdTest
         Assert::true(ProviderId::isKnownRemote(ProviderId::SKILLS_SH));
         Assert::true(ProviderId::isKnownRemote(ProviderId::HTTP));
         Assert::true(ProviderId::isKnownRemote(ProviderId::ZIP));
+        Assert::true(ProviderId::isKnownRemote(ProviderId::DIR));
 
         Assert::false(ProviderId::isKnownRemote('unknown'));
     }
@@ -53,6 +54,34 @@ final class ProviderIdTest
     {
         Assert::false(ProviderId::isUrlOnlyRemote(ProviderId::GITHUB));
         Assert::false(ProviderId::isUrlOnlyRemote(ProviderId::COMPOSER));
+    }
+
+    public function dirIsPathOnly(): void
+    {
+        // `dir` identifies its donor by `path`, not a package name or
+        // URL — the third identifier category alongside url-only.
+        Assert::true(ProviderId::isPathOnlySource(ProviderId::DIR));
+    }
+
+    public function otherAdaptersAreNotPathOnly(): void
+    {
+        Assert::false(ProviderId::isPathOnlySource(ProviderId::GITHUB));
+        Assert::false(ProviderId::isPathOnlySource(ProviderId::COMPOSER));
+        Assert::false(ProviderId::isPathOnlySource(ProviderId::HTTP));
+        Assert::false(ProviderId::isPathOnlySource(ProviderId::ZIP));
+    }
+
+    public function dirIsNotAUrlOnlyAdapter(): void
+    {
+        // Path-only and url-only are disjoint categories.
+        Assert::false(ProviderId::isUrlOnlyRemote(ProviderId::DIR));
+    }
+
+    public function dirIsNotKnownLocal(): void
+    {
+        // `dir` is an explicit declaration under sources[], not an
+        // ecosystem auto-discovery toggle under `local`.
+        Assert::false(ProviderId::isKnownLocal(ProviderId::DIR));
     }
 
     public function composerDefaultsToEnabled(): void

--- a/tests/Unit/Discovery/Provider/Remote/RemoteProviderTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/RemoteProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Tests\Unit\Discovery\Provider\Remote;
 
 use Internal\Path;
+use LLM\Skills\Discovery\Provider\Remote\DirDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\NullRemoteDonorSource;
 use LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\RemoteDonorSource;
@@ -33,6 +34,7 @@ use Testo\Test;
 #[Covers(RemoteProvider::class)]
 #[Covers(NullRemoteDonorSource::class)]
 #[Covers(RemoteDonorRef::class)]
+#[Covers(DirDonorRef::class)]
 #[Covers(RemoteFetchException::class)]
 final class RemoteProviderTest
 {
@@ -351,6 +353,120 @@ final class RemoteProviderTest
         Assert::count($result->warnings, 1);
     }
 
+    // ── dir refs ──────────────────────────────────────────────────────────────
+
+    public function dirRefReadsLiveDirectoryAndDecoratesDonor(): void
+    {
+        // A dir ref carries a resolved directory; the provider reads it
+        // in place (no fetcher wired) and decorates the donor with the
+        // ref's `dir` provenance + implicit trust.
+        $dir = $this->makeExtracted(
+            'live-dir',
+            \json_encode([
+                'name' => 'acme/local',
+                'extra' => ['skills' => ['source' => 'skills']],
+            ]),
+        );
+
+        $provider = new RemoteProvider(
+            $this->sourceWithMixedRefs($this->dirRef($dir, packageHint: 'acme/local')),
+        );
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->packageName, 'acme/local');
+        Assert::same($result->donors[0]->provenance, 'dir');
+        Assert::true($result->donors[0]->implicitTrust);
+        Assert::same($result->warnings, []);
+    }
+
+    public function dirRefMissingDirectoryWarnsAndSkipsWithoutBlockingSiblings(): void
+    {
+        // First dir ref points at a directory that does not exist → a
+        // per-entry warning, skipped. The sibling dir ref still produces
+        // its donor.
+        $missing = Path::create($this->tmp . '/does-not-exist');
+        $good = $this->makeExtracted(
+            'good-dir',
+            \json_encode([
+                'name' => 'acme/good',
+                'extra' => ['skills' => ['source' => 'skills']],
+            ]),
+        );
+
+        $provider = new RemoteProvider($this->sourceWithMixedRefs(
+            $this->dirRef($missing, spelling: './missing'),
+            $this->dirRef($good, spelling: './good', packageHint: 'acme/good'),
+        ));
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->packageName, 'acme/good');
+        Assert::count($result->warnings, 1);
+        Assert::true(\str_contains($result->warnings[0], 'dir ./missing'));
+        Assert::true(\str_contains($result->warnings[0], 'directory does not exist'));
+    }
+
+    public function dirRefBareSkillDirUsesDerivedHintForItsName(): void
+    {
+        // No composer.json, but the directory ships SKILL.md files: the
+        // donor name comes from the ref's packageHint (the derived
+        // `<parent>/<basename>` name the source computed).
+        $dir = $this->makeExtracted('bare-dir');
+        $this->writeSkill($dir);
+
+        $provider = new RemoteProvider(
+            $this->sourceWithMixedRefs($this->dirRef($dir, packageHint: 'team/skills')),
+        );
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->packageName, 'team/skills');
+        Assert::false($result->donors[0]->discovered);
+        Assert::same($result->warnings, []);
+    }
+
+    public function dirRefComposerShapedUsesItsOwnComposerName(): void
+    {
+        // The directory carries a composer.json with a name + skills
+        // source; that name wins over the ref's derived packageHint.
+        $dir = $this->makeExtracted(
+            'composer-dir',
+            \json_encode([
+                'name' => 'real/name',
+                'extra' => ['skills' => ['source' => 'skills']],
+            ]),
+        );
+
+        $provider = new RemoteProvider(
+            $this->sourceWithMixedRefs($this->dirRef($dir, packageHint: 'derived/hint')),
+        );
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->packageName, 'real/name');
+    }
+
+    public function dirRefAllowlistThreadsIntoDonor(): void
+    {
+        $dir = $this->makeExtracted(
+            'allowlist-dir',
+            \json_encode([
+                'name' => 'acme/local',
+                'extra' => ['skills' => ['source' => 'skills']],
+            ]),
+        );
+        $this->writeSkill($dir);
+
+        $provider = new RemoteProvider($this->sourceWithMixedRefs(
+            $this->dirRef($dir, packageHint: 'acme/local', skillFilter: ['example']),
+        ));
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->skillFilter, ['example']);
+    }
+
     public function directDependenciesAlwaysEmpty(): void
     {
         // Even with active source + working fetcher: remote refs are
@@ -381,6 +497,52 @@ final class RemoteProviderTest
     private function ref(string $url, string $ref): RemoteDonorRef
     {
         return new RemoteDonorRef($url, $ref);
+    }
+
+    /**
+     * @param non-empty-string $spelling
+     * @param non-empty-string|null $packageHint
+     * @param list<non-empty-string>|null $skillFilter
+     */
+    private function dirRef(
+        Path $directory,
+        string $spelling = './dir-src',
+        ?string $packageHint = 'acme/local',
+        ?array $skillFilter = null,
+    ): DirDonorRef {
+        return new DirDonorRef(
+            directory: $directory,
+            spelling: $spelling,
+            provenance: 'dir',
+            skillFilter: $skillFilter,
+            packageHint: $packageHint,
+        );
+    }
+
+    private function sourceWithMixedRefs(RemoteDonorRef|DirDonorRef ...$refs): RemoteDonorSource
+    {
+        return new class($refs) implements RemoteDonorSource {
+            /** @param list<RemoteDonorRef|DirDonorRef> $refs */
+            public function __construct(private readonly array $refs) {}
+
+            #[\Override]
+            public function refs(Path $projectRoot): iterable
+            {
+                return $this->refs;
+            }
+
+            #[\Override]
+            public function warnings(): array
+            {
+                return [];
+            }
+
+            #[\Override]
+            public function hasRefs(Path $projectRoot): bool
+            {
+                return $this->refs !== [];
+            }
+        };
     }
 
     private function sourceWithRefs(RemoteDonorRef ...$refs): RemoteDonorSource

--- a/tests/Unit/Discovery/Provider/Remote/SkillsJsonRemoteDonorSourceTest.php
+++ b/tests/Unit/Discovery/Provider/Remote/SkillsJsonRemoteDonorSourceTest.php
@@ -10,6 +10,7 @@ use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapter;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\HostAdapterRegistry;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\ParsedAddInput;
 use LLM\Skills\Discovery\Provider\Remote\Adapter\RemoteResolveException;
+use LLM\Skills\Discovery\Provider\Remote\DirDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\RemoteDonorRef;
 use LLM\Skills\Discovery\Provider\Remote\SkillsJsonRemoteDonorSource;
 use LLM\Skills\Tests\Testo\Filesystem;
@@ -184,8 +185,109 @@ final class SkillsJsonRemoteDonorSourceTest
         Assert::count($source->warnings(), 1);
     }
 
+    public function dirEntryResolvesRelativeToProjectRoot(): void
+    {
+        // A `dir` entry never touches the host-adapter registry; the
+        // source resolves the path (relative → anchored at the project
+        // root) into a DirDonorRef tagged with `dir` provenance.
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => './skills']],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        Assert::count($refs, 1);
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        Assert::same((string) $ref->directory, (string) Path::create($this->tmp)->join('skills'));
+        Assert::same($ref->spelling, './skills');
+        Assert::same($ref->describe(), 'dir ./skills');
+        Assert::same($ref->provenance, 'dir');
+        Assert::same($source->warnings(), []);
+    }
+
+    public function dirEntryHonoursAbsolutePathAsIs(): void
+    {
+        $absolute = $this->tmp . '/shared-skills';
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => $absolute]],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        Assert::count($refs, 1);
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        // Absolute input is used verbatim, not re-anchored at the root.
+        Assert::same((string) $ref->directory, (string) Path::create($absolute));
+    }
+
+    public function dirEntryDerivesPackageNameFromResolvedPath(): void
+    {
+        // No `package` override → the donor name is `<parent>/<basename>`
+        // of the resolved path, lowercased.
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => './Team/Skills']],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        Assert::same($ref->packageHint, 'team/skills');
+    }
+
+    public function dirEntryPackageOverrideWinsOverDerivedName(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => './skills', 'package' => 'myorg/shared']],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        Assert::same($ref->packageHint, 'myorg/shared');
+    }
+
+    public function dirEntryAtFilesystemRootFallsBackToDirVendor(): void
+    {
+        // A path whose resolved parent is a filesystem root has no usable
+        // vendor segment, so the name falls back to `dir/<basename>`.
+        // The resolution is purely lexical — the directory need not exist.
+        $rootChild = \DIRECTORY_SEPARATOR === '\\' ? 'Z:/loneskills' : '/loneskills';
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => $rootChild]],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        Assert::same($ref->packageHint, 'dir/loneskills');
+    }
+
+    public function dirEntryCarriesSkillAllowlist(): void
+    {
+        $this->writeSkillsJson([
+            'sources' => [['from' => 'dir', 'path' => './skills', 'skills' => ['deploy']]],
+        ]);
+        $source = new SkillsJsonRemoteDonorSource(new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs(Path::create($this->tmp)));
+
+        $ref = $refs[0];
+        Assert::instanceOf($ref, DirDonorRef::class);
+        Assert::same($ref->skillFilter, ['deploy']);
+    }
+
     /**
-     * @return list<RemoteDonorRef>
+     * @return list<RemoteDonorRef|DirDonorRef>
      */
     private function collect(iterable $refs): array
     {

--- a/tests/Unit/Discovery/SkillTreeScannerTest.php
+++ b/tests/Unit/Discovery/SkillTreeScannerTest.php
@@ -9,6 +9,7 @@ use LLM\Skills\Discovery\DiscoveredSkill;
 use LLM\Skills\Discovery\SkillTreeScanner;
 use LLM\Skills\Tests\Testo\Filesystem;
 use Testo\Assert;
+use Testo\Core\Exception\SkipTest;
 use Testo\Lifecycle\AfterTest;
 use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
@@ -186,6 +187,27 @@ final class SkillTreeScannerTest
         $skills = (new SkillTreeScanner())->scan(Path::create($packageRoot));
 
         Assert::same($skills, []);
+    }
+
+    public function doesNotDiscoverSkillsInsideALinkedSubdirectory(): void
+    {
+        // A symlink/junction inside a container is not first-party content and
+        // could point anywhere; the scan must not follow it into discovery,
+        // even when its target sits within the package root (so the realpath
+        // containment check alone would not catch it).
+        $this->makeSkill('skills/real');
+
+        $planted = $this->tmp . '/outside/planted';
+        \mkdir($planted, 0o777, true);
+        \file_put_contents($planted . '/SKILL.md', "---\nname: planted\n---\nbody");
+
+        $made = Filesystem::makeDirLink($this->tmp . '/outside', $this->tmp . '/skills/linked');
+        if (!$made) {
+            throw new SkipTest('platform refuses both symlink and junction creation');
+        }
+
+        // Only the genuine directory is discovered; the linked subtree is not.
+        Assert::same($this->names($this->scan()), ['real']);
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/tests/Unit/Show/ReportFormatterTest.php
+++ b/tests/Unit/Show/ReportFormatterTest.php
@@ -177,6 +177,24 @@ final class ReportFormatterTest
         Assert::true(\str_contains($joined, '[via built-in trust]'));
     }
 
+    public function annotatesDeclaredTrustOnPackageRow(): void
+    {
+        // A donor the user declared as a `sources[]` entry is trusted by
+        // that declaration itself; the annotation must credit it instead
+        // of whichever trust list the name happens to match.
+        $donor = $this->donorInspection(
+            packageName: 'myorg/local-skills',
+            source: '.',
+            trust: TrustSource::Declared,
+            skills: [['dir-hello', SyncStatus::InSync]],
+        );
+
+        $joined = $this->renderJoined($donor);
+
+        Assert::true(\str_contains($joined, '[declared in skills.json]'));
+        Assert::false(\str_contains($joined, '[via built-in trust]'));
+    }
+
     public function doesNotAnnotateProjectOrCliTrust(): void
     {
         $project = $this->donorInspection(

--- a/tests/Unit/Sync/SyncEngineTest.php
+++ b/tests/Unit/Sync/SyncEngineTest.php
@@ -297,6 +297,37 @@ final class SyncEngineTest
         Assert::same($report->skippedLinks, [$loop]);
     }
 
+    public function stopsAtTheDepthCapAndReportsTheTruncationPoint(): void
+    {
+        // A tree deeper than the copy backstop must still copy what it can
+        // and surface where it stopped, so a truncated sync is never silent.
+        $skill = $this->makeSkill('acme/deep', 'deep', ['SKILL.md' => '# Deep']);
+        $skillDir = (string) $skill->sourceDir;
+
+        // A chain of nested directories well past the cap, with a marker
+        // file at the very bottom the copy can never reach.
+        $depth = 40; // > SyncEngine::MAX_COPY_DEPTH (32)
+        $chain = $skillDir;
+        for ($i = 0; $i < $depth; $i++) {
+            $chain .= \DIRECTORY_SEPARATOR . 'd';
+        }
+        \mkdir($chain, 0o777, true);
+        \file_put_contents($chain . \DIRECTORY_SEPARATOR . 'bottom.txt', 'too deep');
+
+        $report = (new SyncEngine())->sync([$skill], $this->target());
+
+        Assert::true($report->isSuccess());
+        // Shallow content still lands.
+        Assert::true(\is_file($this->targetPath('deep/SKILL.md')));
+        // The bottom marker never made it past the cap.
+        Assert::false(\is_file($this->targetPath('deep/' . \str_repeat('d/', $depth) . 'bottom.txt')));
+        // The truncation point is reported exactly once and names a source
+        // directory inside the deep chain.
+        Assert::same(\count($report->truncatedDirs), 1);
+        Assert::true(\str_contains($report->truncatedDirs[0], $skillDir));
+        Assert::same($report->skippedLinks, []);
+    }
+
     /**
      * Lay out a skill's files inside `<tmp>/skills/<package>/<skillName>/` and
      * return a Skill pointing at the directory. Different packages get

--- a/tests/Unit/Sync/SyncEngineTest.php
+++ b/tests/Unit/Sync/SyncEngineTest.php
@@ -9,6 +9,7 @@ use LLM\Skills\Discovery\Skill;
 use LLM\Skills\Sync\SyncEngine;
 use LLM\Skills\Tests\Testo\Filesystem;
 use Testo\Assert;
+use Testo\Core\Exception\SkipTest;
 use Testo\Lifecycle\AfterTest;
 use Testo\Lifecycle\BeforeTest;
 use Testo\Test;
@@ -223,6 +224,77 @@ final class SyncEngineTest
         (new SyncEngine())->sync([$skill], $this->target(), dryRun: true);
 
         Assert::same(\file_get_contents($this->targetPath('greeting/SKILL.md')), 'pre-existing content');
+    }
+
+    public function skipsSymlinkedDirectoriesAndFilesAndReportsThem(): void
+    {
+        // Security: a link inside a donor could point at a large or sensitive
+        // tree beyond the skill. The copy must land the regular files, skip
+        // both link kinds, and report each skip so it is never silent.
+        $skill = $this->makeSkill('acme/pro', 'refactor', ['SKILL.md' => '# Refactor']);
+        $skillDir = (string) $skill->sourceDir;
+
+        // A tree outside the skill that the links try to drag in.
+        $outside = $this->tmp . '/outside';
+        \mkdir($outside, 0o777, true);
+        \file_put_contents($outside . '/secret.txt', 'secret');
+
+        $dirLink = $skillDir . \DIRECTORY_SEPARATOR . 'leak';
+        $fileLink = $skillDir . \DIRECTORY_SEPARATOR . 'link.txt';
+        $dirLinkMade = Filesystem::makeDirLink($outside, $dirLink);
+        $fileLinkMade = Filesystem::makeFileLink($outside . '/secret.txt', $fileLink);
+
+        if (!$dirLinkMade && !$fileLinkMade) {
+            throw new SkipTest('platform refuses both symlink and junction creation');
+        }
+
+        $report = (new SyncEngine())->sync([$skill], $this->target());
+
+        Assert::true($report->isSuccess());
+        Assert::true(\is_file($this->targetPath('refactor/SKILL.md')), 'regular files are still copied');
+
+        if ($dirLinkMade) {
+            Assert::false(
+                \is_dir($this->targetPath('refactor/leak')),
+                'a linked subdirectory must not be traversed into the target',
+            );
+            Assert::false(\is_file($this->targetPath('refactor/leak/secret.txt')));
+            Assert::true(
+                \in_array($dirLink, $report->skippedLinks, true),
+                'the skipped directory link must be reported',
+            );
+        }
+
+        if ($fileLinkMade) {
+            Assert::false(
+                \is_file($this->targetPath('refactor/link.txt')),
+                'a symlinked file must not be copied',
+            );
+            Assert::true(
+                \in_array($fileLink, $report->skippedLinks, true),
+                'the skipped file link must be reported',
+            );
+        }
+    }
+
+    public function terminatesOnASymlinkCycleAndReportsTheSkip(): void
+    {
+        // A link that loops back to the skill root: following it would recurse
+        // forever. The copy must break the loop, skip the link, and finish.
+        $skill = $this->makeSkill('acme/pro', 'refactor', ['SKILL.md' => '# Refactor']);
+        $skillDir = (string) $skill->sourceDir;
+        $loop = $skillDir . \DIRECTORY_SEPARATOR . 'loop';
+
+        if (!Filesystem::makeDirLink($skillDir, $loop)) {
+            throw new SkipTest('platform refuses both symlink and junction creation');
+        }
+
+        $report = (new SyncEngine())->sync([$skill], $this->target());
+
+        Assert::true($report->isSuccess());
+        Assert::true(\is_file($this->targetPath('refactor/SKILL.md')));
+        Assert::false(\is_dir($this->targetPath('refactor/loop')));
+        Assert::same($report->skippedLinks, [$loop]);
     }
 
     /**


### PR DESCRIPTION
## What

\`sources[]\` gains a path-based adapter: a local directory declared as an explicit donor. This is the \`path\` source kind sketched in the packages spec, expressed through the existing sources machinery instead of a parallel subsystem.

```jsonc
// skills.json
{
  "sources": [
    { "from": "dir", "path": "./skills" },
    { "from": "dir", "path": "../shared-skills", "package": "myorg/shared", "skills": ["deploy"] }
  ]
}
```

```bash
composer skills:add ./skills        # path-shaped input selects the dir adapter
skills add ../shared-skills --skill=deploy
```

## How it works

- **Config**: \`from: "dir"\` requires \`path\`; \`url\`/\`host\`/\`ref\` are rejected (no host, no version concept); \`package\` optionally overrides the donor name. Composite key is \`dir||<path>\`. \`path\` is forbidden for every other adapter.
- **Runtime**: relative paths resolve from the project root; absolute paths honoured; locations outside the project are allowed (a \`sources[]\` entry is an explicit act of trust — same rationale as remote entries). The directory is read **live** on every sync: no fetch, no cache, no unpacking. A missing directory degrades to a per-entry warning, exactly like a failed remote fetch.
- **Donor shape**: the shared \`DonorArchiveInspector\` decides — a directory with its own \`composer.json\` + \`extra.skills.source\` is composer-shaped; a directory of \`SKILL.md\` subdirectories is a bare skill repo. Package name: \`package\` override → \`composer.json\` name → \`<parent>/<basename>\` lowercased (e.g. \`D:\git\testo\testo\skills\` → \`testo/skills\`).
- **\`skills:add\`**: input starting with \`./\`, \`../\`, \`/\`, \`\\` or a drive letter selects the adapter; \`--from=dir\` forces it; \`owner/repo\` shorthand and URLs route exactly as before. Missing directory is refused at add time; \`--skill\` and \`--no-sync\` work; stored paths are normalised to forward slashes.
- **Everything a sources entry already provides applies unchanged**: implicit trust, per-entry \`skills\` allowlist, \`--from=dir\` provenance filtering, composite-key dedup against other providers.

## Also in this PR

\`skills:show\` now labels user-declared donors \`[declared in skills.json]\` instead of crediting a coincidentally-matching trust list (or nothing): a \`sources[]\` entry is trusted by the declaration itself, so no list may take credit. Applies to all sources entries, not just \`dir\`.

## Field-tested

Ran end to end on a real project (testo): \`skills add ./skills\` folded the project's legacy \`remote\` key into \`sources\`, registered the dir entry, derived \`testo/skills\`, and synced 11 skills into \`.claude/skills\` with the \`.agents/skills\` alias intact — one command, offline.

## Tests

- Unit: mapper validation matrix, SourceEntry invariants, composite keys, writer serialisation, add heuristic, name derivation.
- Feature: end-to-end provider runs over temp dirs — composer-shaped/bare/missing/allowlist, provenance, implicit trust, and a \`neverFetch\` guard proving dir refs bypass the fetcher.
- Acceptance (offline): \`skills:update\` copies from a sandbox fixture dir; \`skills:show\` lists the donor with the declared-trust label; \`skills:add ./local-skills\` writes the entry and syncs — the first offline acceptance path \`skills:add\` has had.
- \`composer test\`: 773 passed / 1 skipped (gated live test). \`composer psalm\`, \`composer cs:diff\` clean.

## Out of scope (follow-ups)

- Guard against pathological self-references (\`path\` pointing at the sync target or project root) — bounded today (finite tree, convergent copies), tracked as real follow-up work.
- Renaming the \`Provider\Remote\` namespace / \`REMOTE_IDS\` vocabulary — parked per the sources-rename spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)