### PR TITLE
feat: per-package-manager `dependencies` block with scoped trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ composer skills:show
 composer skills:update
 ```
 
-Project-level settings (`target`, `trusted`, `discovery`, …) live in the consumer project's
+Project-level settings (`target`, `dependencies`, `discovery`, …) live in the consumer project's
 `skills.json` at the project root. See [Project configuration](#project-configuration) for the
 full reference.
 
@@ -172,13 +172,13 @@ where to put it, who to trust, whether to auto-sync.
   "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
   "target": ".agents/skills",
   "aliases": [".claude/skills", ".cursor/skills"],
-  "trusted": ["acme/*", "myorg/skills-internal"],
-  "trusted-replace": false,
   "discovery": false,
   "auto-sync": true,
   "path-from-root": "packages/api",
 
-  "local":  { "composer": true },
+  "dependencies": {
+    "composer": { "trusted": ["acme/*", "myorg/skills-internal"] }
+  },
   "sources": [
     { "from": "github", "package": "acme/skills", "ref": "^1.2.0" },
     { "from": "github", "package": "team/skills-pack", "ref": "^2",
@@ -191,12 +191,10 @@ where to put it, who to trust, whether to auto-sync.
 |-------------------|-------------|------------------|-----------------------------------------------------------------------------------------|
 | `target`          | string      | `.agents/skills` | Destination directory, relative to the project root.                                    |
 | `aliases`         | string[]    | `[]`             | Mirror paths (junction/symlink) pointing at `target`. See [Aliases](#aliases).          |
-| `trusted`         | string[]    | `[]`             | Extra trust patterns (see [Trust](#trust)).                                             |
-| `trusted-replace` | bool        | `false`          | When `true`, the built-in trust list and direct-dependency auto-trust are both ignored. |
 | `discovery`       | bool        | `false`          | When `true`, auto-discovery is on by default (CLI overrides).                           |
 | `auto-sync`       | bool        | `true`           | Run `skills:update` after `composer install` / `update`. Set to `false` to opt out.     |
 | `path-from-root`  | string      | _(unset)_        | The project's own location below an intended outer root, e.g. `packages/api`. When set, `target` and aliases resolve against (and stay inside) that verified root instead of the project directory. See [path-from-root](#path-from-root). |
-| `local`           | object      | `{}`             | Per-local-provider on/off map. Keys: `composer` (default `true`), `npm`/`go` (future, default `false`). See [Donor sources](#donor-sources). |
+| `dependencies`    | object      | `{}`             | Per-package-manager config: `<id>` → `bool` (walk toggle) or `{ enabled, trusted, trusted-replace }`. Ids: `composer` (walk default `true`), `npm`/`go` (future, default `false`). `trusted` extends the manager's trust list; `trusted-replace` makes it fully replace the built-in and direct-dependency trust. Deprecated aliases `trusted`, `trusted-replace`, `local` fold into this block. See [Trust](#trust) and [Donor sources](#donor-sources). |
 | `sources`         | object[]    | `[]`             | Explicit donor source entries. Managed by `skills:add`; documented in [Donor sources](#donor-sources). |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
@@ -211,6 +209,16 @@ it once and commit it alongside `composer.json`.
 > migrates the key in place and prints a `[migrate]` line; read-only `skills:show` just emits a
 > `[deprecated]` notice. Having both `remote` and `sources` in the same file is a fatal config
 > error — keep `sources` only.
+
+> [!NOTE]
+> **`trusted`, `trusted-replace` and `local` moved into `dependencies`.** Trust is now
+> scoped per package manager, so the flat trust surface and the `local` toggle map collapse
+> into one block: `dependencies.<id>` takes a bool (the old `local` toggle) or an object with
+> `enabled` / `trusted` / `trusted-replace`. The three legacy keys keep working as deprecated
+> aliases — flat `trusted`/`trusted-replace` fold into `dependencies.composer`. Write-mode
+> commands migrate the file in place with a `[migrate]` line; `skills:show` just emits a
+> `[deprecated]` notice. Having `dependencies` alongside any legacy key in the same file is a
+> fatal config error — keep `dependencies` only.
 
 ### Strict shape
 
@@ -378,9 +386,10 @@ Effective trust list:
 builtin ∪ project.trusted ∪ --trust=<pattern> ∪ direct-deps
 ```
 
-`project.trusted` is the `trusted` array from `skills.json`. `direct-deps` is the set of
-packages declared under `require` and `require-dev` in the consumer's root `composer.json`.
-Setting `trusted-replace: true` drops both implicit sources
+`project.trusted` is the `dependencies.composer.trusted` array from `skills.json` (the
+deprecated flat `trusted` key folds into it). `direct-deps` is the set of packages declared
+under `require` and `require-dev` in the consumer's root `composer.json`. Setting
+`dependencies.composer.trusted-replace: true` drops both implicit sources
 (`builtin` and `direct-deps`) from the union, leaving only project trust and `--trust=` —
 the explicit-only mode.
 
@@ -403,7 +412,8 @@ Bare `vendor` without `/` is rejected as ambiguous.
 - **Direct dependencies are implicit trust.** A package the consumer chose to depend on
   (`require` / `require-dev`) does not need a trust pattern: the dependency declaration is
   already a trust decision. Transitive dependencies are still gated by the trust list.
-  Setting `trusted-replace: true` turns this off for projects that want explicit-only trust.
+  Setting `dependencies.composer.trusted-replace: true` turns this off for projects that want
+  explicit-only trust.
 
 ### Built-in trusted vendors
 
@@ -536,15 +546,15 @@ composer skills:update --from=composer    # only local Composer donors
 composer skills:update --from=github      # only remote GitHub donors
 ```
 
-The id matches `local.{id}` keys and `sources[].from` values. Each donor's provenance is set at the source: `ComposerProvider` tags `composer`; `RemoteProvider` tags the entry's `from`. The filter is a simple equality check on that tag.
+The id matches `dependencies.{id}` keys and `sources[].from` values. Each donor's provenance is set at the source: `ComposerProvider` tags `composer`; `RemoteProvider` tags the entry's `from`. The filter is a simple equality check on that tag.
 
-### Local provider toggles
+### Dependency walk toggles
 
 ```jsonc
-{ "local": { "composer": false } }    // disable Composer discovery entirely
+{ "dependencies": { "composer": false } }    // disable Composer discovery entirely
 ```
 
-`local.composer` defaults to `true` (preserves the pre-`local` behaviour). When set to `false`, transitive Composer packages are no longer scanned — useful when the project wants its donors purely from `sources[]`.
+`dependencies.composer` defaults to `true` (transitive Composer packages are scanned for donors). Set it to `false` — either the bool short form above or `{ "composer": { "enabled": false } }` — to stop scanning, useful when the project wants its donors purely from `sources[]`. The per-manager `trusted` / `trusted-replace` fields configure which of those scanned packages are allowed to ship skills (see [Trust](#trust)).
 
 For the full architectural rationale, the version-resolution cascade, the cache layout, and the multi-registry trust model, see [`spec-remote.md`](spec-remote.md).
 

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -28,7 +28,8 @@
         },
         "trusted": {
             "type": "array",
-            "description": "Packages or vendor patterns allowed to ship skills into this project. Each pattern is either an exact name like \"vendor/package\" or a wildcard like \"vendor/*\". Bare vendor names (no slash) are rejected.",
+            "deprecated": true,
+            "description": "Replaced by dependencies.composer.trusted; read as an alias, auto-migrated by skills:update. Packages or vendor patterns allowed to ship skills into this project. Each pattern is either an exact name like \"vendor/package\" or a wildcard like \"vendor/*\". Bare vendor names (no slash) are rejected.",
             "items": {
                 "type": "string",
                 "minLength": 1,
@@ -38,7 +39,8 @@
         },
         "trusted-replace": {
             "type": "boolean",
-            "description": "When true, the project's trusted list completely replaces both the built-in trusted vendors and the implicit direct-dependency trust. Default: false (project list extends the implicit sources).",
+            "deprecated": true,
+            "description": "Replaced by dependencies.composer.trusted-replace; read as an alias, auto-migrated by skills:update. When true, the project's trusted list completely replaces both the built-in trusted vendors and the implicit direct-dependency trust. Default: false (project list extends the implicit sources).",
             "default": false
         },
         "discovery": {
@@ -57,7 +59,8 @@
         },
         "local": {
             "type": "object",
-            "description": "Per-local-provider on/off toggles. Keys must come from the locked vocabulary (composer, npm, go). Absent keys fall back to per-provider defaults: composer enabled, others disabled until their provider implementation lands.",
+            "deprecated": true,
+            "description": "Replaced by dependencies (bool values map one-to-one); read as an alias, auto-migrated by skills:update. Per-local-provider on/off toggles. Keys must come from the locked vocabulary (composer, npm, go). Absent keys fall back to per-provider defaults: composer enabled, others disabled until their provider implementation lands.",
             "additionalProperties": false,
             "properties": {
                 "composer": {
@@ -74,6 +77,34 @@
                     "type": "boolean",
                     "description": "Enable the Go modules local donor provider (future). Default: false.",
                     "default": false
+                }
+            }
+        },
+        "dependencies": {
+            "type": "object",
+            "description": "Per-package-manager configuration: how each manager's installed dependency tree becomes a skill donor, and its trust list. Keys come from the locked vocabulary (composer, npm, go). Each value is a boolean toggle (short form: enable/disable the walk) or a configuration object.",
+            "additionalProperties": false,
+            "properties": {
+                "composer": {
+                    "description": "Composer/Packagist dependencies. Trust patterns use the vendor/pkg grammar: exact \"vendor/package\" or wildcard \"vendor/*\"; bare vendor names (no slash) are rejected.",
+                    "oneOf": [
+                        { "type": "boolean" },
+                        { "$ref": "#/$defs/dependencyManagerConfigComposer" }
+                    ]
+                },
+                "npm": {
+                    "description": "npm dependencies (provider forthcoming). Trust patterns target npm names: bare package (\"lodash\"), scoped package (\"@scope/pkg\"), or scope wildcard (\"@scope/*\"). Grammar is documented but not enforced until the provider lands.",
+                    "oneOf": [
+                        { "type": "boolean" },
+                        { "$ref": "#/$defs/dependencyManagerConfig" }
+                    ]
+                },
+                "go": {
+                    "description": "Go module dependencies (provider forthcoming). Trust patterns target module paths: prefix patterns like \"github.com/owner/mod\" or \"github.com/owner/*\". Grammar is documented but not enforced until the provider lands.",
+                    "oneOf": [
+                        { "type": "boolean" },
+                        { "$ref": "#/$defs/dependencyManagerConfig" }
+                    ]
                 }
             }
         },
@@ -103,10 +134,64 @@
             }
         }
     },
-    "not": {
-        "required": ["sources", "remote"]
-    },
+    "allOf": [
+        { "not": { "required": ["sources", "remote"] } },
+        { "not": { "required": ["dependencies", "local"] } },
+        { "not": { "required": ["dependencies", "trusted"] } },
+        { "not": { "required": ["dependencies", "trusted-replace"] } }
+    ],
     "$defs": {
+        "dependencyManagerConfig": {
+            "type": "object",
+            "description": "Per-manager configuration object. enabled toggles the dependency-tree walk; trusted extends the manager's trust list; trusted-replace makes trusted fully replace the built-in and direct-dependency trust.",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Walk this manager's installed dependency tree for donors. Absent → per-manager default (composer true; npm/go false until their providers land). Configuring trusted does not implicitly enable the walk."
+                },
+                "trusted": {
+                    "type": "array",
+                    "description": "Trust patterns for this manager. Extends the built-in per-manager list and the direct-dependency implicit trust.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "default": []
+                },
+                "trusted-replace": {
+                    "type": "boolean",
+                    "description": "When true, this manager's trusted list fully replaces both its built-in list and its direct-dependency implicit trust. Default: false.",
+                    "default": false
+                }
+            }
+        },
+        "dependencyManagerConfigComposer": {
+            "type": "object",
+            "description": "Composer per-manager configuration object. Identical to dependencyManagerConfig except trusted patterns are enforced against the vendor/pkg grammar.",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Walk the installed Composer dependency tree for donors. Absent → true. Configuring trusted does not implicitly enable the walk."
+                },
+                "trusted": {
+                    "type": "array",
+                    "description": "Composer trust patterns: exact \"vendor/package\" or wildcard \"vendor/*\"; bare vendor names (no slash) are rejected.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "^[^/]+/[^/]+$"
+                    },
+                    "default": []
+                },
+                "trusted-replace": {
+                    "type": "boolean",
+                    "description": "When true, the Composer trusted list fully replaces both the built-in list and the direct-dependency implicit trust. Default: false.",
+                    "default": false
+                }
+            }
+        },
         "sourceByPackage": {
             "type": "object",
             "description": "Donor source entry for name-based adapters (github, gitlab, bitbucket, composer, npm, go, skills.sh).",

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -26,23 +26,6 @@
             "uniqueItems": true,
             "default": []
         },
-        "trusted": {
-            "type": "array",
-            "deprecated": true,
-            "description": "Replaced by dependencies.composer.trusted; read as an alias, auto-migrated by skills:update. Packages or vendor patterns allowed to ship skills into this project. Each pattern is either an exact name like \"vendor/package\" or a wildcard like \"vendor/*\". Bare vendor names (no slash) are rejected.",
-            "items": {
-                "type": "string",
-                "minLength": 1,
-                "pattern": "^[^/]+/[^/]+$"
-            },
-            "default": []
-        },
-        "trusted-replace": {
-            "type": "boolean",
-            "deprecated": true,
-            "description": "Replaced by dependencies.composer.trusted-replace; read as an alias, auto-migrated by skills:update. When true, the project's trusted list completely replaces both the built-in trusted vendors and the implicit direct-dependency trust. Default: false (project list extends the implicit sources).",
-            "default": false
-        },
         "discovery": {
             "type": "boolean",
             "description": "When true, packages without an explicit extra.skills.source block are still considered as donors if they ship a top-level skills/ directory. CLI --discovery overrides this.",
@@ -56,29 +39,6 @@
         "path-from-root": {
             "type": "string",
             "description": "The project's own location relative to an intended outer containment root, e.g. \"packages/api\" in a monorepo. When set, target and aliases are resolved against (and confined to) that root instead of the project directory, after verifying the declared suffix matches the real project location. Must be a relative path with plain segments (no \".\"/\"..\"). Omit to confine writes to the project root."
-        },
-        "local": {
-            "type": "object",
-            "deprecated": true,
-            "description": "Replaced by dependencies (bool values map one-to-one); read as an alias, auto-migrated by skills:update. Per-local-provider on/off toggles. Keys must come from the locked vocabulary (composer, npm, go). Absent keys fall back to per-provider defaults: composer enabled, others disabled until their provider implementation lands.",
-            "additionalProperties": false,
-            "properties": {
-                "composer": {
-                    "type": "boolean",
-                    "description": "Enable the Composer/Packagist local donor provider. Default: true.",
-                    "default": true
-                },
-                "npm": {
-                    "type": "boolean",
-                    "description": "Enable the npm local donor provider (future). Default: false.",
-                    "default": false
-                },
-                "go": {
-                    "type": "boolean",
-                    "description": "Enable the Go modules local donor provider (future). Default: false.",
-                    "default": false
-                }
-            }
         },
         "dependencies": {
             "type": "object",
@@ -119,27 +79,8 @@
                     { "$ref": "#/$defs/sourceByDir" }
                 ]
             }
-        },
-        "remote": {
-            "type": "array",
-            "deprecated": true,
-            "description": "Renamed to sources; read as an alias, auto-migrated by skills:update.",
-            "default": [],
-            "items": {
-                "oneOf": [
-                    { "$ref": "#/$defs/sourceByPackage" },
-                    { "$ref": "#/$defs/sourceByUrl" },
-                    { "$ref": "#/$defs/sourceByDir" }
-                ]
-            }
         }
     },
-    "allOf": [
-        { "not": { "required": ["sources", "remote"] } },
-        { "not": { "required": ["dependencies", "local"] } },
-        { "not": { "required": ["dependencies", "trusted"] } },
-        { "not": { "required": ["dependencies", "trusted-replace"] } }
-    ],
     "$defs": {
         "dependencyManagerConfig": {
             "type": "object",

--- a/resources/trusted-go.txt
+++ b/resources/trusted-go.txt
@@ -1,0 +1,26 @@
+# Built-in trusted-vendors list for the go provider.
+#
+# Module-path prefix patterns; org-owned namespaces only. A module whose path
+# begins with any of these prefixes may ship AI skills into a consumer project
+# without an explicit opt-in.
+#
+# Format: one pattern per line. Blank lines and lines starting with `#` are
+# ignored. Surrounding whitespace is trimmed.
+
+# AI / agent ecosystem
+github.com/anthropics/*
+github.com/modelcontextprotocol/*
+
+# The Go project
+github.com/golang/*
+golang.org/x/*
+google.golang.org/*
+
+# Spiral / RoadRunner / Temporal ecosystem (mirrors the composer list)
+github.com/spiral/*
+github.com/roadrunner-server/*
+github.com/temporalio/*
+
+# Widely-trusted infrastructure orgs
+github.com/grpc/*
+github.com/uber-go/*

--- a/resources/trusted-npm.txt
+++ b/resources/trusted-npm.txt
@@ -1,0 +1,28 @@
+# Built-in trusted-vendors list for the npm provider.
+#
+# Only ownership-verified npm scopes are built in. A package whose npm name
+# matches any of these scope patterns may ship AI skills into a consumer
+# project without an explicit opt-in.
+#
+# Bare (unscoped) package names are deliberately absent: an unscoped name can
+# change hands on the registry, so there is no stable ownership guarantee.
+# Trust those per-project via "dependencies.npm.trusted" in skills.json.
+#
+# Format: one pattern per line. Blank lines and lines starting with `#` are
+# ignored. Surrounding whitespace is trimmed.
+
+# AI / agent ecosystem
+@anthropic-ai/*
+@modelcontextprotocol/*
+@openai/*
+@google/*
+
+# Frameworks & platform vendors
+@angular/*
+@vue/*
+@sveltejs/*
+@nestjs/*
+@nuxt/*
+@astrojs/*
+@remix-run/*
+@vercel/*

--- a/src/Add/SkillsJsonWriter.php
+++ b/src/Add/SkillsJsonWriter.php
@@ -32,7 +32,9 @@ use LLM\Skills\Filesystem\AtomicFileWriter;
  * {@see ProjectConfigMigrator} emits). Existing files keep all their
  * other keys verbatim — only `sources[]` is touched. A file still on
  * the deprecated `remote` key has its entries folded into `sources`
- * and the old key dropped, since the writer rewrites the whole file.
+ * and the old key dropped, and a file still on the legacy trust trio
+ * (`local` / `trusted` / `trusted-replace`) has it folded into a
+ * `dependencies` block, since the writer rewrites the whole file.
  */
 final readonly class SkillsJsonWriter
 {
@@ -63,8 +65,21 @@ final readonly class SkillsJsonWriter
         $updated = self::upsertByCompositeKey($entries, $entry);
         $sorted = self::stableSort($updated);
 
-        // The whole file is rewritten under the canonical key; a
-        // lingering deprecated alias is dropped from the output.
+        // The whole file is rewritten under the canonical keys; lingering
+        // deprecated aliases are dropped from the output. The legacy trust
+        // trio folds into `dependencies` (unless the file already carries
+        // one — a hand-edited mix keeps the canonical block and just drops
+        // the legacy keys), mirroring the `remote` → `sources` fold below.
+        if (ProjectConfigMigrator::hasLegacyDependencyKeys($payload)) {
+            $folded = ProjectConfigMigrator::foldLegacyDependencies($payload);
+            foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $legacyKey) {
+                unset($payload[$legacyKey]);
+            }
+            if (!\array_key_exists(ProjectConfigMapper::DEPENDENCIES_KEY, $payload)) {
+                $payload[ProjectConfigMapper::DEPENDENCIES_KEY] = $folded;
+            }
+        }
+
         unset($payload[ProjectConfigMapper::DEPRECATED_SOURCES_KEY]);
         $payload[ProjectConfigMapper::SOURCES_KEY] = \array_map(self::serialise(...), $sorted);
 

--- a/src/Config/DependencyConfig.php
+++ b/src/Config/DependencyConfig.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+use LLM\Skills\Discovery\Provider\ProviderId;
+
+/**
+ * Parsed configuration for a single package manager under the
+ * `dependencies` block: whether its installed tree is walked for donors
+ * and which patterns extend (or replace) its trust.
+ *
+ * Trust patterns are stored raw — one representation for every manager —
+ * because the grammars differ: composer uses `vendor/pkg` names that
+ * {@see VendorPattern} understands, whereas npm (`@scope/pkg`) and go
+ * (`github.com/owner/mod`) names are strings {@see VendorPattern} rejects
+ * by design. Composer patterns are validated through {@see VendorPattern}
+ * at map time and exposed as a {@see TrustedVendors} view via
+ * {@see self::trustedVendors()}; npm/go patterns are kept as raw strings
+ * until their providers land.
+ *
+ * @psalm-immutable
+ */
+final readonly class DependencyConfig
+{
+    /**
+     * @param bool|null $enabled resolved enable flag, or `null` when the user left
+     *        it out — callers fall back to {@see ProviderId::defaultLocalEnabled()}
+     * @param list<non-empty-string> $trusted raw per-manager trust patterns, validated
+     *        against the manager's grammar at map time
+     * @param bool $trustedReplace when true, `$trusted` fully replaces the manager's
+     *        built-in list and its direct-dependency implicit trust
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public ?bool $enabled,
+        public array $trusted,
+        public bool $trustedReplace,
+    ) {}
+
+    /**
+     * Resolve `$enabled` against the per-manager default for the given id.
+     *
+     * @psalm-mutation-free
+     */
+    public function isEnabled(string $id): bool
+    {
+        return $this->enabled ?? ProviderId::defaultLocalEnabled($id);
+    }
+
+    /**
+     * Composer-grammar view of `$trusted`. Only meaningful for the
+     * `composer` manager, whose patterns were validated through
+     * {@see VendorPattern} at map time; other managers store
+     * registry-specific strings {@see VendorPattern} rejects by design.
+     *
+     * @psalm-mutation-free
+     */
+    public function trustedVendors(): TrustedVendors
+    {
+        return TrustedVendors::fromStrings(...$this->trusted);
+    }
+}

--- a/src/Config/GoPattern.php
+++ b/src/Config/GoPattern.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+/**
+ * A trust pattern that matches Go module paths.
+ *
+ * Two shapes:
+ * - `github.com/owner/mod` — exact module-path match.
+ * - `github.com/owner/*`   — every module path under the `github.com/owner`
+ *                            prefix.
+ *
+ * Wildcard semantics are prefix-based, not single-segment: `github.com/owner/*`
+ * matches `github.com/owner/repo`, the submodule `github.com/owner/repo/tools`,
+ * and the major-version path `github.com/owner/repo/v2` alike. Go encodes
+ * submodules and `/vN` major versions as extra path segments, so an org-level
+ * trust entry only stays useful if it reaches arbitrary depth under its
+ * prefix; matching exactly one segment would silently drop trust for every
+ * submodule and versioned import. The wildcard requires at least one segment
+ * after the prefix — the bare prefix alone is not a real module path.
+ *
+ * Matching is literal and case-sensitive. Go module paths are case-sensitive
+ * (the module proxy escapes upper-case letters, but the canonical path keeps
+ * its case), so a byte-for-byte comparison is the honest rule.
+ *
+ * @psalm-immutable
+ */
+final readonly class GoPattern implements TrustPattern
+{
+    /**
+     * @param non-empty-string $raw   original textual pattern, kept for diagnostics
+     * @param non-empty-string $base  the module path (exact) or the prefix
+     *        before `/*` (wildcard)
+     * @param bool $wildcard whether `$base` is a prefix (`base/*`) rather than
+     *        a full module path
+     *
+     * @psalm-mutation-free
+     */
+    private function __construct(
+        public string $raw,
+        public string $base,
+        public bool $wildcard,
+    ) {}
+
+    /**
+     * @param non-empty-string $pattern
+     *
+     * @throws \InvalidArgumentException when the pattern is empty once the
+     *         optional `/*` suffix is removed.
+     *
+     * @psalm-pure
+     */
+    public static function fromString(string $pattern): self
+    {
+        if (\str_ends_with($pattern, '/*')) {
+            $base = \substr($pattern, 0, -2);
+            if ($base === '') {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid go pattern "%s": a wildcard needs a module-path prefix before "/*".',
+                    $pattern,
+                ));
+            }
+
+            return new self(raw: $pattern, base: $base, wildcard: true);
+        }
+
+        if ($pattern === '*') {
+            throw new \InvalidArgumentException(
+                'Invalid go pattern "*": a bare wildcard is not allowed; give it a prefix ("owner/*").',
+            );
+        }
+
+        return new self(raw: $pattern, base: $pattern, wildcard: false);
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function raw(): string
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @param non-empty-string $packageName  full Go module path
+     *
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function matches(string $packageName): bool
+    {
+        if ($this->wildcard) {
+            return \str_starts_with($packageName, $this->base . '/');
+        }
+
+        return $packageName === $this->base;
+    }
+}

--- a/src/Config/GoPattern.php
+++ b/src/Config/GoPattern.php
@@ -48,7 +48,9 @@ final readonly class GoPattern implements TrustPattern
      * @param non-empty-string $pattern
      *
      * @throws \InvalidArgumentException when the pattern is empty once the
-     *         optional `/*` suffix is removed.
+     *         optional `/*` suffix is removed, or when a `*` appears anywhere
+     *         other than that trailing `/*` wildcard — an embedded `*` yields
+     *         a module path that can never match.
      *
      * @psalm-pure
      */
@@ -62,6 +64,14 @@ final readonly class GoPattern implements TrustPattern
                     $pattern,
                 ));
             }
+            // The prefix is a literal module path; a `*` inside it (`own*er/*`)
+            // never matches a real module.
+            if (\str_contains($base, '*')) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid go pattern "%s": "*" is only allowed as the trailing "/*" wildcard.',
+                    $pattern,
+                ));
+            }
 
             return new self(raw: $pattern, base: $base, wildcard: true);
         }
@@ -70,6 +80,14 @@ final readonly class GoPattern implements TrustPattern
             throw new \InvalidArgumentException(
                 'Invalid go pattern "*": a bare wildcard is not allowed; give it a prefix ("owner/*").',
             );
+        }
+        // An exact module path is literal; a `*` anywhere in it (`*/mod`,
+        // `owner/*/v2`) yields a path that can never match.
+        if (\str_contains($pattern, '*')) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Invalid go pattern "%s": "*" is only allowed as the trailing "/*" wildcard.',
+                $pattern,
+            ));
         }
 
         return new self(raw: $pattern, base: $pattern, wildcard: false);

--- a/src/Config/Mapper/ExternalProjectConfigLoader.php
+++ b/src/Config/Mapper/ExternalProjectConfigLoader.php
@@ -49,6 +49,7 @@ final readonly class ExternalProjectConfigLoader
         '$schema',
         'target',
         'aliases',
+        'dependencies',
         'trusted',
         'trusted-replace',
         'discovery',

--- a/src/Config/Mapper/MappedSkillsBlock.php
+++ b/src/Config/Mapper/MappedSkillsBlock.php
@@ -8,12 +8,13 @@ use LLM\Skills\Config\ProjectConfig;
 
 /**
  * Internal result of {@see ProjectConfigMapper::mapSkillsBlock()}: the
- * mapped {@see ProjectConfig} plus a flag recording whether the block
- * declared its donor sources under the deprecated `remote` key rather
- * than `sources`. The mapper is shared by the external `skills.json`
- * and inline `extra.skills` paths; bundling the flag lets both surface
- * the deprecation upward without widening the public `fromExtra()`
- * signature.
+ * mapped {@see ProjectConfig} plus flags recording which deprecated
+ * aliases the block used — the `remote` sources key, and the legacy
+ * `trusted` / `trusted-replace` / `local` keys folded into the
+ * `dependencies` block. The mapper is shared by the external
+ * `skills.json` and inline `extra.skills` paths; bundling the flags lets
+ * both surface the deprecation upward without widening the public
+ * `fromExtra()` signature.
  *
  * @internal
  *
@@ -24,11 +25,16 @@ final readonly class MappedSkillsBlock
     /**
      * @param bool $usedDeprecatedSourcesKey true when the block used `remote`
      *        instead of `sources`
+     * @param list<non-empty-string> $usedDeprecatedDependencyKeys legacy dependency keys
+     *        (`trusted`, `trusted-replace`, `local`) the block used instead of
+     *        `dependencies`, in the order they are listed; empty when the block used
+     *        the `dependencies` key or declared no dependency config at all
      *
      * @psalm-mutation-free
      */
     public function __construct(
         public ProjectConfig $config,
         public bool $usedDeprecatedSourcesKey,
+        public array $usedDeprecatedDependencyKeys = [],
     ) {}
 }

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LLM\Skills\Config\Mapper;
 
 use Internal\Path;
+use LLM\Skills\Config\DependencyConfig;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\ProjectConfigResolution;
@@ -53,19 +54,40 @@ final readonly class ProjectConfigMapper
     public const DEPRECATED_SOURCES_KEY = 'remote';
 
     /**
+     * Canonical key for per-package-manager dependency config (donor
+     * scanning toggles and scoped trust).
+     */
+    public const DEPENDENCIES_KEY = 'dependencies';
+
+    /**
+     * Legacy keys folded into {@see self::DEPENDENCIES_KEY}, still read
+     * everywhere project config is read and auto-migrated by write-mode
+     * commands. Any of these present alongside `dependencies` is fatal.
+     *
+     * @var list<non-empty-string>
+     */
+    public const DEPRECATED_DEPENDENCY_KEYS = [
+        'trusted',
+        'trusted-replace',
+        'local',
+    ];
+
+    /**
      * Project-level keys understood under `extra.skills`. Donor-side
      * keys (`source`) are deliberately excluded — they describe the
      * package as a donor, not as a consumer, and must not be flagged
      * as "shadowed" when `skills.json` is in effect.
      *
-     * The deprecated `remote` alias stays in the list so a shadowed
-     * inline block still reports it and inline migration can extract it.
+     * The deprecated `remote` alias and the legacy dependency keys stay
+     * in the list so a shadowed inline block still reports them and
+     * inline migration can extract them.
      *
      * @var list<non-empty-string>
      */
     public const PROJECT_KEYS = [
         'target',
         'aliases',
+        self::DEPENDENCIES_KEY,
         'trusted',
         'trusted-replace',
         'discovery',
@@ -104,7 +126,12 @@ final readonly class ProjectConfigMapper
             $mapped = $this->mapSkillsBlock($external, 'skills.json');
             $ignored = $this->collectIgnoredInlineKeys($extra);
 
-            return new ProjectConfigResolution($mapped->config, $ignored, $mapped->usedDeprecatedSourcesKey);
+            return new ProjectConfigResolution(
+                $mapped->config,
+                $ignored,
+                $mapped->usedDeprecatedSourcesKey,
+                $mapped->usedDeprecatedDependencyKeys,
+            );
         }
 
         $mapped = $this->mapExtra($extra);
@@ -112,6 +139,7 @@ final readonly class ProjectConfigMapper
         return new ProjectConfigResolution(
             $mapped->config,
             usedDeprecatedSourcesKey: $mapped->usedDeprecatedSourcesKey,
+            usedDeprecatedDependencyKeys: $mapped->usedDeprecatedDependencyKeys,
         );
     }
 
@@ -329,15 +357,6 @@ final readonly class ProjectConfigMapper
 
         $aliases = $this->mapAliases($skills['aliases'] ?? [], $target, $prefix);
 
-        $trusted = $this->mapTrusted($skills['trusted'] ?? [], $prefix);
-
-        $replace = $skills['trusted-replace'] ?? false;
-        if (!\is_bool($replace)) {
-            throw new MalformedProjectConfig(
-                self::field($prefix, 'trusted-replace') . ' must be a boolean',
-            );
-        }
-
         $discovery = $skills['discovery'] ?? false;
         if (!\is_bool($discovery)) {
             throw new MalformedProjectConfig(
@@ -354,7 +373,31 @@ final readonly class ProjectConfigMapper
 
         $pathFromRoot = $this->mapPathFromRoot($skills['path-from-root'] ?? null, $prefix);
 
-        $local = $this->mapLocal($skills['local'] ?? [], $prefix);
+        // `dependencies` is canonical; `trusted`, `trusted-replace` and
+        // `local` are the legacy aliases folded into it. Either form is
+        // accepted, but mixing them in one block is fatal — the file is
+        // ours and strict, so there is no merge or precedence rule.
+        $usedDeprecatedDependencyKeys = $this->presentLegacyDependencyKeys($skills);
+        if (\array_key_exists(self::DEPENDENCIES_KEY, $skills)) {
+            if ($usedDeprecatedDependencyKeys !== []) {
+                throw new MalformedProjectConfig(\sprintf(
+                    '%s: both "%s" and legacy "%s" are present; keep "%s" only',
+                    $prefix,
+                    self::DEPENDENCIES_KEY,
+                    $usedDeprecatedDependencyKeys[0],
+                    self::DEPENDENCIES_KEY,
+                ));
+            }
+
+            $dependencies = $this->mapDependencies($skills[self::DEPENDENCIES_KEY], $prefix);
+            [$trusted, $replace, $local] = $this->foldDependencies($dependencies);
+            $usedDeprecatedDependencyKeys = [];
+        } else {
+            $trusted = $this->mapTrusted($skills['trusted'] ?? [], $prefix);
+            $replace = $this->mapTrustedReplace($skills['trusted-replace'] ?? false, $prefix);
+            $local = $this->mapLocal($skills['local'] ?? [], $prefix);
+            $dependencies = [];
+        }
 
         // `sources` is canonical; `remote` is the deprecated alias feeding
         // the same validator. Both keys in one block is fatal — the file
@@ -383,9 +426,10 @@ final readonly class ProjectConfigMapper
             pathFromRoot: $pathFromRoot,
             local: $local,
             sources: $sources,
+            dependencies: $dependencies,
         );
 
-        return new MappedSkillsBlock($config, $usedDeprecatedSourcesKey);
+        return new MappedSkillsBlock($config, $usedDeprecatedSourcesKey, $usedDeprecatedDependencyKeys);
     }
 
     /**
@@ -438,6 +482,242 @@ final readonly class ProjectConfigMapper
         }
 
         return $raw;
+    }
+
+    /**
+     * Names of the legacy dependency keys (`trusted`, `trusted-replace`,
+     * `local`) present in the block, in canonical order. Used both to
+     * detect illegal mixing with `dependencies` and to record which
+     * aliases the block relied on for the deprecation notice.
+     *
+     * @param array<array-key, mixed> $skills
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-pure
+     */
+    private function presentLegacyDependencyKeys(array $skills): array
+    {
+        $present = [];
+        foreach (self::DEPRECATED_DEPENDENCY_KEYS as $key) {
+            if (\array_key_exists($key, $skills)) {
+                $present[] = $key;
+            }
+        }
+
+        return $present;
+    }
+
+    /**
+     * Validate the `trusted-replace` toggle. Shared by the legacy flat
+     * form and, indirectly, the per-manager object form.
+     *
+     * @param non-empty-string $prefix
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-pure
+     */
+    private function mapTrustedReplace(mixed $raw, string $prefix): bool
+    {
+        if (!\is_bool($raw)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'trusted-replace') . ' must be a boolean',
+            );
+        }
+
+        return $raw;
+    }
+
+    /**
+     * Parse the `dependencies` block: a map of package-manager id to a
+     * bool toggle or a per-manager object. Each key must be a known
+     * package manager ({@see ProviderId::LOCAL_IDS}).
+     *
+     * @param non-empty-string $prefix
+     *
+     * @return array<non-empty-string, DependencyConfig>
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-mutation-free
+     */
+    private function mapDependencies(mixed $raw, string $prefix): array
+    {
+        if ($raw === [] || $raw === null) {
+            return [];
+        }
+        if (!\is_array($raw) || \array_is_list($raw)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, self::DEPENDENCIES_KEY)
+                . ' must be a map of package-manager id to boolean or object',
+            );
+        }
+
+        $out = [];
+        /** @var mixed $value */
+        foreach ($raw as $id => $value) {
+            if (!\is_string($id) || $id === '') {
+                throw new MalformedProjectConfig(
+                    self::field($prefix, self::DEPENDENCIES_KEY) . ' keys must be non-empty strings',
+                );
+            }
+            if (!ProviderId::isKnownLocal($id)) {
+                throw new MalformedProjectConfig(\sprintf(
+                    '%s.%s is not a known package manager (known: %s)',
+                    self::field($prefix, self::DEPENDENCIES_KEY),
+                    $id,
+                    \implode(', ', ProviderId::LOCAL_IDS),
+                ));
+            }
+            $out[$id] = $this->mapDependencyEntry($value, $id, $prefix);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Parse one `dependencies` entry. `true` / `false` are shorthand for
+     * `{ "enabled": <bool> }`; an object carries `enabled`, `trusted` and
+     * `trusted-replace`, all optional. Unknown object fields are fatal —
+     * the structure is ours and strict.
+     *
+     * @param non-empty-string $id already-validated package-manager id
+     * @param non-empty-string $prefix
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-mutation-free
+     */
+    private function mapDependencyEntry(mixed $raw, string $id, string $prefix): DependencyConfig
+    {
+        $field = self::field($prefix, self::DEPENDENCIES_KEY) . '.' . $id;
+
+        if (\is_bool($raw)) {
+            return new DependencyConfig(enabled: $raw, trusted: [], trustedReplace: false);
+        }
+
+        if (!\is_array($raw) || \array_is_list($raw)) {
+            throw new MalformedProjectConfig($field . ' must be a boolean or an object');
+        }
+
+        foreach ($raw as $key => $_value) {
+            if ($key !== 'enabled' && $key !== 'trusted' && $key !== 'trusted-replace') {
+                throw new MalformedProjectConfig(\sprintf(
+                    '%s has unknown field "%s"; allowed fields: enabled, trusted, trusted-replace',
+                    $field,
+                    (string) $key,
+                ));
+            }
+        }
+
+        // `enabled` absent stays null so the caller can fall back to the
+        // per-manager default — configuring `trusted` never enables a
+        // manager implicitly.
+        $enabled = $raw['enabled'] ?? null;
+        if ($enabled !== null && !\is_bool($enabled)) {
+            throw new MalformedProjectConfig($field . '.enabled must be a boolean');
+        }
+
+        $replace = $raw['trusted-replace'] ?? false;
+        if (!\is_bool($replace)) {
+            throw new MalformedProjectConfig($field . '.trusted-replace must be a boolean');
+        }
+
+        $trusted = $this->mapDependencyTrusted($raw['trusted'] ?? [], $id, $field);
+
+        return new DependencyConfig(enabled: $enabled, trusted: $trusted, trustedReplace: $replace);
+    }
+
+    /**
+     * Validate a per-manager `trusted` list. Composer patterns go through
+     * the {@see VendorPattern} grammar exactly like the flat `trusted`
+     * list; npm/go patterns validate structurally only (non-empty
+     * strings) — their grammars reject npm/go names by design and are
+     * enforced when the providers land. Duplicates are fatal for every
+     * manager. Patterns are stored raw regardless of manager.
+     *
+     * @param non-empty-string $id already-validated package-manager id
+     * @param non-empty-string $field error-message prefix, e.g. `skills.json: dependencies.npm`
+     *
+     * @return list<non-empty-string>
+     *
+     * @throws MalformedProjectConfig
+     *
+     * @psalm-mutation-free
+     */
+    private function mapDependencyTrusted(mixed $raw, string $id, string $field): array
+    {
+        if (!\is_array($raw) || !\array_is_list($raw)) {
+            throw new MalformedProjectConfig($field . '.trusted must be a list of patterns');
+        }
+
+        $isComposer = $id === ProviderId::COMPOSER;
+        $out = [];
+        $seen = [];
+        /** @var int $index */
+        foreach ($raw as $index => $value) {
+            if (!\is_string($value) || $value === '') {
+                throw new MalformedProjectConfig(\sprintf(
+                    '%s.trusted[%d] must be a non-empty string',
+                    $field,
+                    $index,
+                ));
+            }
+
+            if ($isComposer) {
+                try {
+                    VendorPattern::fromString($value);
+                } catch (\InvalidArgumentException $e) {
+                    throw new MalformedProjectConfig(\sprintf(
+                        '%s.trusted[%d]: %s',
+                        $field,
+                        $index,
+                        $e->getMessage(),
+                    ));
+                }
+            }
+
+            if (isset($seen[$value])) {
+                throw new MalformedProjectConfig(\sprintf(
+                    '%s.trusted[%d] (%s) duplicates an earlier entry',
+                    $field,
+                    $index,
+                    $value,
+                ));
+            }
+            $seen[$value] = true;
+            $out[] = $value;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fold the parsed per-manager block into the flat runtime fields
+     * {@see ProjectConfig} still exposes: every manager's resolved
+     * `enabled` populates the `local` toggle map, and the `composer`
+     * entry (the only manager with a live provider) drives `trusted` and
+     * `trustedReplace`.
+     *
+     * @param array<non-empty-string, DependencyConfig> $dependencies
+     *
+     * @return array{TrustedVendors, bool, array<non-empty-string, bool>}
+     *
+     * @psalm-mutation-free
+     */
+    private function foldDependencies(array $dependencies): array
+    {
+        $local = [];
+        foreach ($dependencies as $id => $config) {
+            $local[$id] = $config->isEnabled($id);
+        }
+
+        $composer = $dependencies[ProviderId::COMPOSER] ?? null;
+        $trusted = $composer?->trustedVendors() ?? TrustedVendors::empty();
+        $replace = $composer?->trustedReplace ?? false;
+
+        return [$trusted, $replace, $local];
     }
 
     /**

--- a/src/Config/Mapper/ProjectConfigMigrator.php
+++ b/src/Config/Mapper/ProjectConfigMigrator.php
@@ -78,10 +78,13 @@ final readonly class ProjectConfigMigrator
      * Pull the project-level keys out of an inline `extra.skills`
      * block, in canonical order, as they should be written into
      * `skills.json`. Donor `source` and any unrelated keys are
-     * deliberately dropped, and a deprecated `remote` value is folded
-     * into the canonical `sources` key so the written file never
-     * carries the alias. A block with both keys is rejected pre-flight
-     * by the mapper, so at most one of the pair is present here.
+     * deliberately dropped. Two families of deprecated keys are folded
+     * into their canonical replacement so the written file never
+     * carries an alias: a `remote` value becomes `sources`, and the
+     * legacy trust trio (`local`, flat `trusted`, flat
+     * `trusted-replace`) becomes a `dependencies` block. A block that
+     * mixes an alias with its canonical key is rejected pre-flight by
+     * the mapper, so at most one form of each pair is present here.
      *
      * @param array<array-key, mixed> $skills the inline `extra.skills` value
      *
@@ -93,9 +96,23 @@ final readonly class ProjectConfigMigrator
     {
         $out = [];
         foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
-            // The alias never lands in the output under its own name;
-            // its value is picked up when the canonical key is visited.
-            if ($key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY) {
+            // Aliases never land in the output under their own name;
+            // their values are picked up when the canonical key is
+            // visited (`remote` → `sources`, the legacy trust trio →
+            // `dependencies`).
+            if (
+                $key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY
+                || \in_array($key, ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS, true)
+            ) {
+                continue;
+            }
+            if ($key === ProjectConfigMapper::DEPENDENCIES_KEY) {
+                if (\array_key_exists($key, $skills)) {
+                    /** @psalm-suppress MixedAssignment value type intentionally unknown until mapper validates */
+                    $out[$key] = $skills[$key];
+                } elseif (self::hasLegacyDependencyKeys($skills)) {
+                    $out[$key] = self::foldLegacyDependencies($skills);
+                }
                 continue;
             }
             if (\array_key_exists($key, $skills)) {
@@ -113,6 +130,80 @@ final readonly class ProjectConfigMigrator
         }
 
         return $out;
+    }
+
+    /**
+     * Whether the block carries any of the legacy trust keys folded
+     * into `dependencies` (`trusted`, `trusted-replace`, `local`).
+     *
+     * @param array<array-key, mixed> $block a `skills.json` / `extra.skills` block
+     *
+     * @psalm-pure
+     */
+    public static function hasLegacyDependencyKeys(array $block): bool
+    {
+        foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $key) {
+            if (\array_key_exists($key, $block)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fold the legacy trust trio into a `dependencies` block. Starts
+     * from the `local` map verbatim, then upgrades the `composer` entry
+     * to object form when a flat `trusted` / `trusted-replace` value is
+     * present, carrying an explicit `local.composer` bool across as the
+     * object's `enabled`. Only keys the user actually wrote are emitted:
+     * an absent `enabled` or `trusted-replace` is not materialised as
+     * its default.
+     *
+     * Values are copied verbatim, not validated — the mapper enforces
+     * the shape after migration exactly as it would for a hand-written
+     * `dependencies` block.
+     *
+     * @param array<array-key, mixed> $block a `skills.json` / `extra.skills` block
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    public static function foldLegacyDependencies(array $block): array
+    {
+        /** @var mixed $local */
+        $local = $block['local'] ?? null;
+        $hasTrusted = \array_key_exists('trusted', $block);
+        $hasReplace = \array_key_exists('trusted-replace', $block);
+
+        $dependencies = [];
+        if (\is_array($local)) {
+            /** @var mixed $enabled */
+            foreach ($local as $id => $enabled) {
+                /** @psalm-suppress MixedAssignment value copied verbatim; mapper validates */
+                $dependencies[(string) $id] = $enabled;
+            }
+        }
+
+        if ($hasTrusted || $hasReplace) {
+            $composer = [];
+            if (\is_array($local) && \array_key_exists('composer', $local)) {
+                /** @psalm-suppress MixedAssignment */
+                $composer['enabled'] = $local['composer'];
+            }
+            if ($hasTrusted) {
+                /** @psalm-suppress MixedAssignment */
+                $composer['trusted'] = $block['trusted'];
+            }
+            if ($hasReplace) {
+                /** @psalm-suppress MixedAssignment */
+                $composer['trusted-replace'] = $block['trusted-replace'];
+            }
+            $dependencies['composer'] = $composer;
+        }
+
+        return $dependencies;
     }
 
     /**
@@ -357,5 +448,130 @@ final readonly class ProjectConfigMigrator
         ));
 
         return MigrationResult::migrated([ProjectConfigMapper::SOURCES_KEY]);
+    }
+
+    /**
+     * Restructure the legacy trust trio (`local`, flat `trusted`, flat
+     * `trusted-replace`) into a single `dependencies` block in an
+     * existing `skills.json`, in place. Runs next to
+     * {@see self::renameSourcesKey()} on the write-mode entrypoints and
+     * after it, so a fully-legacy file gets both fixes in one run.
+     * Returns:
+     *
+     * - {@see MigrationStatus::Skipped} when there is no `skills.json`,
+     *   when `dependencies` is already present (new form, or an illegal
+     *   mix with legacy keys the mapper will reject — migration must not
+     *   guess which form wins), when no legacy key is present, or when
+     *   `local` is present but not an object (it cannot be transformed
+     *   into a per-manager map without dropping data; the mapper reports
+     *   the shape error on the original file instead). Malformed JSON is
+     *   skipped too, letting {@see ExternalProjectConfigLoader} surface
+     *   the parse error during mapping.
+     * - {@see MigrationStatus::Migrated} after rewriting the file with
+     *   `dependencies` at the slot of the first legacy key, every other
+     *   key and its position preserved and the remaining legacy keys
+     *   dropped.
+     * - {@see MigrationStatus::Failed} when the file exists but a read,
+     *   encode, or write step errored out (message already on `$io`).
+     */
+    public function restructureDependencies(Path $projectRoot, IOInterface $io): MigrationResult
+    {
+        $skillsJsonPath = (string) $projectRoot->join(ExternalProjectConfigLoader::FILE_NAME);
+        if (!\is_file($skillsJsonPath)) {
+            return MigrationResult::skipped();
+        }
+
+        $original = \file_get_contents($skillsJsonPath);
+        if ($original === false) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to read skills.json at %s</error>',
+                $skillsJsonPath,
+            ));
+            return MigrationResult::failed();
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($original, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return MigrationResult::skipped();
+        }
+
+        if (!\is_array($decoded)) {
+            return MigrationResult::skipped();
+        }
+
+        // Already on the canonical key — a new-form file, or an illegal
+        // mix of `dependencies` with a legacy key. Either way, leave it:
+        // the mapper's fatal "both present" check must stand rather than
+        // the migration guessing which trust surface wins.
+        if (\array_key_exists(ProjectConfigMapper::DEPENDENCIES_KEY, $decoded)) {
+            return MigrationResult::skipped();
+        }
+
+        $found = [];
+        foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $key) {
+            if (\array_key_exists($key, $decoded)) {
+                $found[] = $key;
+            }
+        }
+        if ($found === []) {
+            return MigrationResult::skipped();
+        }
+
+        // A non-object `local` cannot fold into a per-manager map
+        // without discarding it; leave the file untouched so the mapper
+        // reports the shape error on the original rather than migration
+        // dropping data.
+        if (\array_key_exists('local', $decoded) && !\is_array($decoded['local'])) {
+            return MigrationResult::skipped();
+        }
+
+        $dependencies = self::foldLegacyDependencies($decoded);
+
+        // Rebuild so `dependencies` takes the slot of the first legacy
+        // key encountered and every sibling key keeps its position; the
+        // remaining legacy keys drop out.
+        $rebuilt = [];
+        $placed = false;
+        /** @var mixed $value */
+        foreach ($decoded as $key => $value) {
+            if (\in_array($key, ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS, true)) {
+                if (!$placed) {
+                    $rebuilt[ProjectConfigMapper::DEPENDENCIES_KEY] = $dependencies;
+                    $placed = true;
+                }
+                continue;
+            }
+            /** @psalm-suppress MixedAssignment value type is validated later by the mapper */
+            $rebuilt[$key] = $value;
+        }
+
+        $json = \json_encode(
+            $rebuilt,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+        );
+        if ($json === false) {
+            $io->writeError('<error>[llm/skills] failed to encode skills.json during dependency restructure</error>');
+            return MigrationResult::failed();
+        }
+
+        try {
+            AtomicFileWriter::write($skillsJsonPath, $json . "\n");
+        } catch (\RuntimeException $e) {
+            $io->writeError(\sprintf(
+                '<error>[llm/skills] failed to write skills.json during dependency restructure: %s</error>',
+                $e->getMessage(),
+            ));
+            return MigrationResult::failed();
+        }
+
+        $io->write(\sprintf(
+            '<info>[migrate]</info> restructured %s into "%s" in skills.json',
+            \implode(', ', \array_map(static fn(string $k): string => '"' . $k . '"', $found)),
+            ProjectConfigMapper::DEPENDENCIES_KEY,
+        ));
+
+        return MigrationResult::migrated([ProjectConfigMapper::DEPENDENCIES_KEY]);
     }
 }

--- a/src/Config/Mapper/ProjectConfigMigrator.php
+++ b/src/Config/Mapper/ProjectConfigMigrator.php
@@ -233,6 +233,43 @@ final readonly class ProjectConfigMigrator
     }
 
     /**
+     * Rename the deprecated `remote` key to `sources` in an in-memory
+     * config map, preserving the renamed key's slot and every sibling
+     * verbatim. When the map already carries `sources` (or carries both
+     * keys, or neither), it is returned untouched — the "both present"
+     * case is the mapper's to reject, not this helper's to silently
+     * merge. This is the pure core the file-level {@see
+     * self::renameSourcesKey()} and the wizard's defaults normaliser both
+     * lean on, so one implementation owns the rename rule.
+     *
+     * @param array<string, mixed> $map
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    public static function renameSourcesInMap(array $map): array
+    {
+        $hasDeprecated = \array_key_exists(ProjectConfigMapper::DEPRECATED_SOURCES_KEY, $map);
+        $hasCanonical = \array_key_exists(ProjectConfigMapper::SOURCES_KEY, $map);
+        if (!$hasDeprecated || $hasCanonical) {
+            return $map;
+        }
+
+        $rebuilt = [];
+        /** @var mixed $value */
+        foreach ($map as $key => $value) {
+            $target = $key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY
+                ? ProjectConfigMapper::SOURCES_KEY
+                : $key;
+            /** @psalm-suppress MixedAssignment value type is validated later by the mapper */
+            $rebuilt[$target] = $value;
+        }
+
+        return $rebuilt;
+    }
+
+    /**
      * Detect-and-migrate. Returns:
      *
      * - {@see MigrationStatus::Skipped} when `skills.json` already
@@ -412,15 +449,8 @@ final readonly class ProjectConfigMigrator
 
         // Rebuild the map so the renamed key keeps its original slot and
         // every sibling key stays verbatim.
-        $rebuilt = [];
-        /** @var mixed $value */
-        foreach ($decoded as $key => $value) {
-            $target = $key === ProjectConfigMapper::DEPRECATED_SOURCES_KEY
-                ? ProjectConfigMapper::SOURCES_KEY
-                : $key;
-            /** @psalm-suppress MixedAssignment value type is validated later by the mapper */
-            $rebuilt[$target] = $value;
-        }
+        /** @var array<string, mixed> $decoded */
+        $rebuilt = self::renameSourcesInMap($decoded);
 
         $json = \json_encode(
             $rebuilt,

--- a/src/Config/NpmPattern.php
+++ b/src/Config/NpmPattern.php
@@ -46,7 +46,11 @@ final readonly class NpmPattern implements TrustPattern
      * @param non-empty-string $pattern
      *
      * @throws \InvalidArgumentException when the pattern is not a bare name,
-     *         a `@scope/pkg`, or a `@scope/*` wildcard.
+     *         a `@scope/pkg`, or a `@scope/*` wildcard. The `*` wildcard is
+     *         only ever valid as the whole package segment of a scoped
+     *         pattern; a `*` anywhere else — in an unscoped name, in the
+     *         scope segment, or embedded in a package segment — is rejected,
+     *         since a real npm name never contains one.
      *
      * @psalm-pure
      */
@@ -67,11 +71,37 @@ final readonly class NpmPattern implements TrustPattern
                 ));
             }
 
-            /** @var non-empty-string $scope the `@` guarantees a non-empty segment */
             $scope = \substr($pattern, 0, $slash);
-            /** @var non-empty-string $package */
             $package = \substr($pattern, $slash + 1);
 
+            // `@/pkg` carries a bare `@` with no scope name behind it.
+            if ($scope === '@') {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid npm pattern "%s": the scope segment after "@" must not be empty.',
+                    $pattern,
+                ));
+            }
+            // Only the package segment may be a wildcard; a `*` in the scope
+            // segment never matches a real npm name.
+            if (\str_contains($scope, '*')) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid npm pattern "%s": the scope segment cannot contain "*".',
+                    $pattern,
+                ));
+            }
+            // The package segment is either the whole wildcard (`*`) or a
+            // literal name; a `*` embedded in a name (`*foo`) matches nothing.
+            if ($package !== '*' && \str_contains($package, '*')) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid npm pattern "%s": the package segment must be "*" or contain no "*".',
+                    $pattern,
+                ));
+            }
+
+            /**
+             * @var non-empty-string $scope the `@` plus a non-empty name
+             * @var non-empty-string $package
+             */
             return new self(
                 raw: $pattern,
                 scope: $scope,
@@ -79,8 +109,9 @@ final readonly class NpmPattern implements TrustPattern
             );
         }
 
-        // Unscoped names are bare identifiers: no slash, no wildcard. A bare
-        // `*` would trust the whole registry and is never a valid npm name.
+        // Unscoped names are bare identifiers: no slash, no wildcard. Only a
+        // scope may carry a wildcard, and an unscoped npm name never contains
+        // a slash.
         if (\str_contains($pattern, '/')) {
             throw new \InvalidArgumentException(\sprintf(
                 'Invalid npm pattern "%s": an unscoped package name cannot contain "/".',
@@ -91,6 +122,14 @@ final readonly class NpmPattern implements TrustPattern
             throw new \InvalidArgumentException(
                 'Invalid npm pattern "*": a bare wildcard is not allowed; scope it as "@scope/*".',
             );
+        }
+        // Any other `*` in an unscoped name matches nothing — the wildcard
+        // belongs to a scope (`@scope/*`), never to a bare name.
+        if (\str_contains($pattern, '*')) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Invalid npm pattern "%s": an unscoped package name cannot contain "*"; scope it as "@scope/*".',
+                $pattern,
+            ));
         }
 
         return new self(raw: $pattern, scope: null, package: $pattern);

--- a/src/Config/NpmPattern.php
+++ b/src/Config/NpmPattern.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+/**
+ * A trust pattern that matches npm package names.
+ *
+ * Three shapes, mirroring how the npm registry names packages:
+ * - `lodash`      — a bare, unscoped package: exact name match.
+ * - `@scope/pkg`  — a scoped package: exact name match.
+ * - `@scope/*`    — every package published under `@scope`.
+ *
+ * Matching is literal and case-sensitive. The npm registry lower-cases
+ * package names on publish, so a case-insensitive fold would buy nothing and
+ * only blur the comparison; keeping it byte-for-byte matches how names appear
+ * in a lockfile.
+ *
+ * Bare wildcards (`*`) and unscoped names containing a slash are rejected:
+ * only a scope may carry a wildcard, and an unscoped npm name never contains
+ * a slash.
+ *
+ * @psalm-immutable
+ */
+final readonly class NpmPattern implements TrustPattern
+{
+    /**
+     * @param non-empty-string $raw    original textual pattern, kept for diagnostics
+     * @param non-empty-string|null $scope
+     *        the `@scope` segment (leading `@` included) for a scoped pattern;
+     *        `null` for a bare, unscoped package
+     * @param non-empty-string|null $package
+     *        the package segment; `null` means the scope wildcard (`@scope/*`).
+     *        For a bare pattern this holds the whole unscoped name.
+     *
+     * @psalm-mutation-free
+     */
+    private function __construct(
+        public string $raw,
+        public ?string $scope,
+        public ?string $package,
+    ) {}
+
+    /**
+     * @param non-empty-string $pattern
+     *
+     * @throws \InvalidArgumentException when the pattern is not a bare name,
+     *         a `@scope/pkg`, or a `@scope/*` wildcard.
+     *
+     * @psalm-pure
+     */
+    public static function fromString(string $pattern): self
+    {
+        if (\str_starts_with($pattern, '@')) {
+            $slash = \strpos($pattern, '/');
+            if ($slash === false || $slash === \strlen($pattern) - 1) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid npm pattern "%s": a scoped pattern needs "@scope/pkg" or "@scope/*".',
+                    $pattern,
+                ));
+            }
+            if (\strpos($pattern, '/', $slash + 1) !== false) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid npm pattern "%s": expected exactly one "/" after the scope.',
+                    $pattern,
+                ));
+            }
+
+            /** @var non-empty-string $scope the `@` guarantees a non-empty segment */
+            $scope = \substr($pattern, 0, $slash);
+            /** @var non-empty-string $package */
+            $package = \substr($pattern, $slash + 1);
+
+            return new self(
+                raw: $pattern,
+                scope: $scope,
+                package: $package === '*' ? null : $package,
+            );
+        }
+
+        // Unscoped names are bare identifiers: no slash, no wildcard. A bare
+        // `*` would trust the whole registry and is never a valid npm name.
+        if (\str_contains($pattern, '/')) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Invalid npm pattern "%s": an unscoped package name cannot contain "/".',
+                $pattern,
+            ));
+        }
+        if ($pattern === '*') {
+            throw new \InvalidArgumentException(
+                'Invalid npm pattern "*": a bare wildcard is not allowed; scope it as "@scope/*".',
+            );
+        }
+
+        return new self(raw: $pattern, scope: null, package: $pattern);
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function raw(): string
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @param non-empty-string $packageName  npm package name (`lodash` or `@scope/pkg`)
+     *
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function matches(string $packageName): bool
+    {
+        if ($this->scope === null) {
+            return $packageName === $this->package;
+        }
+
+        if ($this->package === null) {
+            return \str_starts_with($packageName, $this->scope . '/');
+        }
+
+        return $packageName === $this->scope . '/' . $this->package;
+    }
+}

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -56,6 +56,12 @@ final readonly class ProjectConfig
      * @param list<SourceEntry> $sources donor sources declared by the project. The remote
      *         provider treats each entry as an explicit fetch target. Empty list means
      *         the remote provider stays inactive — symmetric with `local.composer == false`.
+     * @param array<non-empty-string, DependencyConfig> $dependencies full per-manager
+     *         `dependencies` block, keyed by package-manager id. Populated only from the
+     *         `dependencies` config key; the `trusted`, `trustedReplace` and `local` fields
+     *         above are folded out of it so downstream stages keep reading the flat model
+     *         until the per-manager providers land. Empty when the block is absent (legacy
+     *         `trusted` / `local` forms leave it empty and feed the flat fields directly).
      *
      * @psalm-mutation-free
      */
@@ -69,6 +75,7 @@ final readonly class ProjectConfig
         public ?string $pathFromRoot = null,
         public array $local = [],
         public array $sources = [],
+        public array $dependencies = [],
     ) {}
 
     /**
@@ -89,6 +96,7 @@ final readonly class ProjectConfig
             pathFromRoot: null,
             local: [],
             sources: [],
+            dependencies: [],
         );
     }
 
@@ -126,6 +134,7 @@ final readonly class ProjectConfig
             $this->pathFromRoot,
             $this->local,
             $this->sources,
+            $this->dependencies,
         );
     }
 
@@ -146,6 +155,7 @@ final readonly class ProjectConfig
             $this->pathFromRoot,
             $this->local,
             $this->sources,
+            $this->dependencies,
         );
     }
 }

--- a/src/Config/ProjectConfigResolution.php
+++ b/src/Config/ProjectConfigResolution.php
@@ -26,6 +26,11 @@ final readonly class ProjectConfigResolution
      *        its donor sources under the deprecated `remote` key instead of `sources`.
      *        Callers surface a deprecation notice; write-mode callers migrate the file
      *        before mapping, so they never observe it set.
+     * @param list<non-empty-string> $usedDeprecatedDependencyKeys legacy dependency keys
+     *        (`trusted`, `trusted-replace`, `local`) the winning block used instead of the
+     *        `dependencies` key. Empty when the block used `dependencies` or declared no
+     *        dependency config. Callers surface a deprecation notice naming these keys;
+     *        write-mode callers migrate the file before mapping, so they never observe it set.
      *
      * @psalm-mutation-free
      */
@@ -33,5 +38,6 @@ final readonly class ProjectConfigResolution
         public ProjectConfig $config,
         public array $ignoredInlineKeys = [],
         public bool $usedDeprecatedSourcesKey = false,
+        public array $usedDeprecatedDependencyKeys = [],
     ) {}
 }

--- a/src/Config/SyncOptions.php
+++ b/src/Config/SyncOptions.php
@@ -33,7 +33,7 @@ final readonly class SyncOptions
      *         must not rewrite the user's `composer.json` mid-install.
      * @param non-empty-string|null $fromFilter `--from=<id>` scope. When set,
      *         the runner keeps only donors whose {@see VendorConfig::$provenance} matches
-     *         this id. The vocabulary is shared with `skills.json` `local.{id}` and
+     *         this id. The vocabulary is shared with `skills.json` `dependencies.{id}` and
      *         `sources[].from`.
      *
      * @psalm-mutation-free

--- a/src/Config/TrustPattern.php
+++ b/src/Config/TrustPattern.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config;
+
+/**
+ * A single trust pattern for one package-manager ecosystem.
+ *
+ * Each ecosystem names packages differently, so trust patterns cannot share
+ * one grammar. Composer names are `vendor/package` ({@see VendorPattern}),
+ * npm packages are bare or `@scope/pkg` ({@see NpmPattern}), and Go modules
+ * are slash-separated import paths ({@see GoPattern}). A {@see TrustedVendors}
+ * set holds patterns of one ecosystem behind this interface so membership
+ * checks stay uniform while each implementation keeps its own grammar and
+ * matching semantics.
+ *
+ * @psalm-immutable
+ */
+interface TrustPattern
+{
+    /**
+     * Whether `$packageName` is trusted by this pattern. The name is an
+     * ecosystem-native package identifier (Composer `vendor/pkg`, npm
+     * `@scope/pkg` or bare, Go module path); each implementation compares it
+     * against its own grammar.
+     *
+     * @param non-empty-string $packageName
+     *
+     * @psalm-mutation-free
+     */
+    public function matches(string $packageName): bool;
+
+    /**
+     * The original textual pattern, kept verbatim for diagnostics.
+     *
+     * @return non-empty-string
+     *
+     * @psalm-mutation-free
+     */
+    public function raw(): string;
+}

--- a/src/Config/TrustedVendorRegistry.php
+++ b/src/Config/TrustedVendorRegistry.php
@@ -10,13 +10,15 @@ use LLM\Skills\Info;
 /**
  * Loader for the per-provider built-in trust files.
  *
- * Each provider that supports transitive donor discovery (today only
- * Composer; later npm, go) ships an opinionated list of trusted
- * vendor patterns under `resources/trusted-<providerId>.txt`. The
- * registry picks the right file by id, parses it into a
- * {@see TrustedVendors}, and falls back to an empty list when the
- * file does not exist — keeping a future provider opt-in until its
- * own trust file ships.
+ * Each provider that supports transitive donor discovery (Composer,
+ * npm, go) ships an opinionated list of trusted vendor patterns under
+ * `resources/trusted-<providerId>.txt`. The registry picks the right
+ * file by id, parses each line through that ecosystem's grammar
+ * ({@see VendorPattern} for composer, {@see NpmPattern} for npm,
+ * {@see GoPattern} for go) into a {@see TrustedVendors}, and falls
+ * back to an empty list when the id is unregistered or the file is
+ * missing — keeping a future provider opt-in until its own trust file
+ * ships.
  *
  * The trust files apply only to **local-provider transitive
  * discoveries**. Direct deps are implicit-trusted because the user
@@ -38,16 +40,20 @@ final readonly class TrustedVendorRegistry
      */
     private const FILE_BY_PROVIDER = [
         ProviderId::COMPOSER => 'trusted-composer.txt',
+        ProviderId::NPM => 'trusted-npm.txt',
+        ProviderId::GO => 'trusted-go.txt',
     ];
 
     /**
      * Load the built-in trust list for `$providerId`. Returns
      * {@see TrustedVendors::empty()} when:
      *
-     * - the provider id is not registered (e.g. `npm` until its file ships),
+     * - the provider id is not registered (e.g. `github`, which has no
+     *   built-in trust list),
      * - the registered file is missing on disk.
      *
-     * Throws only when the file exists but cannot be read.
+     * Throws only when the file exists but cannot be read, or when a
+     * line violates the provider's pattern grammar.
      *
      * @param non-empty-string $providerId
      *
@@ -79,9 +85,32 @@ final readonly class TrustedVendorRegistry
             if ($line === '' || \str_starts_with($line, '#')) {
                 continue;
             }
-            $patterns[] = $line;
+            $patterns[] = self::parse($providerId, $line);
         }
 
-        return TrustedVendors::fromStrings(...$patterns);
+        return new TrustedVendors($patterns);
+    }
+
+    /**
+     * Parse one non-empty, non-comment line through the grammar of the
+     * given provider. The set of ids handled here mirrors
+     * {@see self::FILE_BY_PROVIDER}: only registered providers ever
+     * reach parsing.
+     *
+     * @param non-empty-string $providerId
+     * @param non-empty-string $line
+     *
+     * @psalm-pure
+     */
+    private static function parse(string $providerId, string $line): TrustPattern
+    {
+        return match ($providerId) {
+            ProviderId::COMPOSER => VendorPattern::fromString($line),
+            ProviderId::NPM => NpmPattern::fromString($line),
+            ProviderId::GO => GoPattern::fromString($line),
+            default => throw new \RuntimeException(
+                'No trust-pattern grammar registered for provider "' . $providerId . '"',
+            ),
+        };
     }
 }

--- a/src/Config/TrustedVendors.php
+++ b/src/Config/TrustedVendors.php
@@ -21,7 +21,7 @@ namespace LLM\Skills\Config;
 final readonly class TrustedVendors
 {
     /**
-     * @param list<VendorPattern> $patterns
+     * @param list<TrustPattern> $patterns
      *
      * @psalm-mutation-free
      */
@@ -38,8 +38,11 @@ final readonly class TrustedVendors
     }
 
     /**
-     * Build from raw pattern strings. Useful for loading the built-in list and
-     * for short-hand construction in tests. Robust to named-argument calls —
+     * Build from raw Composer pattern strings, parsed through
+     * {@see VendorPattern}. Useful for the composer built-in list and for
+     * short-hand construction in tests. Other ecosystems (npm, go) build their
+     * sets from {@see NpmPattern} / {@see GoPattern} directly rather than
+     * through this composer-grammar helper. Robust to named-argument calls —
      * the foreach preserves order and rebuilds a list regardless of the input
      * array's keys.
      *

--- a/src/Config/VendorPattern.php
+++ b/src/Config/VendorPattern.php
@@ -16,7 +16,7 @@ namespace LLM\Skills\Config;
  *
  * @psalm-immutable
  */
-final readonly class VendorPattern
+final readonly class VendorPattern implements TrustPattern
 {
     /**
      * @param non-empty-string $raw      original textual pattern, kept for diagnostics
@@ -76,10 +76,20 @@ final readonly class VendorPattern
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function raw(): string
+    {
+        return $this->raw;
+    }
+
+    /**
      * @param non-empty-string $packageName  full Composer package name (`vendor/package`)
      *
      * @psalm-mutation-free
      */
+    #[\Override]
     public function matches(string $packageName): bool
     {
         $slash = \strpos($packageName, '/');

--- a/src/Console/SyncCliDefinition.php
+++ b/src/Console/SyncCliDefinition.php
@@ -91,8 +91,8 @@ final class SyncCliDefinition
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Scope the sync to donors from a single provider. The id matches '
-                . 'skills.json local.{id} keys (e.g. "composer") and sources[].from values '
-                . '(e.g. "github"). Without this flag, all active providers contribute.',
+                . 'skills.json dependencies.{id} keys (e.g. "composer") and sources[].from '
+                . 'values (e.g. "github"). Without this flag, all active providers contribute.',
             );
     }
 

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -210,14 +210,18 @@ final readonly class InitRunner
         $defaults = [];
 
         // Existing skills.json (only under --force; the early refusal
-        // check would have failed otherwise).
+        // check would have failed otherwise). The file is read raw —
+        // deliberately without running the file migrators — so the
+        // wizard can present the current values as prompt defaults;
+        // {@see self::foldLegacyDefaults()} normalises the legacy trust
+        // keys the wizard no longer reads directly.
         if (\is_file($target)) {
             $existing = $this->readJsonObject($target, $io, 'skills.json');
             if ($existing === null) {
                 return Command::FAILURE;
             }
             unset($existing['$schema']);
-            $defaults = $existing;
+            $defaults = $this->foldLegacyDefaults($existing);
         }
 
         $inlineKeys = [];
@@ -283,6 +287,46 @@ final readonly class InitRunner
         $io->write('<info>[init]</info> done.');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Normalise a raw `skills.json` map into the shape the wizard reads
+     * its defaults from. The wizard reads trust only from
+     * `dependencies.composer`, so a legacy file carrying the flat
+     * `trusted` / `trusted-replace` / `local` trio would otherwise
+     * present empty trust defaults and silently drop the user's config
+     * when they accept the prompts. Folding here — through the same
+     * {@see ProjectConfigMigrator} helpers the file migrators use —
+     * keeps a single owner for the legacy-trust rule.
+     *
+     * A map already carrying `dependencies` is left untouched: mixing it
+     * with a legacy key is the mapper's to reject on write, not this
+     * normaliser's to silently merge. The deprecated `remote` → `sources`
+     * pair needs no analogue here — the wizard prompts for neither
+     * `sources` nor `remote`, so those keys never feed a wizard default.
+     *
+     * @param array<string, mixed> $defaults
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    private function foldLegacyDefaults(array $defaults): array
+    {
+        if (
+            \array_key_exists(ProjectConfigMapper::DEPENDENCIES_KEY, $defaults)
+            || !ProjectConfigMigrator::hasLegacyDependencyKeys($defaults)
+        ) {
+            return $defaults;
+        }
+
+        $folded = ProjectConfigMigrator::foldLegacyDependencies($defaults);
+        foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $key) {
+            unset($defaults[$key]);
+        }
+        $defaults[ProjectConfigMapper::DEPENDENCIES_KEY] = $folded;
+
+        return $defaults;
     }
 
     /**

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -140,6 +140,10 @@ final readonly class InitRunner
             return Command::FAILURE;
         }
 
+        if ($this->migrator->restructureDependencies($projectRoot, $io)->status === MigrationStatus::Failed) {
+            return Command::FAILURE;
+        }
+
         $result = $this->migrator->migrate($projectRoot, $io);
 
         switch ($result->status) {
@@ -428,6 +432,10 @@ final readonly class InitRunner
             return Command::FAILURE;
         }
 
+        if ($this->migrator->restructureDependencies($projectRoot, $io)->status === MigrationStatus::Failed) {
+            return Command::FAILURE;
+        }
+
         $result = $this->migrator->migrate($projectRoot, $io);
 
         if ($result->status === MigrationStatus::Failed) {
@@ -508,13 +516,13 @@ final readonly class InitRunner
             return false;
         }
 
-        // Stub `skills.json` ships with the `local` and `sources`
+        // Stub `skills.json` ships with the `dependencies` and `sources`
         // knobs visible so users discover them without reading docs.
-        // `local.composer: true` is also the default, but we emit it
-        // explicitly — hiding it would make the npm / go toggles seem
+        // `dependencies.composer: true` is also the default, but we emit
+        // it explicitly — hiding it would make the npm / go toggles seem
         // surprise-feature-y when they arrive.
         $content = ProjectConfigMigrator::renderSkillsJson([
-            'local' => ['composer' => true],
+            'dependencies' => ['composer' => true],
             'sources' => [],
         ]);
         if (\file_put_contents($target, $content) === false) {

--- a/src/Init/InitRunner.php
+++ b/src/Init/InitRunner.php
@@ -291,19 +291,25 @@ final readonly class InitRunner
 
     /**
      * Normalise a raw `skills.json` map into the shape the wizard reads
-     * its defaults from. The wizard reads trust only from
-     * `dependencies.composer`, so a legacy file carrying the flat
-     * `trusted` / `trusted-replace` / `local` trio would otherwise
-     * present empty trust defaults and silently drop the user's config
-     * when they accept the prompts. Folding here — through the same
-     * {@see ProjectConfigMigrator} helpers the file migrators use —
-     * keeps a single owner for the legacy-trust rule.
+     * its defaults from — and, since the wizard now preserves the keys it
+     * does not prompt for, the shape those preserved keys should be
+     * written back under.
      *
-     * A map already carrying `dependencies` is left untouched: mixing it
-     * with a legacy key is the mapper's to reject on write, not this
-     * normaliser's to silently merge. The deprecated `remote` → `sources`
-     * pair needs no analogue here — the wizard prompts for neither
-     * `sources` nor `remote`, so those keys never feed a wizard default.
+     * Three legacy shapes are canonicalised here, all through the same
+     * {@see ProjectConfigMigrator} helpers the file migrators use so a
+     * single implementation owns each rule:
+     *
+     * - the flat trust trio (`trusted` / `trusted-replace` / `local`)
+     *   folds into `dependencies`, so the wizard reads trust from
+     *   `dependencies.composer` and a preserved block is never re-emitted
+     *   under a legacy key. A map already carrying `dependencies` is left
+     *   untouched: mixing it with a legacy key is the mapper's to reject
+     *   on write, not this normaliser's to silently merge;
+     * - the deprecated `remote` key is renamed to `sources`, so a
+     *   preserved donor list lands under its canonical name rather than
+     *   surviving verbatim;
+     * - `$schema` is dropped — the renderer re-adds it, and a preserved
+     *   copy would duplicate it.
      *
      * @param array<string, mixed> $defaults
      *
@@ -313,20 +319,22 @@ final readonly class InitRunner
      */
     private function foldLegacyDefaults(array $defaults): array
     {
+        // The renderer re-adds `$schema`; drop it so it never leaks into a
+        // preserved key.
+        unset($defaults['$schema']);
+
         if (
-            \array_key_exists(ProjectConfigMapper::DEPENDENCIES_KEY, $defaults)
-            || !ProjectConfigMigrator::hasLegacyDependencyKeys($defaults)
+            !\array_key_exists(ProjectConfigMapper::DEPENDENCIES_KEY, $defaults)
+            && ProjectConfigMigrator::hasLegacyDependencyKeys($defaults)
         ) {
-            return $defaults;
+            $folded = ProjectConfigMigrator::foldLegacyDependencies($defaults);
+            foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $key) {
+                unset($defaults[$key]);
+            }
+            $defaults[ProjectConfigMapper::DEPENDENCIES_KEY] = $folded;
         }
 
-        $folded = ProjectConfigMigrator::foldLegacyDependencies($defaults);
-        foreach (ProjectConfigMapper::DEPRECATED_DEPENDENCY_KEYS as $key) {
-            unset($defaults[$key]);
-        }
-        $defaults[ProjectConfigMapper::DEPENDENCIES_KEY] = $folded;
-
-        return $defaults;
+        return ProjectConfigMigrator::renameSourcesInMap($defaults);
     }
 
     /**

--- a/src/Init/InteractiveInitWizard.php
+++ b/src/Init/InteractiveInitWizard.php
@@ -89,11 +89,20 @@ final readonly class InteractiveInitWizard
         if ($aliases !== []) {
             $result['aliases'] = $aliases;
         }
+        // Trust answers land under `dependencies.composer` — the flat
+        // `trusted` / `trusted-replace` keys are deprecated aliases the
+        // wizard no longer emits. Only non-default fields are written:
+        // `enabled` (composer defaults to on) and an unchecked
+        // `trusted-replace` are omitted.
+        $composer = [];
         if ($trusted !== []) {
-            $result['trusted'] = $trusted;
+            $composer['trusted'] = $trusted;
         }
         if ($trustedReplace) {
-            $result['trusted-replace'] = true;
+            $composer['trusted-replace'] = true;
+        }
+        if ($composer !== []) {
+            $result['dependencies'] = ['composer' => $composer];
         }
         if ($discovery) {
             $result['discovery'] = true;
@@ -112,6 +121,34 @@ final readonly class InteractiveInitWizard
         }
 
         return $result;
+    }
+
+    /**
+     * The `composer` entry of a `dependencies` defaults block, as an
+     * object. Defaults reach the wizard from a migrated `skills.json`
+     * (or a folded inline block), both of which carry trust under
+     * `dependencies.composer` rather than the flat legacy keys. A short
+     * `"composer": true` toggle carries no trust fields, so it maps to
+     * an empty object here.
+     *
+     * @param array<string, mixed> $defaults
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    private static function composerDependencyDefault(array $defaults): array
+    {
+        /** @var mixed $dependencies */
+        $dependencies = $defaults['dependencies'] ?? null;
+        if (!\is_array($dependencies)) {
+            return [];
+        }
+        /** @var mixed $composer */
+        $composer = $dependencies['composer'] ?? null;
+
+        /** @var array<string, mixed> */
+        return \is_array($composer) ? $composer : [];
     }
 
     /**
@@ -305,7 +342,7 @@ final readonly class InteractiveInitWizard
     {
         $current = [];
         /** @var mixed $rawTrusted */
-        $rawTrusted = $defaults['trusted'] ?? null;
+        $rawTrusted = self::composerDependencyDefault($defaults)['trusted'] ?? null;
         if (\is_array($rawTrusted)) {
             /** @var mixed $value */
             foreach ($rawTrusted as $value) {
@@ -364,7 +401,7 @@ final readonly class InteractiveInitWizard
      */
     private function askTrustedReplace(IOInterface $io, array $defaults): bool
     {
-        $default = (bool) ($defaults['trusted-replace'] ?? false);
+        $default = (bool) (self::composerDependencyDefault($defaults)['trusted-replace'] ?? false);
 
         $io->write('<info>4/6  trusted-replace</info> — when <comment>true</comment>, the project trust');
         $io->write('     list <comment>replaces</comment> both the built-in trusted vendors and the');

--- a/src/Init/InteractiveInitWizard.php
+++ b/src/Init/InteractiveInitWizard.php
@@ -78,40 +78,51 @@ final readonly class InteractiveInitWizard
         $discovery = $this->askDiscovery($io, $defaults);
         $autoSync = $this->askAutoSync($io, $defaults);
 
-        $result = [];
-        // Order matches ProjectConfigMapper::PROJECT_KEYS so generated
-        // skills.json files are diff-stable. We compare against the
-        // canonical default rather than the literal string so this
-        // wizard tracks any future change to DEFAULT_TARGET in one place.
+        // Seed from the (already normalised) defaults so every key the
+        // wizard does NOT prompt for — `sources`, `path-from-root`, other
+        // managers' `dependencies` entries, `dependencies.composer.enabled`
+        // — survives a `--force` rewrite verbatim. The prompted answers
+        // below override only the keys the wizard owns.
+        $result = $defaults;
+
+        // Prompted keys are compared against their canonical default: an
+        // answer equal to the default stays un-emitted (dropping any seeded
+        // copy), tracking DEFAULT_TARGET in one place. A non-default answer
+        // overrides the seed.
         if ($target !== ProjectConfig::DEFAULT_TARGET) {
             $result['target'] = $target;
+        } else {
+            unset($result['target']);
         }
         if ($aliases !== []) {
             $result['aliases'] = $aliases;
+        } else {
+            unset($result['aliases']);
         }
-        // Trust answers land under `dependencies.composer` — the flat
-        // `trusted` / `trusted-replace` keys are deprecated aliases the
-        // wizard no longer emits. Only non-default fields are written:
-        // `enabled` (composer defaults to on) and an unchecked
-        // `trusted-replace` are omitted.
-        $composer = [];
-        if ($trusted !== []) {
-            $composer['trusted'] = $trusted;
-        }
-        if ($trustedReplace) {
-            $composer['trusted-replace'] = true;
-        }
-        if ($composer !== []) {
-            $result['dependencies'] = ['composer' => $composer];
-        }
+
+        // Trust answers land under `dependencies.composer`; the wizard owns
+        // only `trusted` / `trusted-replace` there. `enabled` and sibling
+        // manager entries (`npm`, `go`) are preserved by merging at the
+        // composer-object / dependencies-map level rather than rebuilding
+        // from scratch.
+        $this->applyComposerTrust($result, $trusted, $trustedReplace);
+
         if ($discovery) {
             $result['discovery'] = true;
+        } else {
+            unset($result['discovery']);
         }
-        // auto-sync's default is `true`; only emit the key when the
-        // user opted out, otherwise let the default carry it.
+        // auto-sync's default is `true`; only emit the key when the user
+        // opted out, otherwise let the default carry it.
         if (!$autoSync) {
             $result['auto-sync'] = false;
+        } else {
+            unset($result['auto-sync']);
         }
+
+        // Emit in PROJECT_KEYS order so generated skills.json files are
+        // diff-stable regardless of the seeded defaults' key order.
+        $result = $this->orderProjectKeys($result);
 
         $this->renderSummary($io, $result);
 
@@ -149,6 +160,42 @@ final readonly class InteractiveInitWizard
 
         /** @var array<string, mixed> */
         return \is_array($composer) ? $composer : [];
+    }
+
+    /**
+     * Build the `dependencies.composer` entry from the inherited default
+     * and the wizard-owned trust knobs, in canonical field order
+     * (`enabled`, `trusted`, `trusted-replace`). Composer defaults to
+     * enabled, so only an explicit `enabled: false` is carried across; a
+     * `true` or absent flag is the default and stays unwritten. Returns
+     * `null` when the entry would hold nothing.
+     *
+     * @param list<non-empty-string> $trusted
+     *
+     * @return array<string, mixed>|null
+     *
+     * @psalm-pure
+     */
+    private static function mergeComposerTrust(mixed $default, array $trusted, bool $trustedReplace): ?array
+    {
+        // A bare bool toggle carries only `enabled`; an object carries it
+        // under the `enabled` field. Either way, only `false` is meaningful
+        // to preserve — it flips composer off its enabled-by-default state.
+        /** @var mixed $rawEnabled */
+        $rawEnabled = \is_array($default) ? ($default['enabled'] ?? null) : $default;
+
+        $composer = [];
+        if ($rawEnabled === false) {
+            $composer['enabled'] = false;
+        }
+        if ($trusted !== []) {
+            $composer['trusted'] = $trusted;
+        }
+        if ($trustedReplace) {
+            $composer['trusted-replace'] = true;
+        }
+
+        return $composer === [] ? null : $composer;
     }
 
     /**
@@ -229,6 +276,65 @@ final readonly class InteractiveInitWizard
             // Anything else: literal path
             /** @var non-empty-string $token */
             $out[] = $token;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Overlay the wizard-owned `trusted` / `trusted-replace` knobs onto the
+     * seeded `dependencies.composer` entry, writing the merged map back into
+     * `$result`. Sibling manager entries (`npm`, `go`) and composer's own
+     * `enabled` flag survive because the merge happens at the composer-object
+     * / dependencies-map level rather than rebuilding from the prompts alone.
+     * An emptied composer entry, and an emptied `dependencies` block, are
+     * dropped — the only content that can empty them is the wizard-owned
+     * trust the user just cleared.
+     *
+     * @param array<string, mixed> $result
+     * @param list<non-empty-string> $trusted
+     */
+    private function applyComposerTrust(array &$result, array $trusted, bool $trustedReplace): void
+    {
+        /** @var array<string, mixed> $dependencies */
+        $dependencies = \is_array($result[ProjectConfigMapper::DEPENDENCIES_KEY] ?? null)
+            ? $result[ProjectConfigMapper::DEPENDENCIES_KEY]
+            : [];
+        /** @var mixed $composerDefault */
+        $composerDefault = $dependencies['composer'] ?? null;
+
+        $composer = self::mergeComposerTrust($composerDefault, $trusted, $trustedReplace);
+        if ($composer === null) {
+            unset($dependencies['composer']);
+        } else {
+            $dependencies['composer'] = $composer;
+        }
+
+        if ($dependencies === []) {
+            unset($result[ProjectConfigMapper::DEPENDENCIES_KEY]);
+        } else {
+            $result[ProjectConfigMapper::DEPENDENCIES_KEY] = $dependencies;
+        }
+    }
+
+    /**
+     * Re-order a project-keys map to {@see ProjectConfigMapper::PROJECT_KEYS}
+     * order for diff-stable output; keys outside that list are dropped.
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    private function orderProjectKeys(array $values): array
+    {
+        $out = [];
+        foreach (ProjectConfigMapper::PROJECT_KEYS as $key) {
+            if (\array_key_exists($key, $values)) {
+                /** @psalm-suppress MixedAssignment */
+                $out[$key] = $values[$key];
+            }
         }
 
         return $out;

--- a/src/Show/ShowRunner.php
+++ b/src/Show/ShowRunner.php
@@ -73,6 +73,20 @@ final readonly class ShowRunner
             );
         }
 
+        // Same read-only surface for the legacy trust trio folded into
+        // `dependencies`: warn at normal verbosity and point the user at
+        // the command that migrates the file.
+        if ($resolution->usedDeprecatedDependencyKeys !== []) {
+            $io->writeError(\sprintf(
+                '<comment>[deprecated] config keys %s were replaced by "dependencies"; '
+                . 'skills:update migrates the file automatically</comment>',
+                \implode(', ', \array_map(
+                    static fn(string $k): string => '"' . $k . '"',
+                    $resolution->usedDeprecatedDependencyKeys,
+                )),
+            ));
+        }
+
         // See SyncRunner: notice is provider-neutral, specifics flow
         // through `-v` warnings emitted at the entrypoint.
         if (!$provider->isActive($projectRoot)) {

--- a/src/Sync/SyncRunner.php
+++ b/src/Sync/SyncRunner.php
@@ -104,6 +104,14 @@ final readonly class SyncRunner
                 return Command::FAILURE;
             }
 
+            // Fold the legacy trust trio into a `dependencies` block in
+            // an existing skills.json, after the sources rename so a
+            // fully-legacy file gets both fixes in one write-mode run.
+            $restructure = $this->migrator->restructureDependencies($projectRoot, $io);
+            if ($restructure->status === MigrationStatus::Failed) {
+                return Command::FAILURE;
+            }
+
             $migration = $this->migrator->migrate($projectRoot, $io);
             if ($migration->status === MigrationStatus::Failed) {
                 return Command::FAILURE;
@@ -131,6 +139,7 @@ final readonly class SyncRunner
         $project = $configResolution->config;
         $this->emitShadowedKeysWarning($io, $configResolution->ignoredInlineKeys);
         $this->emitDeprecatedSourcesKeyNotice($io, $configResolution->usedDeprecatedSourcesKey);
+        $this->emitDeprecatedDependencyKeysNotice($io, $configResolution->usedDeprecatedDependencyKeys);
 
         // No donor provider can contribute. Reasons vary by provider —
         // {@see \LLM\Skills\Discovery\Provider\ComposerProvider} is
@@ -466,6 +475,28 @@ final readonly class SyncRunner
             '<comment>[deprecated] config key "remote" was renamed to "sources"; '
             . 'skills:update migrates the file automatically</comment>',
         );
+    }
+
+    /**
+     * The winning config block declared trust and donor toggles under
+     * the legacy `trusted` / `trusted-replace` / `local` keys instead of
+     * the `dependencies` block. Surface a notice at normal verbosity;
+     * write mode restructures the file first, so this fires only when
+     * migration was suppressed (the `post-install-cmd` auto-sync hook).
+     *
+     * @param list<non-empty-string> $used legacy keys the block relied on
+     */
+    private function emitDeprecatedDependencyKeysNotice(IOInterface $io, array $used): void
+    {
+        if ($used === []) {
+            return;
+        }
+
+        $io->writeError(\sprintf(
+            '<comment>[deprecated] config keys %s were replaced by "dependencies"; '
+            . 'skills:update migrates the file automatically</comment>',
+            \implode(', ', \array_map(static fn(string $k): string => '"' . $k . '"', $used)),
+        ));
     }
 
     /**

--- a/tests/Acceptance/SkillsAutoMigrateTest.php
+++ b/tests/Acceptance/SkillsAutoMigrateTest.php
@@ -66,7 +66,12 @@ final class SkillsAutoMigrateTest
         Assert::true(\is_file(self::SKILLS_JSON), 'skills.json must be created');
         $skills = $this->readSkillsJson();
         Assert::same($skills['target'] ?? null, 'auto-migrate-target/skills');
-        Assert::same($skills['trusted'] ?? null, ['acme/skills-basic', 'acme/skills-pro']);
+        // Flat `trusted` folds into the `dependencies.composer` block.
+        Assert::false(\array_key_exists('trusted', $skills));
+        Assert::same(
+            $skills['dependencies'] ?? null,
+            ['composer' => ['trusted' => ['acme/skills-basic', 'acme/skills-pro']]],
+        );
         Assert::true(\array_key_exists('$schema', $skills));
 
         // composer.json no longer carries the migrated keys.
@@ -93,11 +98,13 @@ final class SkillsAutoMigrateTest
 
     public function updateIsNoOpForComposerJsonWhenSkillsJsonAlreadyExists(): void
     {
-        // Pre-create skills.json so the precedence path picks it. The
-        // sandbox composer.json still has its inline `trusted` block;
-        // we should NOT touch it.
+        // Pre-create skills.json in the modern `dependencies` form so the
+        // precedence path picks it and neither the inline relocation nor
+        // the in-place restructure has anything to do. The sandbox
+        // composer.json still has its inline `trusted` block; we should
+        // NOT touch it.
         \file_put_contents(self::SKILLS_JSON, \json_encode([
-            'trusted' => ['acme/skills-basic'],
+            'dependencies' => ['composer' => ['trusted' => ['acme/skills-basic']]],
         ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $composerBefore = (string) \file_get_contents(self::COMPOSER_JSON);

--- a/tests/Acceptance/SkillsDependenciesMigrationTest.php
+++ b/tests/Acceptance/SkillsDependenciesMigrationTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Acceptance;
+
+use Internal\Path;
+use LLM\Skills\Config\Mapper\ProjectConfigMigrator;
+use LLM\Skills\Tests\Testo\Composer\ComposerRunner;
+use LLM\Skills\Tests\Testo\Composer\WithSkillsJson;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Symfony\Component\Process\Process;
+use Testo\Assert;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * Acceptance coverage for the legacy trust trio (`trusted`,
+ * `trusted-replace`, `local`) → `dependencies` restructure in
+ * `skills.json`:
+ *
+ * - `skills:update` (write-mode) folds the legacy keys into a
+ *   `dependencies` block in place, placing it at the first legacy key's
+ *   slot and preserving every other key and its order, announces the
+ *   rewrite with a `[migrate]` notice, and syncs the trusted donor
+ *   exactly as the flat form did.
+ * - `skills:show` (read-only) reads the legacy keys, emits the
+ *   `[deprecated]` notice, and never touches the file.
+ * - A file carrying BOTH `dependencies` and a legacy key is fatal: the
+ *   command fails and the file is left untouched for the user to
+ *   resolve.
+ * - The new form drives the same behaviour the flat form did:
+ *   `dependencies.composer.trusted` approves a donor, and
+ *   `dependencies.composer == false` disables the vendor walk.
+ *
+ * Sandbox already has `acme/skills-basic` installed (but not built-in
+ * trusted), so approving it via config and syncing its `greeting` skill
+ * is the real end-to-end check, not remote fetching.
+ */
+#[Test]
+final class SkillsDependenciesMigrationTest
+{
+    private const TARGET_DIR = Info::PROJECT_DIR . '/.agents/skills';
+    private const SKILLS_JSON = Info::PROJECT_DIR . '/skills.json';
+
+    #[BeforeTest]
+    public function clearSyncTarget(): void
+    {
+        Filesystem::removeRecursive(self::TARGET_DIR);
+    }
+
+    #[AfterTest]
+    public function removeSkillsJson(): void
+    {
+        if (\is_file(self::SKILLS_JSON)) {
+            @\unlink(self::SKILLS_JSON);
+        }
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'trusted' => ['acme/skills-basic'],
+        'trusted-replace' => false,
+        'local' => ['composer' => true],
+        'sources' => [],
+    ])]
+    public function updateRestructuresLegacyTrustTrioInPlaceAndSyncs(): void
+    {
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+
+        // The legacy trio folds into one `dependencies` block that takes
+        // the slot of the first legacy key (`trusted` here). Every
+        // non-legacy key keeps its position; the other legacy keys drop
+        // out.
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            \array_keys($skills),
+            ['$schema', 'target', 'dependencies', 'sources'],
+            'the restructure places `dependencies` at the first legacy key slot, order preserved',
+        );
+        Assert::false(\array_key_exists('trusted', $skills), 'the legacy trusted key must be folded away');
+        Assert::false(\array_key_exists('trusted-replace', $skills), 'the legacy trusted-replace key must be folded away');
+        Assert::false(\array_key_exists('local', $skills), 'the legacy local key must be folded away');
+        Assert::same(
+            $skills['dependencies'],
+            [
+                'composer' => [
+                    'enabled' => true,
+                    'trusted' => ['acme/skills-basic'],
+                    'trusted-replace' => false,
+                ],
+            ],
+            'the composer entry carries the folded enabled/trusted/trusted-replace values',
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains(
+                $combined,
+                '[migrate] restructured "trusted", "trusted-replace", "local" into "dependencies" in skills.json',
+            ),
+            'update must announce the in-place restructure naming the keys found. Got: ' . $combined,
+        );
+
+        // The trusted Composer donor synced exactly as it would have
+        // under the flat form.
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/greeting/SKILL.md'),
+            'the trusted donor must still sync after the restructure',
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function showReadsLegacyKeysWithoutRewritingTheFile(): void
+    {
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runShow();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'show is read-only and must not rewrite skills.json',
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains(
+                $combined,
+                '[deprecated] config keys "trusted" were replaced by "dependencies"',
+            ),
+            'show must surface the deprecation notice for the legacy key. Got: ' . $combined,
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'dependencies' => ['composer' => true],
+        'trusted' => ['acme/skills-basic'],
+    ])]
+    public function updateFailsWhenDependenciesAndLegacyTrustedArePresent(): void
+    {
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runUpdate();
+
+        Assert::notSame(
+            $process->getExitCode(),
+            0,
+            'a file mixing dependencies with a legacy key must fail; stderr: ' . $process->getErrorOutput(),
+        );
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains(
+                $combined,
+                'both "dependencies" and legacy "trusted" are present; keep "dependencies" only',
+            ),
+            'the mixing error must name the conflict. Got: ' . $combined,
+        );
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'the ambiguous file must be left untouched for the user to resolve',
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'dependencies' => [
+            'composer' => ['trusted' => ['acme/skills-basic']],
+        ],
+    ])]
+    public function newFormComposerTrustedApprovesAndSyncs(): void
+    {
+        $before = (string) \file_get_contents(self::SKILLS_JSON);
+
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::same(
+            \file_get_contents(self::SKILLS_JSON),
+            $before,
+            'a new-form file needs no migration and must not be rewritten',
+        );
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/greeting/SKILL.md'),
+            'dependencies.composer.trusted must approve and sync the donor',
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'dependencies' => ['composer' => false],
+    ])]
+    public function newFormComposerFalseDisablesTheVendorWalk(): void
+    {
+        // With the Composer walk off and no sources either, the composite
+        // has nothing to do — nothing is written and the runner exits 0
+        // with the neutral "no donor providers are active" notice.
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::false(
+            \is_dir(self::TARGET_DIR),
+            'target dir must not be created when the Composer walk is disabled',
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, 'no donor providers are active'),
+            'runner must announce the inactive state. Got: ' . $combined,
+        );
+    }
+
+    private function runUpdate(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:update',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    private function runShow(): Process
+    {
+        return ComposerRunner::run(
+            Path::create(Info::PROJECT_DIR),
+            'skills:show',
+            timeout: 60,
+            mustSucceed: false,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSkillsJson(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = \json_decode(
+            (string) \file_get_contents(self::SKILLS_JSON),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+        return $decoded;
+    }
+}

--- a/tests/Acceptance/SkillsJsonConfigTest.php
+++ b/tests/Acceptance/SkillsJsonConfigTest.php
@@ -372,7 +372,12 @@ final class SkillsJsonConfigTest
         Assert::true(\is_file(self::SKILLS_JSON), 'skills.json must exist after init');
         $skills = $this->readSkillsJson();
         Assert::same($skills['target'] ?? null, 'external-target/skills');
-        Assert::same($skills['trusted'] ?? null, ['acme/skills-basic']);
+        // Flat `trusted` folds into the `dependencies.composer` block.
+        Assert::false(\array_key_exists('trusted', $skills));
+        Assert::same(
+            $skills['dependencies'] ?? null,
+            ['composer' => ['trusted' => ['acme/skills-basic']]],
+        );
         Assert::true(
             \array_key_exists('$schema', $skills),
             '$schema pointer must be emitted into the generated file',

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -18,6 +18,15 @@ use Testo\Test;
  * and invalid documents and asserting the schema agrees with what
  * the PHP mapper would do.
  *
+ * Deliberate asymmetry: the schema is STRICTER than the PHP mapper on
+ * legacy keys. The schema describes only the canonical config form
+ * (`sources`, `dependencies`), so `remote`, `local`, `trusted` and
+ * `trusted-replace` are unknown top-level keys and any document using
+ * them fails validation — a useful editor nudge toward `skills:update`.
+ * The mapper still reads those legacy keys as aliases and write-mode
+ * commands auto-migrate them in place, so such files keep working at
+ * runtime; the schema simply does not document the transitional form.
+ *
  * `justinrainbow/json-schema` is pulled in transitively via
  * `composer/composer` (already required for the plugin) so no new
  * production dependency is added.
@@ -46,8 +55,12 @@ final class SkillsSchemaTest
         $this->assertAccepts([
             'target' => '.agents/skills',
             'aliases' => ['.claude/skills', '.cursor/skills'],
-            'trusted' => ['acme/skills-basic', 'acme/*'],
-            'trusted-replace' => true,
+            'dependencies' => [
+                'composer' => [
+                    'trusted' => ['acme/skills-basic', 'acme/*'],
+                    'trusted-replace' => true,
+                ],
+            ],
             'discovery' => true,
             'auto-sync' => true,
         ]);
@@ -100,12 +113,12 @@ final class SkillsSchemaTest
         ]);
     }
 
-    public function deprecatedRemoteDocumentIsAccepted(): void
+    public function legacyRemoteDocumentIsRejected(): void
     {
-        // `remote` is the deprecated alias of `sources`. The schema
-        // still accepts it so editors do not flag legacy files before
-        // skills:update migrates them.
-        $this->assertAccepts([
+        // `remote` is the legacy alias of `sources`. The schema documents
+        // only the canonical form, so `remote` is an unknown key and the
+        // document is rejected. The mapper still reads it and migrates it.
+        $this->assertRejects([
             'remote' => [
                 ['from' => 'github', 'package' => 'acme/skills'],
             ],
@@ -114,8 +127,9 @@ final class SkillsSchemaTest
 
     public function bothSourcesAndRemoteIsRejected(): void
     {
-        // The PHP mapper treats both keys present as fatal; the schema's
-        // root `not` clause mirrors that.
+        // `sources` is canonical and `remote` is an unknown key, so the
+        // document is rejected regardless of the mapper's own "both keys
+        // present is fatal" rule.
         $this->assertRejects([
             'sources' => [['from' => 'github', 'package' => 'acme/skills']],
             'remote' => [['from' => 'github', 'package' => 'acme/other']],
@@ -176,19 +190,13 @@ final class SkillsSchemaTest
         ]);
     }
 
-    public function bareVendorPatternIsRejected(): void
+    public function legacyTrustedDocumentIsRejected(): void
     {
-        // The mapper rejects `acme` (no slash); the schema mirrors
-        // that with a pattern constraint.
+        // The flat `trusted` list moved into `dependencies.composer.trusted`.
+        // The schema documents only the canonical form, so top-level
+        // `trusted` is an unknown key and the document is rejected.
         $this->assertRejects([
-            'trusted' => ['acme'],
-        ]);
-    }
-
-    public function emptyTrustedEntryIsRejected(): void
-    {
-        $this->assertRejects([
-            'trusted' => [''],
+            'trusted' => ['acme/skills-basic', 'acme/*'],
         ]);
     }
 
@@ -245,26 +253,30 @@ final class SkillsSchemaTest
         ]);
     }
 
-    public function deprecatedLocalDocumentIsAccepted(): void
+    public function legacyLocalDocumentIsRejected(): void
     {
-        // The legacy `local` toggle map is still a valid document (marked
-        // deprecated) so editors do not flag files awaiting migration.
-        $this->assertAccepts([
+        // The `local` toggle map folded into `dependencies` (bool values
+        // map one-to-one). As an unknown key it is rejected by the schema;
+        // the mapper still reads it as an alias and migrates it.
+        $this->assertRejects([
             'local' => ['composer' => true, 'npm' => false],
         ]);
     }
 
-    public function deprecatedTrustedReplaceDocumentIsAccepted(): void
+    public function legacyTrustedReplaceDocumentIsRejected(): void
     {
-        $this->assertAccepts([
+        // The flat `trusted-replace` moved into
+        // `dependencies.composer.trusted-replace`; the top-level key is
+        // unknown to the schema and rejected.
+        $this->assertRejects([
             'trusted-replace' => true,
         ]);
     }
 
     public function dependenciesWithLegacyTrustedIsRejected(): void
     {
-        // Mixing the canonical block with a legacy key is fatal; the
-        // root `not` clause mirrors the mapper's "keep dependencies only".
+        // A canonical block next to a legacy key: `trusted` is unknown to
+        // the schema, so the document is rejected outright.
         $this->assertRejects([
             'dependencies' => ['composer' => true],
             'trusted' => ['acme/*'],

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -192,6 +192,117 @@ final class SkillsSchemaTest
         ]);
     }
 
+    public function dependenciesBoolFormIsAccepted(): void
+    {
+        // Short form: a plain enable/disable toggle per manager.
+        $this->assertAccepts([
+            'dependencies' => [
+                'composer' => true,
+                'npm' => false,
+            ],
+        ]);
+    }
+
+    public function dependenciesComposerObjectFormIsAccepted(): void
+    {
+        $this->assertAccepts([
+            'dependencies' => [
+                'composer' => [
+                    'enabled' => true,
+                    'trusted' => ['acme/*', 'myorg/skills'],
+                    'trusted-replace' => false,
+                ],
+            ],
+        ]);
+    }
+
+    public function dependenciesNpmAndGoBlocksAreAccepted(): void
+    {
+        // npm/go trust patterns validate structurally only — bare names,
+        // scoped names and module paths all pass without a pattern.
+        $this->assertAccepts([
+            'dependencies' => [
+                'npm' => [
+                    'enabled' => true,
+                    'trusted' => ['lodash', '@myorg/pkg', '@myorg/*'],
+                ],
+                'go' => [
+                    'trusted' => ['github.com/myorg/mod', 'github.com/myorg/*'],
+                    'trusted-replace' => true,
+                ],
+            ],
+        ]);
+    }
+
+    public function dependenciesComposerBadPatternIsRejected(): void
+    {
+        // Composer's `trusted` carries the vendor/pkg pattern; a bare name
+        // matches neither the boolean branch nor the object branch.
+        $this->assertRejects([
+            'dependencies' => [
+                'composer' => ['trusted' => ['acme']],
+            ],
+        ]);
+    }
+
+    public function deprecatedLocalDocumentIsAccepted(): void
+    {
+        // The legacy `local` toggle map is still a valid document (marked
+        // deprecated) so editors do not flag files awaiting migration.
+        $this->assertAccepts([
+            'local' => ['composer' => true, 'npm' => false],
+        ]);
+    }
+
+    public function deprecatedTrustedReplaceDocumentIsAccepted(): void
+    {
+        $this->assertAccepts([
+            'trusted-replace' => true,
+        ]);
+    }
+
+    public function dependenciesWithLegacyTrustedIsRejected(): void
+    {
+        // Mixing the canonical block with a legacy key is fatal; the
+        // root `not` clause mirrors the mapper's "keep dependencies only".
+        $this->assertRejects([
+            'dependencies' => ['composer' => true],
+            'trusted' => ['acme/*'],
+        ]);
+    }
+
+    public function dependenciesWithLegacyLocalIsRejected(): void
+    {
+        $this->assertRejects([
+            'dependencies' => ['composer' => true],
+            'local' => ['composer' => false],
+        ]);
+    }
+
+    public function dependenciesWithLegacyTrustedReplaceIsRejected(): void
+    {
+        $this->assertRejects([
+            'dependencies' => ['composer' => true],
+            'trusted-replace' => true,
+        ]);
+    }
+
+    public function dependenciesUnknownManagerIdIsRejected(): void
+    {
+        $this->assertRejects([
+            'dependencies' => ['pip' => true],
+        ]);
+    }
+
+    public function dependenciesUnknownObjectFieldIsRejected(): void
+    {
+        $this->assertRejects([
+            'dependencies' => [
+                'composer' => ['enabled' => true, 'rogue-field' => 'x'],
+            ],
+        ]);
+    }
+
     /**
      * @param array<string, mixed> $document
      */

--- a/tests/Acceptance/SkillsSourcesMigrationTest.php
+++ b/tests/Acceptance/SkillsSourcesMigrationTest.php
@@ -101,6 +101,60 @@ final class SkillsSourcesMigrationTest
         'target' => '.agents/skills',
         'remote' => [],
         'trusted' => ['acme/skills-basic'],
+        'local' => ['composer' => true],
+    ])]
+    public function updateRunsBothMigrationsOnAFullyLegacyFileInOneRun(): void
+    {
+        // A file carrying the deprecated `remote` alias alongside the
+        // full legacy trust trio (`trusted` + `local`) gets both
+        // write-mode fixes in a single run: `remote` renames to `sources`
+        // in its slot, and the trust keys fold into a `dependencies` block
+        // at the first legacy key's slot — with `local.composer` carried
+        // across as the composer entry's `enabled`.
+        $process = $this->runUpdate();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            \array_keys($skills),
+            ['$schema', 'target', 'sources', 'dependencies'],
+            'both migrations run in place, each replacing its key in its original slot',
+        );
+        Assert::false(\array_key_exists('remote', $skills), 'the deprecated remote key must be gone');
+        Assert::false(\array_key_exists('trusted', $skills), 'the legacy trusted key must be folded away');
+        Assert::false(\array_key_exists('local', $skills), 'the legacy local key must be folded away');
+        Assert::same($skills['sources'], []);
+        Assert::same(
+            $skills['dependencies'],
+            ['composer' => ['enabled' => true, 'trusted' => ['acme/skills-basic']]],
+            'local.composer folds into the composer entry as `enabled`, trusted rides along',
+        );
+
+        $combined = $process->getOutput() . $process->getErrorOutput();
+        Assert::true(
+            \str_contains($combined, '[migrate] renamed "remote" to "sources" in skills.json'),
+            'update must announce the in-place rename. Got: ' . $combined,
+        );
+        Assert::true(
+            \str_contains(
+                $combined,
+                '[migrate] restructured "trusted", "local" into "dependencies" in skills.json',
+            ),
+            'update must announce the dependency restructure naming both keys found. Got: ' . $combined,
+        );
+
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/greeting/SKILL.md'),
+            'skills must sync after both migrations',
+        );
+    }
+
+    #[WithSkillsJson([
+        '$schema' => ProjectConfigMigrator::SCHEMA_URL,
+        'target' => '.agents/skills',
+        'remote' => [],
+        'trusted' => ['acme/skills-basic'],
     ])]
     public function showReadsLegacyRemoteKeyWithoutRewritingTheFile(): void
     {

--- a/tests/Acceptance/SkillsSourcesMigrationTest.php
+++ b/tests/Acceptance/SkillsSourcesMigrationTest.php
@@ -63,23 +63,30 @@ final class SkillsSourcesMigrationTest
 
         Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
 
-        // The renamed file keeps every sibling key in its original slot,
-        // with `remote` replaced by `sources` in place.
+        // A fully-legacy file gets both write-mode fixes in one run:
+        // `remote` is renamed to `sources` in its slot, and the legacy
+        // `trusted` list is folded into a `dependencies` block in its
+        // slot. Every non-legacy key keeps its position.
         $skills = $this->readSkillsJson();
         Assert::same(
             \array_keys($skills),
-            ['$schema', 'target', 'sources', 'trusted'],
-            'key order must be preserved with remote renamed to sources in place',
+            ['$schema', 'target', 'sources', 'dependencies'],
+            'both migrations run in place, each replacing its key in its original slot',
         );
         Assert::false(\array_key_exists('remote', $skills), 'the deprecated remote key must be gone');
+        Assert::false(\array_key_exists('trusted', $skills), 'the legacy trusted key must be folded away');
         Assert::same($skills['sources'], []);
         Assert::same($skills['target'], '.agents/skills');
-        Assert::same($skills['trusted'], ['acme/skills-basic']);
+        Assert::same($skills['dependencies'], ['composer' => ['trusted' => ['acme/skills-basic']]]);
 
         $combined = $process->getOutput() . $process->getErrorOutput();
         Assert::true(
             \str_contains($combined, '[migrate] renamed "remote" to "sources" in skills.json'),
             'update must announce the in-place rename. Got: ' . $combined,
+        );
+        Assert::true(
+            \str_contains($combined, '[migrate] restructured "trusted" into "dependencies" in skills.json'),
+            'update must announce the dependency restructure. Got: ' . $combined,
         );
 
         // The sync proceeded against the Composer donor with the renamed config.
@@ -120,7 +127,6 @@ final class SkillsSourcesMigrationTest
         'target' => '.agents/skills',
         'sources' => [],
         'remote' => [],
-        'trusted' => ['acme/skills-basic'],
     ])]
     public function updateFailsWhenBothSourcesAndRemoteArePresent(): void
     {

--- a/tests/Acceptance/StandaloneBinTest.php
+++ b/tests/Acceptance/StandaloneBinTest.php
@@ -222,8 +222,8 @@ final class StandaloneBinTest
         );
         Assert::same(
             \array_keys($decoded),
-            ['$schema', 'local', 'sources'],
-            'standalone init writes a stub with the local + sources knobs visible',
+            ['$schema', 'dependencies', 'sources'],
+            'standalone init writes a stub with the dependencies + sources knobs visible',
         );
     }
 }

--- a/tests/Unit/Add/SkillsJsonWriterTest.php
+++ b/tests/Unit/Add/SkillsJsonWriterTest.php
@@ -86,12 +86,13 @@ final class SkillsJsonWriterTest
 
     public function preservesUnrelatedTopLevelKeys(): void
     {
-        // The writer must NOT clobber `target` / `aliases` / `trusted`
-        // — only `sources[]` is its concern.
+        // The writer must NOT clobber unrelated keys like `target` /
+        // `aliases` — only `sources[]` is its concern (the legacy trust
+        // trio is the one exception; it is normalised into `dependencies`,
+        // covered by its own test).
         $this->writeSkillsJson([
             'target' => '.agents/skills',
             'aliases' => ['.claude/skills'],
-            'trusted' => ['acme/*'],
         ]);
 
         (new SkillsJsonWriter())->upsertSource(
@@ -102,7 +103,6 @@ final class SkillsJsonWriterTest
         $payload = $this->readSkillsJson();
         Assert::same($payload['target'] ?? null, '.agents/skills');
         Assert::same($payload['aliases'] ?? null, ['.claude/skills']);
-        Assert::same($payload['trusted'] ?? null, ['acme/*']);
     }
 
     public function upsertReplacesEntryWithSameCompositeKey(): void
@@ -424,6 +424,36 @@ final class SkillsJsonWriterTest
             ['alpha', 'beta'],
             'the legacy entry allowlist must merge with the new one',
         );
+    }
+
+    public function upsertNormalisesLegacyTrustTrioIntoDependencies(): void
+    {
+        // A file still on the legacy trust trio is normalised on write:
+        // `local` / `trusted` / `trusted-replace` fold into a
+        // `dependencies` block, the legacy keys are dropped, and
+        // unrelated keys survive.
+        $this->writeSkillsJson([
+            'target' => '.agents/skills',
+            'trusted' => ['acme/*'],
+            'trusted-replace' => false,
+            'local' => ['composer' => true, 'npm' => false],
+        ]);
+
+        (new SkillsJsonWriter())->upsertSource(
+            Path::create($this->tmp),
+            self::entry('acme/skills'),
+        );
+
+        $payload = $this->readSkillsJson();
+        Assert::false(\array_key_exists('trusted', $payload), 'legacy trusted must be dropped');
+        Assert::false(\array_key_exists('trusted-replace', $payload), 'legacy trusted-replace must be dropped');
+        Assert::false(\array_key_exists('local', $payload), 'legacy local must be dropped');
+        Assert::same($payload['target'] ?? null, '.agents/skills', 'unrelated keys must survive');
+        Assert::same($payload['dependencies'] ?? null, [
+            'composer' => ['enabled' => true, 'trusted' => ['acme/*'], 'trusted-replace' => false],
+            'npm' => false,
+        ]);
+        Assert::count((array) $payload['sources'], 1);
     }
 
     public function dirEntryStoresPathAsIdentifier(): void

--- a/tests/Unit/Config/GoPatternTest.php
+++ b/tests/Unit/Config/GoPatternTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Config;
+
+use LLM\Skills\Config\GoPattern;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataSet;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+#[Covers(GoPattern::class)]
+final class GoPatternTest
+{
+    public function fromStringExactModulePath(): void
+    {
+        $p = GoPattern::fromString('github.com/owner/mod');
+
+        Assert::same($p->raw(), 'github.com/owner/mod');
+        Assert::same($p->base, 'github.com/owner/mod');
+        Assert::false($p->wildcard);
+    }
+
+    public function fromStringPrefixWildcard(): void
+    {
+        $p = GoPattern::fromString('github.com/owner/*');
+
+        Assert::same($p->base, 'github.com/owner');
+        Assert::true($p->wildcard);
+    }
+
+    public function fromStringRejectsBareWildcard(): void
+    {
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('bare wildcard');
+
+        GoPattern::fromString('*');
+    }
+
+    public function fromStringRejectsWildcardWithoutPrefix(): void
+    {
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('module-path prefix');
+
+        GoPattern::fromString('/*');
+    }
+
+    #[DataSet(['github.com/owner/mod', 'github.com/owner/mod', true], name: 'exact match')]
+    #[DataSet(['github.com/owner/mod', 'github.com/owner/other', false], name: 'exact rejects a sibling')]
+    #[DataSet(['github.com/owner/mod', 'github.com/owner/mod/v2', false], name: 'exact does not swallow deeper paths')]
+    #[DataSet(['github.com/owner/*', 'github.com/owner/repo', true], name: 'wildcard matches one segment')]
+    #[DataSet(['github.com/owner/*', 'github.com/owner/repo/v2', true], name: 'wildcard matches a /vN suffix')]
+    #[DataSet(['github.com/owner/*', 'github.com/owner/repo/sub/tool', true], name: 'wildcard matches a nested submodule')]
+    #[DataSet(['github.com/owner/*', 'github.com/other/repo', false], name: 'wildcard rejects a different owner')]
+    #[DataSet(['github.com/owner/*', 'github.com/owner', false], name: 'wildcard needs a trailing segment')]
+    #[DataSet(['github.com/owner/*', 'github.com/ownerX/repo', false], name: 'wildcard respects the segment boundary')]
+    public function matches(string $pattern, string $packageName, bool $expected): void
+    {
+        Assert::same(
+            GoPattern::fromString($pattern)->matches($packageName),
+            $expected,
+        );
+    }
+
+    public function matchingIsCaseSensitive(): void
+    {
+        // Go module paths are case-sensitive; the comparison is literal.
+        Assert::false(GoPattern::fromString('github.com/owner/*')->matches('github.com/Owner/repo'));
+    }
+}

--- a/tests/Unit/Config/GoPatternTest.php
+++ b/tests/Unit/Config/GoPatternTest.php
@@ -48,6 +48,35 @@ final class GoPatternTest
         GoPattern::fromString('/*');
     }
 
+    public function fromStringRejectsWildcardInMiddleSegment(): void
+    {
+        // `github.com/*/mod` puts the wildcard mid-path; it is not the
+        // trailing `/*`, so the "exact" path it produces can never match.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('only allowed as the trailing');
+
+        GoPattern::fromString('github.com/*/mod');
+    }
+
+    public function fromStringRejectsWildcardBeforeTrailingSegment(): void
+    {
+        // `github.com/owner/*/v2` has a `*` that is not the final segment.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('only allowed as the trailing');
+
+        GoPattern::fromString('github.com/owner/*/v2');
+    }
+
+    public function fromStringRejectsWildcardInsideWildcardPrefix(): void
+    {
+        // The prefix before a trailing `/*` is literal; `github.com/own*er/*`
+        // embeds a stray `*` in it.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('only allowed as the trailing');
+
+        GoPattern::fromString('github.com/own*er/*');
+    }
+
     #[DataSet(['github.com/owner/mod', 'github.com/owner/mod', true], name: 'exact match')]
     #[DataSet(['github.com/owner/mod', 'github.com/owner/other', false], name: 'exact rejects a sibling')]
     #[DataSet(['github.com/owner/mod', 'github.com/owner/mod/v2', false], name: 'exact does not swallow deeper paths')]

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -1185,6 +1185,394 @@ final class ProjectConfigMapperTest
         ]);
     }
 
+    // ── dependencies: per-manager config & scoped trust ─────────────────
+
+    public function dependenciesBoolShortFormTogglesManagers(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => true, 'npm' => false]],
+        ]);
+
+        Assert::same($cfg->local, ['composer' => true, 'npm' => false]);
+        Assert::true($cfg->isLocalEnabled('composer'));
+        Assert::false($cfg->isLocalEnabled('npm'));
+        Assert::same($cfg->trusted->patterns, []);
+        Assert::same($cfg->trustedReplace, false);
+    }
+
+    public function dependenciesBoolFormEqualsEnabledObject(): void
+    {
+        // `true` ≡ `{ enabled: true }`, `false` ≡ `{ enabled: false }`.
+        $boolForm = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['npm' => true]],
+        ]);
+        $objectForm = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['npm' => ['enabled' => true]]],
+        ]);
+
+        Assert::same($boolForm->local, $objectForm->local);
+        Assert::same($boolForm->dependencies['npm']->enabled, true);
+        Assert::same($objectForm->dependencies['npm']->enabled, true);
+    }
+
+    public function dependenciesComposerTrustedIsFoldedIntoFlatTrusted(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'dependencies' => [
+                    'composer' => ['trusted' => ['acme/*', 'foo/bar'], 'trusted-replace' => true],
+                ],
+            ],
+        ]);
+
+        Assert::same($cfg->trustedReplace, true);
+        Assert::same(\count($cfg->trusted->patterns), 2);
+        Assert::true($cfg->trusted->trusts('acme/anything'));
+        Assert::true($cfg->trusted->trusts('foo/bar'));
+        Assert::false($cfg->trusted->trusts('foo/baz'));
+    }
+
+    public function dependenciesTrustedDoesNotImplicitlyEnableManager(): void
+    {
+        // Configuring `trusted` is separate from opting the walk in — an
+        // npm object without `enabled` stays disabled by its per-manager
+        // default.
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['npm' => ['trusted' => ['@myorg/*']]]],
+        ]);
+
+        Assert::false($cfg->isLocalEnabled('npm'));
+        Assert::same($cfg->dependencies['npm']->enabled, null);
+        Assert::same($cfg->dependencies['npm']->trusted, ['@myorg/*']);
+    }
+
+    public function dependenciesComposerObjectWithoutEnabledKeepsDefaultOn(): void
+    {
+        // composer's per-manager default is enabled, so a composer object
+        // without `enabled` still resolves to on.
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['trusted' => ['acme/*']]]],
+        ]);
+
+        Assert::true($cfg->isLocalEnabled('composer'));
+        Assert::same($cfg->dependencies['composer']->enabled, null);
+    }
+
+    public function dependenciesTrustedReplaceDefaultsFalse(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['trusted' => ['acme/*']]]],
+        ]);
+
+        Assert::same($cfg->trustedReplace, false);
+        Assert::same($cfg->dependencies['composer']->trustedReplace, false);
+    }
+
+    public function dependenciesNpmAcceptsRegistryNamesVendorPatternRejects(): void
+    {
+        // npm patterns validate structurally only and are stored raw —
+        // bare and scoped names that VendorPattern would reject pass.
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'dependencies' => ['npm' => ['trusted' => ['lodash', '@scope/pkg', '@scope/*']]],
+            ],
+        ]);
+
+        Assert::same($cfg->dependencies['npm']->trusted, ['lodash', '@scope/pkg', '@scope/*']);
+    }
+
+    public function dependenciesGoAcceptsModulePaths(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'dependencies' => ['go' => ['trusted' => ['github.com/owner/mod', 'github.com/owner/*']]],
+            ],
+        ]);
+
+        Assert::same($cfg->dependencies['go']->trusted, ['github.com/owner/mod', 'github.com/owner/*']);
+    }
+
+    public function dependenciesComposerBadPatternThrows(): void
+    {
+        // composer entries go through the VendorPattern grammar exactly
+        // like the flat `trusted` list.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.dependencies.composer.trusted[0]');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['trusted' => ['bare-name']]]],
+        ]);
+    }
+
+    public function dependenciesNpmNonStringEntryThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills.dependencies.npm.trusted[0] must be a non-empty string');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['npm' => ['trusted' => [42]]]],
+        ]);
+    }
+
+    public function dependenciesDuplicateTrustedEntryThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('duplicates an earlier entry');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['npm' => ['trusted' => ['lodash', 'lodash']]]],
+        ]);
+    }
+
+    public function dependenciesTrustedNotAListThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('dependencies.composer.trusted must be a list of patterns');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['trusted' => ['acme' => '*']]]],
+        ]);
+    }
+
+    public function dependenciesUnknownManagerIdThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('not a known package manager');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['pip' => true]],
+        ]);
+    }
+
+    public function dependenciesUnknownObjectFieldThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('unknown field "enabledd"');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['enabledd' => true]]],
+        ]);
+    }
+
+    public function dependenciesEnabledNonBoolThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('dependencies.composer.enabled must be a boolean');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['enabled' => 'yes']]],
+        ]);
+    }
+
+    public function dependenciesTrustedReplaceNonBoolThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('dependencies.composer.trusted-replace must be a boolean');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['trusted-replace' => 'yes']]],
+        ]);
+    }
+
+    public function dependenciesAsListThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('must be a map of package-manager id');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer']],
+        ]);
+    }
+
+    public function dependencyEntryAsListThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('dependencies.composer must be a boolean or an object');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => ['acme/*']]],
+        ]);
+    }
+
+    public function dependenciesStructureIsExposedOnProjectConfig(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'dependencies' => [
+                    'composer' => ['enabled' => false, 'trusted' => ['acme/*']],
+                    'go' => ['trusted' => ['github.com/x/*'], 'trusted-replace' => true],
+                ],
+            ],
+        ]);
+
+        Assert::same(\array_keys($cfg->dependencies), ['composer', 'go']);
+        Assert::same($cfg->dependencies['composer']->enabled, false);
+        Assert::same($cfg->dependencies['composer']->trusted, ['acme/*']);
+        Assert::same($cfg->dependencies['go']->enabled, null);
+        Assert::same($cfg->dependencies['go']->trustedReplace, true);
+        // composer entry drives the flat fields even when disabled.
+        Assert::same($cfg->local['composer'], false);
+        Assert::true($cfg->trusted->trusts('acme/x'));
+    }
+
+    // ── dependencies: folding equivalence with the flat legacy form ─────
+
+    public function dependenciesFoldingMatchesFlatForm(): void
+    {
+        // The new block and the equivalent flat trio must produce
+        // identical `trusted` / `trustedReplace` / `local` fields.
+        $flat = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'trusted' => ['acme/*', 'foo/bar'],
+                'trusted-replace' => true,
+                'local' => ['composer' => true, 'npm' => false],
+            ],
+        ]);
+        $new = (new ProjectConfigMapper())->fromExtra([
+            'skills' => [
+                'dependencies' => [
+                    'composer' => ['enabled' => true, 'trusted' => ['acme/*', 'foo/bar'], 'trusted-replace' => true],
+                    'npm' => false,
+                ],
+            ],
+        ]);
+
+        Assert::same($flat->trustedReplace, $new->trustedReplace);
+        Assert::same($flat->local, $new->local);
+        Assert::same(
+            \array_map(static fn(\LLM\Skills\Config\VendorPattern $p): string => $p->raw, $flat->trusted->patterns),
+            \array_map(static fn(\LLM\Skills\Config\VendorPattern $p): string => $p->raw, $new->trusted->patterns),
+        );
+    }
+
+    public function legacyFlatFormLeavesDependenciesStructureEmpty(): void
+    {
+        $cfg = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['trusted' => ['acme/*']],
+        ]);
+
+        Assert::same($cfg->dependencies, []);
+        Assert::true($cfg->trusted->trusts('acme/x'));
+    }
+
+    // ── dependencies: mixing with legacy keys is fatal ──────────────────
+
+    public function dependenciesWithLegacyTrustedInlineThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills: both "dependencies" and legacy "trusted" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => true], 'trusted' => ['acme/*']],
+        ]);
+    }
+
+    public function dependenciesWithLegacyTrustedReplaceInlineThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills: both "dependencies" and legacy "trusted-replace" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => true], 'trusted-replace' => true],
+        ]);
+    }
+
+    public function dependenciesWithLegacyLocalInlineThrows(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('extra.skills: both "dependencies" and legacy "local" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['dependencies' => ['composer' => true], 'local' => ['npm' => true]],
+        ]);
+    }
+
+    public function dependenciesWithLegacyTrustedInSkillsJsonThrows(): void
+    {
+        $this->writeSkillsJson(['dependencies' => ['composer' => true], 'trusted' => ['acme/*']]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: both "dependencies" and legacy "trusted" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+    }
+
+    public function dependenciesWithLegacyTrustedReplaceInSkillsJsonThrows(): void
+    {
+        $this->writeSkillsJson(['dependencies' => ['composer' => true], 'trusted-replace' => true]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: both "dependencies" and legacy "trusted-replace" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+    }
+
+    public function dependenciesWithLegacyLocalInSkillsJsonThrows(): void
+    {
+        $this->writeSkillsJson(['dependencies' => ['composer' => true], 'local' => ['npm' => true]]);
+
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('skills.json: both "dependencies" and legacy "local" are present; keep "dependencies" only');
+
+        (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+    }
+
+    // ── dependencies: deprecation flag lists the legacy keys used ───────
+
+    public function forProjectInlineDependenciesDoesNotFlagDeprecation(): void
+    {
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['dependencies' => ['composer' => true]]],
+        );
+
+        Assert::same($resolution->usedDeprecatedDependencyKeys, []);
+    }
+
+    public function forProjectInlineLegacyTrustedFlagsDeprecation(): void
+    {
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['trusted' => ['acme/*']]],
+        );
+
+        Assert::same($resolution->usedDeprecatedDependencyKeys, ['trusted']);
+    }
+
+    public function forProjectListsEveryLegacyDependencyKeyFound(): void
+    {
+        // The flag names exactly the legacy keys the winning block used,
+        // in canonical order.
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => [
+                'trusted' => ['acme/*'],
+                'trusted-replace' => true,
+                'local' => ['composer' => true],
+            ]],
+        );
+
+        Assert::same($resolution->usedDeprecatedDependencyKeys, ['trusted', 'trusted-replace', 'local']);
+    }
+
+    public function forProjectExternalLegacyDependencyKeysFlagDeprecation(): void
+    {
+        $this->writeSkillsJson(['local' => ['composer' => true], 'trusted' => ['acme/*']]);
+
+        $resolution = (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+
+        Assert::same($resolution->usedDeprecatedDependencyKeys, ['trusted', 'local']);
+    }
+
+    public function forProjectExternalDependenciesDoesNotFlagDeprecation(): void
+    {
+        $this->writeSkillsJson(['dependencies' => ['composer' => ['trusted' => ['acme/*']]]]);
+
+        $resolution = (new ProjectConfigMapper())->forProject(Path::create($this->tmp), null);
+
+        Assert::same($resolution->usedDeprecatedDependencyKeys, []);
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMigratorTest.php
@@ -120,12 +120,15 @@ final class ProjectConfigMigratorTest
         );
 
         Assert::same($result->status, MigrationStatus::Migrated);
-        Assert::same($result->migratedKeys, ['target', 'trusted', 'auto-sync']);
+        // Flat `trusted` folds into `dependencies`; the migrated key set
+        // and the written file both name the canonical key.
+        Assert::same($result->migratedKeys, ['target', 'dependencies', 'auto-sync']);
 
         // The new skills.json carries the migrated keys plus `$schema`.
         $skills = $this->readSkillsJson();
         Assert::same($skills['target'] ?? null, 'custom/skills');
-        Assert::same($skills['trusted'] ?? null, ['acme/*']);
+        Assert::false(\array_key_exists('trusted', $skills), 'written file must not carry the legacy key');
+        Assert::same($skills['dependencies'] ?? null, ['composer' => ['trusted' => ['acme/*']]]);
         Assert::same($skills['auto-sync'] ?? null, true);
         Assert::true(\array_key_exists('$schema', $skills));
 
@@ -425,6 +428,242 @@ final class ProjectConfigMigratorTest
             $before,
             'a both-keys file must be left byte-for-byte untouched',
         );
+    }
+
+    public function restructuresLegacyTrustTrioIntoDependenciesBlock(): void
+    {
+        // Spec §3.1 worked example, verbatim. `dependencies` takes the
+        // slot of the first legacy key (`trusted`), the composer entry is
+        // upgraded to object form carrying the explicit `local.composer`
+        // enable flag and both flat trust fields, `npm` stays a bare
+        // bool, and every non-legacy key keeps its position.
+        $this->writeSkillsJson([
+            'target' => '.claude/skills',
+            'trusted' => ['acme/*'],
+            'trusted-replace' => false,
+            'local' => ['composer' => true, 'npm' => false],
+            'sources' => [],
+        ]);
+
+        $io = new BufferIO();
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            $io,
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+        Assert::same($result->migratedKeys, ['dependencies']);
+
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            \array_keys($skills),
+            ['target', 'dependencies', 'sources'],
+            'dependencies must take the slot of the first legacy key and siblings keep order',
+        );
+        Assert::same($skills['dependencies'] ?? null, [
+            'composer' => ['enabled' => true, 'trusted' => ['acme/*'], 'trusted-replace' => false],
+            'npm' => false,
+        ]);
+        Assert::same($skills['target'] ?? null, '.claude/skills');
+        Assert::same($skills['sources'] ?? null, []);
+
+        Assert::true(
+            \str_contains(
+                $io->getOutput(),
+                'restructured "trusted", "trusted-replace", "local" into "dependencies" in skills.json',
+            ),
+            'a [migrate] notice listing the found keys must be emitted; got: ' . $io->getOutput(),
+        );
+    }
+
+    public function restructuresFlatTrustedOnlyIntoComposerObject(): void
+    {
+        // Only a flat `trusted` list, no `local` and no `trusted-replace`:
+        // the composer entry is an object with just `trusted`; `enabled`
+        // stays absent (no explicit `local.composer`) and `trusted-replace`
+        // is not materialised as its `false` default.
+        $this->writeSkillsJson([
+            'trusted' => ['acme/*', 'myorg/skills'],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            $skills['dependencies'] ?? null,
+            ['composer' => ['trusted' => ['acme/*', 'myorg/skills']]],
+        );
+    }
+
+    public function restructuresLocalOnlyVerbatim(): void
+    {
+        // Only a `local` map, no flat trust keys: the block is the local
+        // map verbatim — bare bools, no composer object upgrade.
+        $this->writeSkillsJson([
+            'local' => ['composer' => false],
+            'sources' => [],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+        $skills = $this->readSkillsJson();
+        Assert::same($skills['dependencies'] ?? null, ['composer' => false]);
+    }
+
+    public function restructuresTrustedReplaceWithoutTrusted(): void
+    {
+        // `trusted-replace` present without a `trusted` list: the composer
+        // object carries only `trusted-replace`; no empty `trusted` list
+        // is invented.
+        $this->writeSkillsJson([
+            'trusted-replace' => true,
+        ]);
+
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+        $skills = $this->readSkillsJson();
+        Assert::same(
+            $skills['dependencies'] ?? null,
+            ['composer' => ['trusted-replace' => true]],
+        );
+    }
+
+    public function restructureIsNoOpWhenDependenciesAlreadyPresent(): void
+    {
+        // A file already on `dependencies` is left byte-for-byte alone,
+        // even if it also (illegally) carries a legacy key — the mapper's
+        // fatal "both present" check must stand.
+        $this->writeSkillsJson([
+            'dependencies' => ['composer' => ['trusted' => ['acme/*']]],
+            'trusted' => ['other/*'],
+        ]);
+        $before = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $io = new BufferIO();
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            $io,
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            $before,
+            'a file already carrying dependencies must not be rewritten',
+        );
+        Assert::false(\str_contains($io->getOutput(), 'restructured'));
+    }
+
+    public function restructureIsNoOpWhenNoLegacyKeys(): void
+    {
+        $this->writeSkillsJson([
+            'target' => 'custom/skills',
+            'sources' => [],
+        ]);
+        $before = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same((string) \file_get_contents($this->tmp . '/skills.json'), $before);
+    }
+
+    public function restructureIsIdempotentAcrossRuns(): void
+    {
+        // A second pass over the already-restructured file is a no-op:
+        // the first run leaves `dependencies` in place, so the second
+        // short-circuits without touching the bytes.
+        $this->writeSkillsJson([
+            'trusted' => ['acme/*'],
+            'local' => ['composer' => true],
+        ]);
+        $migrator = new ProjectConfigMigrator();
+
+        $migrator->restructureDependencies(Path::create($this->tmp), new BufferIO());
+        $afterFirst = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $second = $migrator->restructureDependencies(Path::create($this->tmp), new BufferIO());
+
+        Assert::same($second->status, MigrationStatus::Skipped);
+        Assert::same(
+            (string) \file_get_contents($this->tmp . '/skills.json'),
+            $afterFirst,
+            'a second restructure run must not rewrite the file',
+        );
+    }
+
+    public function restructureIsNoOpWhenLocalIsNotAnObject(): void
+    {
+        // A malformed non-object `local` cannot fold into a per-manager
+        // map without dropping data, so the file is left untouched and
+        // the mapper reports the shape error on the original.
+        $this->writeSkillsJson([
+            'local' => 'nonsense',
+        ]);
+        $before = (string) \file_get_contents($this->tmp . '/skills.json');
+
+        $result = (new ProjectConfigMigrator())->restructureDependencies(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Skipped);
+        Assert::same((string) \file_get_contents($this->tmp . '/skills.json'), $before);
+    }
+
+    public function inlineMigrationFoldsLegacyTrioIntoDependencies(): void
+    {
+        // The inline extra.skills → skills.json move folds the legacy
+        // trio the same way; the generated file never carries the legacy
+        // keys, and composer.json is stripped of the keys the user wrote.
+        $this->writeComposerJson([
+            'name' => 'demo/consumer',
+            'extra' => [
+                'skills' => [
+                    'target' => 'custom/skills',
+                    'trusted' => ['acme/*'],
+                    'trusted-replace' => true,
+                    'local' => ['composer' => false],
+                ],
+            ],
+        ]);
+
+        $result = (new ProjectConfigMigrator())->migrate(
+            Path::create($this->tmp),
+            new BufferIO(),
+        );
+
+        Assert::same($result->status, MigrationStatus::Migrated);
+
+        $skills = $this->readSkillsJson();
+        Assert::false(\array_key_exists('trusted', $skills));
+        Assert::false(\array_key_exists('trusted-replace', $skills));
+        Assert::false(\array_key_exists('local', $skills));
+        Assert::same($skills['dependencies'] ?? null, [
+            'composer' => ['enabled' => false, 'trusted' => ['acme/*'], 'trusted-replace' => true],
+        ]);
+
+        // composer.json stripped of the legacy keys the user wrote.
+        $composer = $this->readComposerJson();
+        $remaining = $composer['extra']['skills'] ?? [];
+        Assert::false(\array_key_exists('trusted', $remaining));
+        Assert::false(\array_key_exists('trusted-replace', $remaining));
+        Assert::false(\array_key_exists('local', $remaining));
     }
 
     /**

--- a/tests/Unit/Config/NpmPatternTest.php
+++ b/tests/Unit/Config/NpmPatternTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Config;
+
+use LLM\Skills\Config\NpmPattern;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataSet;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+#[Covers(NpmPattern::class)]
+final class NpmPatternTest
+{
+    public function fromStringBareName(): void
+    {
+        $p = NpmPattern::fromString('lodash');
+
+        Assert::same($p->raw(), 'lodash');
+        Assert::same($p->scope, null);
+        Assert::same($p->package, 'lodash');
+    }
+
+    public function fromStringScopedExact(): void
+    {
+        $p = NpmPattern::fromString('@anthropic-ai/claude-code');
+
+        Assert::same($p->scope, '@anthropic-ai');
+        Assert::same($p->package, 'claude-code');
+    }
+
+    public function fromStringScopeWildcard(): void
+    {
+        $p = NpmPattern::fromString('@anthropic-ai/*');
+
+        Assert::same($p->scope, '@anthropic-ai');
+        Assert::same($p->package, null);
+    }
+
+    public function fromStringRejectsBareWildcard(): void
+    {
+        // A bare `*` would trust the whole registry — never allowed.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('bare wildcard');
+
+        NpmPattern::fromString('*');
+    }
+
+    public function fromStringRejectsUnscopedNameWithSlash(): void
+    {
+        // An unscoped npm name never contains a slash.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('cannot contain');
+
+        NpmPattern::fromString('foo/bar');
+    }
+
+    public function fromStringRejectsScopeWithoutPackage(): void
+    {
+        // `@scope/` has an empty package segment.
+        Expect::exception(\InvalidArgumentException::class);
+
+        NpmPattern::fromString('@scope/');
+    }
+
+    public function fromStringRejectsScopedMultiSlash(): void
+    {
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('exactly one');
+
+        NpmPattern::fromString('@scope/a/b');
+    }
+
+    #[DataSet(['lodash', 'lodash', true], name: 'bare exact match')]
+    #[DataSet(['lodash', 'lodash-es', false], name: 'bare rejects a different name')]
+    #[DataSet(['lodash', '@scope/lodash', false], name: 'bare rejects a scoped name')]
+    #[DataSet(['@scope/pkg', '@scope/pkg', true], name: 'scoped exact match')]
+    #[DataSet(['@scope/pkg', '@scope/other', false], name: 'scoped rejects a different package')]
+    #[DataSet(['@scope/pkg', 'pkg', false], name: 'scoped rejects the bare package')]
+    #[DataSet(['@scope/*', '@scope/anything', true], name: 'wildcard matches a package in the scope')]
+    #[DataSet(['@scope/*', '@scope/a/b', true], name: 'wildcard matches a nested path in the scope')]
+    #[DataSet(['@scope/*', '@other/pkg', false], name: 'wildcard rejects a different scope')]
+    #[DataSet(['@scope/*', 'scope', false], name: 'wildcard rejects the bare scope word')]
+    public function matches(string $pattern, string $packageName, bool $expected): void
+    {
+        Assert::same(
+            NpmPattern::fromString($pattern)->matches($packageName),
+            $expected,
+        );
+    }
+
+    public function matchingIsCaseSensitive(): void
+    {
+        // npm publishes lower-cased names, so the comparison is literal.
+        Assert::false(NpmPattern::fromString('@scope/pkg')->matches('@Scope/pkg'));
+    }
+}

--- a/tests/Unit/Config/NpmPatternTest.php
+++ b/tests/Unit/Config/NpmPatternTest.php
@@ -74,6 +74,44 @@ final class NpmPatternTest
         NpmPattern::fromString('@scope/a/b');
     }
 
+    public function fromStringRejectsUnscopedNameWithWildcard(): void
+    {
+        // `lodash*` is not a real npm name — only a scope may carry the
+        // wildcard, so this can never match anything.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('cannot contain "*"');
+
+        NpmPattern::fromString('lodash*');
+    }
+
+    public function fromStringRejectsEmptyScopeName(): void
+    {
+        // `@/*` has a bare `@` with no scope name behind it.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('scope segment after "@" must not be empty');
+
+        NpmPattern::fromString('@/*');
+    }
+
+    public function fromStringRejectsWildcardInScopeSegment(): void
+    {
+        // A `*` in the scope segment (`@sc*ope/x`) never matches a real name.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('scope segment cannot contain "*"');
+
+        NpmPattern::fromString('@sc*ope/x');
+    }
+
+    public function fromStringRejectsWildcardInsidePackageSegment(): void
+    {
+        // The package segment is either the whole wildcard (`*`) or a
+        // literal name; `@scope/*foo` embeds a `*` and is rejected.
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('package segment must be "*"');
+
+        NpmPattern::fromString('@scope/*foo');
+    }
+
     #[DataSet(['lodash', 'lodash', true], name: 'bare exact match')]
     #[DataSet(['lodash', 'lodash-es', false], name: 'bare rejects a different name')]
     #[DataSet(['lodash', '@scope/lodash', false], name: 'bare rejects a scoped name')]

--- a/tests/Unit/Config/TrustedVendorRegistryTest.php
+++ b/tests/Unit/Config/TrustedVendorRegistryTest.php
@@ -16,9 +16,10 @@ use Testo\Test;
  *
  * Per-ecosystem trust file, loaded by provider id. The registry must:
  *
- * - Return a populated list for the bundled `composer` file.
+ * - Return a populated list for each bundled file (`composer`, `npm`,
+ *   `go`), parsed through that ecosystem's grammar.
  * - Return {@see TrustedVendors::empty()} for an unregistered
- *   provider id (e.g. `npm` until its file ships).
+ *   provider id (e.g. `github`, which ships no trust file).
  *
  * We do not exercise the "file exists but read fails" branch —
  * triggering it requires platform-specific chmod tricks that don't
@@ -50,14 +51,73 @@ final class TrustedVendorRegistryTest
         Assert::same($vendors->patterns, []);
     }
 
-    public function npmProviderReturnsEmptyUntilFileShips(): void
+    public function npmProviderParsesBundledFileAndMatchesScopes(): void
     {
-        // npm is locked vocabulary in ProviderId but does NOT have a
-        // bundled trust file in v1. The registry maps it to "no
-        // built-in trust" — same effect as a typo. Pins the
-        // forward-compat contract: shipping trusted-npm.txt becomes
-        // a purely additive change.
+        // The shipped resources/trusted-npm.txt parses through the npm
+        // grammar (scope wildcards) and matches a package inside a
+        // trusted scope while rejecting one outside it.
         $vendors = (new TrustedVendorRegistry())->loadForProvider(ProviderId::NPM);
+
+        Assert::true($vendors->patterns !== [], 'npm trust file should ship at least one pattern');
+        Assert::true(
+            $vendors->trusts('@anthropic-ai/claude-code'),
+            '@anthropic-ai/* must trust a package in the scope',
+        );
+        Assert::false(
+            $vendors->trusts('@evil/x'),
+            'an untrusted scope must not be trusted',
+        );
+        Assert::false(
+            $vendors->trusts('lodash'),
+            'a bare name absent from the built-in list must not be trusted',
+        );
+    }
+
+    public function goProviderParsesBundledFileAndMatchesPrefixes(): void
+    {
+        // The shipped resources/trusted-go.txt parses through the go
+        // grammar (module-path prefixes) and matches module paths under
+        // trusted orgs while rejecting others.
+        $vendors = (new TrustedVendorRegistry())->loadForProvider(ProviderId::GO);
+
+        Assert::true($vendors->patterns !== [], 'go trust file should ship at least one pattern');
+        Assert::true(
+            $vendors->trusts('github.com/anthropics/anything'),
+            'github.com/anthropics/* must trust a module under the org',
+        );
+        Assert::true(
+            $vendors->trusts('github.com/golang/tools'),
+            'github.com/golang/* must trust a module under the org',
+        );
+        Assert::false(
+            $vendors->trusts('github.com/evil/x'),
+            'an untrusted org must not be trusted',
+        );
+    }
+
+    public function goWildcardMatchesArbitraryDepthUnderPrefix(): void
+    {
+        // Prefix (not single-segment) semantics: submodule paths and
+        // /vN major-version suffixes are deeper segments, so an
+        // org-level entry must reach them. Pins the depth decision.
+        $vendors = (new TrustedVendorRegistry())->loadForProvider(ProviderId::GO);
+
+        Assert::true(
+            $vendors->trusts('github.com/anthropics/repo/v2'),
+            'a /vN major-version path must stay trusted under the org prefix',
+        );
+        Assert::true(
+            $vendors->trusts('github.com/anthropics/repo/internal/tools'),
+            'a nested submodule path must stay trusted under the org prefix',
+        );
+    }
+
+    public function unregisteredProviderWithoutFileReturnsEmpty(): void
+    {
+        // A locked-vocabulary id that ships no built-in trust file
+        // (e.g. a remote-only provider) maps to "no built-in trust" —
+        // same effect as a typo.
+        $vendors = (new TrustedVendorRegistry())->loadForProvider(ProviderId::GITHUB);
 
         Assert::same($vendors->patterns, []);
     }
@@ -85,11 +145,11 @@ final class TrustedVendorRegistryTest
 
         foreach ($vendors->patterns as $pattern) {
             Assert::false(
-                \str_starts_with($pattern->raw, '#'),
-                'comment line leaked into trust list as pattern: ' . $pattern->raw,
+                \str_starts_with($pattern->raw(), '#'),
+                'comment line leaked into trust list as pattern: ' . $pattern->raw(),
             );
             Assert::notSame(
-                $pattern->raw,
+                $pattern->raw(),
                 '',
                 'blank line leaked into trust list',
             );

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -387,6 +387,70 @@ final class InitRunnerTest
         Assert::true(\str_contains($io->getOutput(), 'will not be discovered'));
     }
 
+    public function forceInteractiveFoldsLegacyTrustKeysAndRoundTripsThem(): void
+    {
+        // Regression guard: the interactive `--force` path reads the
+        // existing skills.json raw (no file migrators) so the wizard can
+        // show current values as defaults. A legacy flat `trusted` /
+        // `trusted-replace` / `local` file must still surface those as
+        // trust defaults; accepting every prompt verbatim must round-trip
+        // the config into the `dependencies` form without dropping the
+        // patterns or flipping `trusted-replace` back off.
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            (string) \json_encode(
+                [
+                    '$schema' => InitRunner::SCHEMA_URL,
+                    'target' => 'custom/skills',
+                    'trusted' => ['acme/*'],
+                    'trusted-replace' => true,
+                    'local' => ['composer' => true],
+                ],
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
+
+        // `setUserInputs` flips BufferIO into interactive mode, which is
+        // what routes the runner through the wizard. Empty answers accept
+        // each surfaced default; the final `yes` confirms the write.
+        $io = new BufferIO();
+        $io->setUserInputs([
+            '',    // target → keep custom/skills
+            '',    // aliases → keep none
+            '',    // trusted → keep acme/*
+            '',    // trusted-replace → keep true
+            '',    // discovery → keep default
+            '',    // auto-sync → keep default
+            'yes', // confirm write
+        ]);
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(force: true),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+
+        $written = $this->readSkillsJson();
+        Assert::same($written['target'] ?? null, 'custom/skills');
+        // The flat legacy keys are gone; trust lands under the canonical
+        // `dependencies.composer` block with both the patterns and the
+        // replace flag intact. `local.composer: true` is the composer
+        // default, so the wizard omits the redundant `enabled` toggle.
+        Assert::false(\array_key_exists('trusted', $written), 'flat trusted must not survive the rewrite');
+        Assert::false(
+            \array_key_exists('trusted-replace', $written),
+            'flat trusted-replace must not survive the rewrite',
+        );
+        Assert::false(\array_key_exists('local', $written), 'flat local must not survive the rewrite');
+        Assert::same(
+            $written['dependencies'] ?? null,
+            ['composer' => ['trusted' => ['acme/*'], 'trusted-replace' => true]],
+            'trust must round-trip into the dependencies form without loss',
+        );
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -451,6 +451,104 @@ final class InitRunnerTest
         );
     }
 
+    public function forceInteractivePreservesUnpromptedConfig(): void
+    {
+        // A rich existing skills.json carrying keys the wizard never prompts
+        // for: `sources`, `path-from-root`, a sibling `npm` block, and an
+        // explicit `composer.enabled: false`. Running `skills:init --force`
+        // interactively and pressing Enter through every prompt must rewrite
+        // the file WITHOUT dropping any of them — the six prompted knobs are
+        // the only ones the wizard owns.
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            (string) \json_encode(
+                [
+                    '$schema' => InitRunner::SCHEMA_URL,
+                    'target' => 'custom/skills',
+                    'aliases' => ['.claude/skills'],
+                    'dependencies' => [
+                        'composer' => ['enabled' => false, 'trusted' => ['acme/*']],
+                        'npm' => ['trusted' => ['@scope/*']],
+                    ],
+                    'path-from-root' => 'packages/api',
+                    'sources' => [['from' => 'dir', 'path' => '../shared/skills']],
+                ],
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
+
+        $io = new BufferIO();
+        $io->setUserInputs(['', '', '', '', '', '', 'yes']);
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(force: true),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+
+        $written = $this->readSkillsJson();
+        // Unprompted keys survive verbatim.
+        Assert::same($written['sources'] ?? null, [['from' => 'dir', 'path' => '../shared/skills']]);
+        Assert::same($written['path-from-root'] ?? null, 'packages/api');
+        // composer.enabled=false and the sibling npm block are preserved; the
+        // kept trusted list lands under dependencies.composer.
+        Assert::same($written['dependencies'] ?? null, [
+            'composer' => ['enabled' => false, 'trusted' => ['acme/*']],
+            'npm' => ['trusted' => ['@scope/*']],
+        ]);
+        // No legacy flat keys survive; keys come out in canonical order.
+        Assert::false(\array_key_exists('trusted', $written));
+        Assert::false(\array_key_exists('trusted-replace', $written));
+        Assert::false(\array_key_exists('local', $written));
+        Assert::false(\array_key_exists('remote', $written));
+        Assert::same(
+            \array_keys($written),
+            ['$schema', 'target', 'aliases', 'dependencies', 'path-from-root', 'sources'],
+        );
+    }
+
+    public function forceInteractiveMigratesLegacyRemoteAndFlatTrust(): void
+    {
+        // A legacy skills.json using the deprecated `remote` alias and the
+        // flat trust trio. The interactive `--force` path reads it raw, so
+        // the defaults normaliser must rename `remote` to `sources` and fold
+        // the flat trust into `dependencies` before the wizard preserves
+        // them. The rewritten file carries `sources` + `dependencies` and
+        // none of the legacy keys.
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            (string) \json_encode(
+                [
+                    '$schema' => InitRunner::SCHEMA_URL,
+                    'remote' => [['from' => 'dir', 'path' => '../shared/skills']],
+                    'trusted' => ['acme/*'],
+                ],
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
+
+        $io = new BufferIO();
+        $io->setUserInputs(['', '', '', '', '', '', 'yes']);
+
+        $code = (new InitRunner())->run(
+            Path::create($this->tmp),
+            $io,
+            new InitOptions(force: true),
+        );
+
+        Assert::same($code, Command::SUCCESS, 'stderr: ' . $io->getOutput());
+
+        $written = $this->readSkillsJson();
+        // `remote` renamed to the canonical `sources`, entries verbatim.
+        Assert::false(\array_key_exists('remote', $written), 'legacy remote must not survive');
+        Assert::same($written['sources'] ?? null, [['from' => 'dir', 'path' => '../shared/skills']]);
+        // Flat trust folded into dependencies.composer.
+        Assert::false(\array_key_exists('trusted', $written), 'flat trusted must not survive');
+        Assert::same($written['dependencies'] ?? null, ['composer' => ['trusted' => ['acme/*']]]);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Unit/Init/InitRunnerTest.php
+++ b/tests/Unit/Init/InitRunnerTest.php
@@ -41,9 +41,9 @@ final class InitRunnerTest
 
     public function standaloneModeCreatesStubWithSchemaAndProviderDefaults(): void
     {
-        // The stub advertises the `local` and `sources` knobs explicitly,
-        // even when their values match the defaults, so users discover
-        // them without reading docs.
+        // The stub advertises the `dependencies` and `sources` knobs
+        // explicitly, even when their values match the defaults, so users
+        // discover them without reading docs.
         $io = new BufferIO();
         $code = (new InitRunner())->run(
             Path::create($this->tmp),
@@ -54,13 +54,13 @@ final class InitRunnerTest
         Assert::same($code, Command::SUCCESS);
 
         $written = $this->readSkillsJson();
-        Assert::same(\array_keys($written), ['$schema', 'local', 'sources']);
+        Assert::same(\array_keys($written), ['$schema', 'dependencies', 'sources']);
         Assert::same(
             $written['$schema'],
             InitRunner::SCHEMA_URL,
             '$schema pointer must use the published GitHub raw URL',
         );
-        Assert::same($written['local'], ['composer' => true]);
+        Assert::same($written['dependencies'], ['composer' => true]);
         Assert::same($written['sources'], []);
 
         // Output advertises the mode so the user understands no composer.json
@@ -183,7 +183,10 @@ final class InitRunnerTest
 
         $skills = $this->readSkillsJson();
         Assert::same($skills['target'], 'custom/skills');
-        Assert::same($skills['trusted'], ['acme/*']);
+        // Flat `trusted` folds into the `dependencies.composer` block;
+        // the migrated file never carries the legacy key.
+        Assert::false(\array_key_exists('trusted', $skills));
+        Assert::same($skills['dependencies'], ['composer' => ['trusted' => ['acme/*']]]);
         Assert::same($skills['auto-sync'], true);
 
         // The migrated keys must be gone from composer.json.
@@ -279,7 +282,7 @@ final class InitRunnerTest
         );
 
         Assert::same($code, Command::SUCCESS);
-        Assert::same(\array_keys($this->readSkillsJson()), ['$schema', 'local', 'sources']);
+        Assert::same(\array_keys($this->readSkillsJson()), ['$schema', 'dependencies', 'sources']);
         Assert::true(\str_contains($io->getOutput(), 'no project keys to migrate'));
     }
 

--- a/tests/Unit/Init/InteractiveInitWizardTest.php
+++ b/tests/Unit/Init/InteractiveInitWizardTest.php
@@ -192,7 +192,13 @@ final class InteractiveInitWizardTest
 
         $result = (new InteractiveInitWizard())->run($io, []);
 
-        Assert::same($result['trusted'] ?? null, ['acme/*', 'vendor/pkg']);
+        // Trust lands under `dependencies.composer.trusted`, not the
+        // deprecated flat `trusted` key.
+        Assert::false(\array_key_exists('trusted', $result ?? []));
+        Assert::same(
+            $result['dependencies'] ?? null,
+            ['composer' => ['trusted' => ['acme/*', 'vendor/pkg']]],
+        );
     }
 
     public function trustedNoneTokenClearsExistingList(): void
@@ -213,11 +219,11 @@ final class InteractiveInitWizardTest
         ]);
 
         $result = (new InteractiveInitWizard())->run($io, [
-            'trusted' => ['acme/*', 'vendor/pkg'],
+            'dependencies' => ['composer' => ['trusted' => ['acme/*', 'vendor/pkg']]],
         ]);
 
         Assert::false(
-            \array_key_exists('trusted', $result ?? []),
+            \array_key_exists('dependencies', $result ?? []),
             'cleared trusted must not land in the result (empty list is the default)',
         );
     }
@@ -241,7 +247,9 @@ final class InteractiveInitWizardTest
 
         $result = (new InteractiveInitWizard())->run($io, []);
 
-        Assert::same($result['trusted-replace'] ?? null, true);
+        // trusted-replace lands under `dependencies.composer`; with no
+        // trusted patterns the composer object carries it alone.
+        Assert::same($result['dependencies'] ?? null, ['composer' => ['trusted-replace' => true]]);
         Assert::same($result['discovery'] ?? null, true);
         Assert::same($result['auto-sync'] ?? null, false);
     }
@@ -303,12 +311,13 @@ final class InteractiveInitWizardTest
         $result = (new InteractiveInitWizard())->run($io, [
             'target' => 'custom/skills',
             'aliases' => ['.claude/skills', '.cursor/skills'],
-            'trusted' => ['acme/*'],
+            'dependencies' => ['composer' => ['trusted' => ['acme/*']]],
         ]);
 
         Assert::same($result['target'] ?? null, 'custom/skills');
         Assert::same($result['aliases'] ?? null, ['.claude/skills', '.cursor/skills']);
-        Assert::same($result['trusted'] ?? null, ['acme/*']);
+        // Accepting the surfaced default re-emits it under the canonical key.
+        Assert::same($result['dependencies'] ?? null, ['composer' => ['trusted' => ['acme/*']]]);
     }
 
     /**

--- a/tests/Unit/Init/InteractiveInitWizardTest.php
+++ b/tests/Unit/Init/InteractiveInitWizardTest.php
@@ -320,6 +320,80 @@ final class InteractiveInitWizardTest
         Assert::same($result['dependencies'] ?? null, ['composer' => ['trusted' => ['acme/*']]]);
     }
 
+    public function preservesUnpromptedKeysAndMergesTrust(): void
+    {
+        // --force over a rich existing skills.json: the wizard prompts for
+        // only six knobs, but everything else in the file — `sources`,
+        // `path-from-root`, a sibling `npm` block, and composer's explicit
+        // `enabled: false` — must survive. Enter through every prompt: the
+        // surfaced trusted list is kept and lands under dependencies.composer.
+        $io = $this->ioWithAnswers([
+            '',    // target → keep custom/skills
+            '',    // aliases → keep .claude/skills
+            '',    // trusted → keep acme/*
+            '',    // trusted-replace → keep default (false)
+            '',    // discovery → keep default (false)
+            '',    // auto-sync → keep default (true)
+            'yes', // confirm write
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, [
+            'target' => 'custom/skills',
+            'aliases' => ['.claude/skills'],
+            'dependencies' => [
+                'composer' => ['enabled' => false, 'trusted' => ['acme/*']],
+                'npm' => ['trusted' => ['@scope/*']],
+            ],
+            'path-from-root' => 'packages/api',
+            'sources' => [['from' => 'dir', 'path' => '../shared/skills']],
+        ]);
+
+        // Unprompted keys survive verbatim.
+        Assert::same($result['sources'] ?? null, [['from' => 'dir', 'path' => '../shared/skills']]);
+        Assert::same($result['path-from-root'] ?? null, 'packages/api');
+        // The sibling npm entry and composer.enabled=false are preserved;
+        // the kept trusted list lands under dependencies.composer.
+        Assert::same($result['dependencies'] ?? null, [
+            'composer' => ['enabled' => false, 'trusted' => ['acme/*']],
+            'npm' => ['trusted' => ['@scope/*']],
+        ]);
+        // No legacy flat keys leak in.
+        Assert::false(\array_key_exists('trusted', $result ?? []));
+        Assert::false(\array_key_exists('trusted-replace', $result ?? []));
+        Assert::false(\array_key_exists('local', $result ?? []));
+        Assert::false(\array_key_exists('remote', $result ?? []));
+        // Canonical PROJECT_KEYS order.
+        Assert::same(
+            \array_keys($result ?? []),
+            ['target', 'aliases', 'dependencies', 'path-from-root', 'sources'],
+        );
+    }
+
+    public function preservedDisabledComposerSurvivesAddedTrust(): void
+    {
+        // A file that switched composer OFF (`enabled: false`) must keep that
+        // opt-out even as the user adds a fresh trusted pattern — losing it
+        // would silently re-broaden the discovery surface.
+        $io = $this->ioWithAnswers([
+            '',              // target
+            '',              // aliases
+            'acme/*',        // trusted → add a pattern
+            '',              // trusted-replace
+            '',              // discovery
+            '',              // auto-sync
+            'yes',
+        ]);
+
+        $result = (new InteractiveInitWizard())->run($io, [
+            'dependencies' => ['composer' => ['enabled' => false]],
+        ]);
+
+        Assert::same(
+            $result['dependencies'] ?? null,
+            ['composer' => ['enabled' => false, 'trusted' => ['acme/*']]],
+        );
+    }
+
     /**
      * @param list<string> $answers
      */


### PR DESCRIPTION
## What

The flat trust surface (\`trusted\`, \`trusted-replace\`) and the \`local\` toggle map merge into one per-package-manager block — **\`dependencies\`**:

```jsonc
{
  "dependencies": {
    "composer": { "enabled": true, "trusted": ["acme/*"], "trusted-replace": false },
    "npm":      { "trusted": ["@myorg/*"] },
    "go":       true
  }
}
```

## Why

- **Trust is ecosystem-scoped in reality.** The built-in list is already per-manager (\`resources/trusted-composer.txt\`, resolved by provider id), and the \`vendor/pkg\` pattern grammar cannot express npm names (\`@scope/pkg\`) or Go module paths (\`github.com/owner/mod\`). A per-manager \`trusted\` list is a precondition for the npm/go providers, not a style choice.
- **\`local\` stopped describing its content** the moment it grew past on/off toggles: the block configures how the project's *dependencies* become skill donors — the key now says that.

## Semantics

- Value is \`bool | object\`: \`true\` ≡ \`{"enabled": true}\`. \`enabled\` absent → per-manager default (composer on, npm/go off until their providers land). Configuring \`trusted\` does **not** implicitly enable a manager.
- Per-manager grammar: composer patterns validate as today; npm/go lists are locked structurally now, grammar-enforced when their providers ship.
- \`sources[]\` entries are unaffected — they are trusted by declaration and never consult these lists.

## Migration (same machinery as \`remote\` → \`sources\`)

- Write-mode commands restructure a legacy file in place: \`local\` map + flat trust keys fold into \`dependencies\` at the first legacy key's position, everything else byte-preserved, \`[migrate]\` notice. A fully-legacy file (\`remote\` + \`trusted\` + \`local\`) gets both migrations in one run.
- Read-only surfaces read the aliases and emit a \`[deprecated]\` notice; they never rewrite.
- Mixing \`dependencies\` with any legacy key in one block is a fatal config error — one security surface, one form.
- The interactive \`skills:init --force\` path folds legacy defaults before prompting (review caught a trust-broadening regression here — a legacy \`trusted-replace: true\` would have silently flipped off; fixed with round-trip coverage).

## Runtime

\`ProjectConfig\`'s existing fields are folded from the block, so \`SyncPlanner\`, \`DonorProviderBuilder\`, trust attribution and every downstream stage are untouched — behaviour parity between the flat form and its translation is pinned by tests. The full per-manager structure rides on \`ProjectConfig::$dependencies\`, ready for the npm/go providers.

## Tests

Unit matrix (forms, defaults, grammars, mixing, folding parity, migration edge cases, wizard round-trip), schema matrix (valid/deprecated/mixed/unknown), acceptance: in-place restructure + sync parity, read-only notice with byte-identical file, mixed-form failure, new-form trust approval, \`composer: false\` toggle, double-migration in one run.

\`composer test\`: **842 passed / 1 skipped**. \`composer psalm\`, \`composer cs:diff\` clean.

## Out of scope

npm/go provider implementations (config shape is now locked for them), per-manager \`--trust\` CLI scoping, built-in \`trusted-npm.txt\`/\`trusted-go.txt\` lists, internal renames (\`LOCAL_IDS\` etc.), alias removal (next major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope addendum

The built-in \`trusted-npm.txt\` / \`trusted-go.txt\` lists were originally listed as out of scope, but were pulled INTO this PR once the lists themselves were authored: the \`TrustedVendorRegistry\` now resolves them per provider id behind a \`TrustPattern\` abstraction (\`VendorPattern\` untouched for composer; new \`NpmPattern\`/\`GoPattern\` with per-ecosystem grammars, go wildcards using arbitrary-depth prefix semantics). Runtime consultation still arrives with the npm/go providers — the lists are wired and tested, not yet queried.
