### PR TITLE
fix: skip symlink entries when extracting a donor archive

### DIFF
--- a/src/Discovery/Provider/Source/HttpArchiveFetcher.php
+++ b/src/Discovery/Provider/Source/HttpArchiveFetcher.php
@@ -28,8 +28,9 @@ use LLM\Skills\Unpacker\UnpackerFactory;
  * 2. If the path already exists, return it — the cache is content-
  *    addressed-by-ref, so a hit means we have the right files.
  * 3. Otherwise, GET the URL via {@see HttpClient}, write the bytes to
- *    a temp zip file, list every entry name via the selected
- *    {@see ArchiveUnpacker} (zip-slip lexical check on each), extract,
+ *    a temp zip file, list every entry via the selected
+ *    {@see ArchiveUnpacker} (zip-slip lexical check on each name,
+ *    symlink entries collected for exclusion), extract,
  *    locate the single top-level directory inside the archive
  *    (GitHub's zipball wraps everything in `<owner>-<repo>-<sha>/`),
  *    and rename that directory into the cache location.
@@ -254,7 +255,7 @@ final readonly class HttpArchiveFetcher implements RemoteFetcher
         // anywhere on disk. Reject anything that does not lexically
         // resolve to a path inside `$scratch`.
         try {
-            $names = $unpacker->listEntries($tmpZip);
+            $entries = $unpacker->listEntries($tmpZip);
         } catch (UnpackerException $e) {
             throw new RemoteFetchException(
                 $ref,
@@ -263,12 +264,29 @@ final readonly class HttpArchiveFetcher implements RemoteFetcher
             );
         }
 
-        foreach ($names as $name) {
-            if (!self::isSafeZipEntryName($name)) {
+        foreach ($entries as $entry) {
+            if (!self::isSafeZipEntryName($entry->name)) {
                 throw new RemoteFetchException(
                     $ref,
-                    'archive contains an unsafe entry path "' . $name . '" — refusing to extract',
+                    'archive contains an unsafe entry path "' . $entry->name . '" — refusing to extract',
                 );
+            }
+        }
+
+        // Symlink entries are excluded from the extraction. Recreating
+        // a link on Windows needs `SeCreateSymbolicLinkPrivilege`,
+        // which an unelevated process outside Developer Mode does not
+        // hold; 7-Zip treats the refusal as a fatal error and exits
+        // non-zero, losing the whole archive over a single link.
+        // Excluding up front sidesteps that, and the plugin has no use
+        // for the links anyway: {@see \LLM\Skills\Filesystem\LinkGuard}
+        // refuses to copy symlinks into the target, so a donor whose
+        // *content* rides on symlinks (even a symlinked composer.json)
+        // is unsupported by design.
+        $exclude = [];
+        foreach ($entries as $entry) {
+            if ($entry->isSymlink) {
+                $exclude[] = $entry->name;
             }
         }
 
@@ -277,7 +295,7 @@ final readonly class HttpArchiveFetcher implements RemoteFetcher
         }
 
         try {
-            $unpacker->extractTo($tmpZip, $scratch);
+            $unpacker->extractTo($tmpZip, $scratch, $exclude);
         } catch (UnpackerException $e) {
             throw new RemoteFetchException(
                 $ref,

--- a/src/Unpacker/ArchiveUnpacker.php
+++ b/src/Unpacker/ArchiveUnpacker.php
@@ -10,10 +10,14 @@ namespace LLM\Skills\Unpacker;
  * The fetcher uses one implementation per fetch: `\ZipArchive`-backed
  * when ext-zip is available, otherwise a CLI tool wrapper. Two-step
  * contract (`listEntries` → `extractTo`) is deliberate: it lets the
- * fetcher run a lexical zip-slip check against every entry name
- * **before** the underlying tool writes any byte to disk. CLI tools
- * (`unzip`, `7z`) do not expose a hook for that validation, so we own
- * the safety boundary at this seam instead.
+ * fetcher inspect every entry **before** the underlying tool writes any
+ * byte to disk — running the lexical zip-slip check and deciding which
+ * entries to exclude from the extraction. CLI tools (`unzip`, `7z`) do
+ * not expose a hook for that validation, so we own the safety boundary
+ * at this seam instead. Keeping the decision in the fetcher also keeps
+ * both implementations producing the same tree for the same archive:
+ * per-unpacker code only translates the exclusion list into its tool's
+ * vocabulary.
  *
  * Implementations are not required to be pure — extraction is an
  * intentional filesystem effect.
@@ -34,29 +38,37 @@ interface ArchiveUnpacker
     public function id(): string;
 
     /**
-     * Enumerate entry names from the archive without writing anything
-     * to disk. Implementations must throw {@see UnpackerException} on
-     * malformed input.
+     * Enumerate archive entries without writing anything to disk.
+     * Implementations must throw {@see UnpackerException} on malformed
+     * input.
      *
      * @param non-empty-string $zipPath absolute path to a `.zip` file
      *
-     * @return list<string> raw entry names exactly as encoded in the archive
+     * @return list<ZipEntry> entries with raw names exactly as encoded in the archive
      *
      * @psalm-impure
      */
     public function listEntries(string $zipPath): array;
 
     /**
-     * Extract every entry into `$targetDir` preserving the archive's
-     * internal directory structure. The directory is expected to exist
-     * and be writable.
+     * Extract the archive into `$targetDir` preserving its internal
+     * directory structure. The directory is expected to exist and be
+     * writable.
+     *
+     * Entries named in `$excludeNames` are left unextracted. Exclusion
+     * is best-effort at the tool boundary — a CLI tool may be unable to
+     * express some names safely (see {@see CliUnpacker}) — so callers
+     * must tolerate an excluded entry occasionally reaching the target
+     * tree anyway.
      *
      * @param non-empty-string $zipPath absolute path to a `.zip` file
      * @param non-empty-string $targetDir absolute path of an existing scratch directory
+     * @param list<string> $excludeNames raw entry names, as returned by
+     *        {@see self::listEntries()}, to leave unextracted
      *
      * @throws UnpackerException when the underlying tool fails
      *
      * @psalm-impure
      */
-    public function extractTo(string $zipPath, string $targetDir): void;
+    public function extractTo(string $zipPath, string $targetDir, array $excludeNames = []): void;
 }

--- a/src/Unpacker/CliUnpacker.php
+++ b/src/Unpacker/CliUnpacker.php
@@ -28,6 +28,18 @@ use Symfony\Component\Process\Process;
  * zip-slip protection and apply `-y`-style overwrite by default;
  * validating ourselves is the only safe approach.
  *
+ * **Symlink entries are excluded from the extraction.** Recreating a
+ * symlink on Windows needs `SeCreateSymbolicLinkPrivilege`, which an
+ * unelevated process outside Developer Mode does not hold; 7-Zip treats
+ * the refusal as a fatal error and exits non-zero, losing the whole
+ * archive over a single link. Excluding the entries up front sidesteps
+ * that, and costs nothing downstream: {@see \LLM\Skills\Filesystem\LinkGuard}
+ * refuses to copy symlinks into the target anyway, so a link that did
+ * extract could never reach a skill directory. The exclusion is spelled
+ * per tool (`-x!<path>` for 7-Zip, `-x <path>` for Info-ZIP) rather than
+ * with 7-Zip's `-snl-`, which only exists from 21.02 and would break the
+ * p7zip 16.02 builds still shipping as `7za` on older distributions.
+ *
  * @psalm-suppress MissingImmutableAnnotation
  *         stateless wrapper, but `listEntries`/`extractTo` perform I/O
  */
@@ -37,6 +49,13 @@ final readonly class CliUnpacker implements ArchiveUnpacker
      * @param non-empty-string $id short identifier (`unzip`, `7z`, …) used in errors
      * @param non-empty-string $executablePath absolute path to the binary
      * @param non-empty-list<string> $extractArgsTemplate argv template with `{file}` / `{dir}` placeholders.
+     * @param list<string> $excludeArgsTemplate tokens appended once, ahead of the excluded
+     *        paths, when the archive holds any symlink entry. Info-ZIP takes a single `-x`
+     *        that opens a list; 7-Zip needs no opener, so this is empty for it. Nothing is
+     *        appended when the archive has no symlinks.
+     * @param non-empty-string|null $excludePathTemplate per-path template with a `{path}`
+     *        placeholder — `-x!{path}` for 7-Zip, `{path}` for Info-ZIP. `null` marks a tool
+     *        that cannot express exclusions, in which case extraction runs unfiltered.
      *
      * @psalm-mutation-free
      */
@@ -44,6 +63,8 @@ final readonly class CliUnpacker implements ArchiveUnpacker
         private string $id,
         private string $executablePath,
         private array $extractArgsTemplate,
+        private array $excludeArgsTemplate = [],
+        private ?string $excludePathTemplate = null,
         private ZipCentralDirectoryReader $cdReader = new ZipCentralDirectoryReader(),
         /**
          * Hard cap on `Process::setTimeout()` — extraction of a typical
@@ -82,6 +103,14 @@ final readonly class CliUnpacker implements ArchiveUnpacker
             ]);
         }
 
+        // Exclusions go last: Info-ZIP's `-x` opens a list that runs to
+        // the end of the command line, so it cannot precede `{file}` or
+        // `-d {dir}`. 7-Zip accepts `-x!` anywhere, so one ordering
+        // serves both.
+        foreach ($this->buildExclusions($zipPath) as $arg) {
+            $argv[] = $arg;
+        }
+
         $process = new Process($argv);
         $process->setTimeout($this->timeout);
 
@@ -102,5 +131,48 @@ final readonly class CliUnpacker implements ArchiveUnpacker
                 \trim($process->getErrorOutput() ?: $process->getOutput()),
             ));
         }
+    }
+
+    /**
+     * Argv tail excluding every symlink entry in the archive, or an
+     * empty list when there are none (the overwhelmingly common case)
+     * or when the tool has no exclusion syntax.
+     *
+     * A malformed Central Directory is swallowed here rather than
+     * raised: the fetcher already ran {@see self::listEntries()} over
+     * the same archive and would have rejected it, so a throw at this
+     * point could only turn a readable archive into a failure. Losing
+     * the exclusions degrades to the previous behaviour.
+     *
+     * @param non-empty-string $zipPath
+     *
+     * @return list<string>
+     */
+    private function buildExclusions(string $zipPath): array
+    {
+        if ($this->excludePathTemplate === null) {
+            return [];
+        }
+
+        try {
+            $entries = $this->cdReader->readEntries($zipPath);
+        } catch (UnpackerException) {
+            return [];
+        }
+
+        $paths = [];
+        foreach ($entries as $entry) {
+            if ($entry->isSymlink) {
+                // 7-Zip reads `-x!` patterns as wildcards, so an entry
+                // name containing `*` or `?` can exclude more than
+                // itself. Over-excluding only ever drops files the copy
+                // step would not have wanted (and cannot widen what
+                // gets written), so it is left as-is rather than
+                // guarded with a version-dependent literal-match switch.
+                $paths[] = \strtr($this->excludePathTemplate, ['{path}' => $entry->name]);
+            }
+        }
+
+        return $paths === [] ? [] : [...$this->excludeArgsTemplate, ...$paths];
     }
 }

--- a/src/Unpacker/CliUnpacker.php
+++ b/src/Unpacker/CliUnpacker.php
@@ -28,17 +28,12 @@ use Symfony\Component\Process\Process;
  * zip-slip protection and apply `-y`-style overwrite by default;
  * validating ourselves is the only safe approach.
  *
- * **Symlink entries are excluded from the extraction.** Recreating a
- * symlink on Windows needs `SeCreateSymbolicLinkPrivilege`, which an
- * unelevated process outside Developer Mode does not hold; 7-Zip treats
- * the refusal as a fatal error and exits non-zero, losing the whole
- * archive over a single link. Excluding the entries up front sidesteps
- * that, and costs nothing downstream: {@see \LLM\Skills\Filesystem\LinkGuard}
- * refuses to copy symlinks into the target anyway, so a link that did
- * extract could never reach a skill directory. The exclusion is spelled
- * per tool (`-x!<path>` for 7-Zip, `-x <path>` for Info-ZIP) rather than
- * with 7-Zip's `-snl-`, which only exists from 21.02 and would break the
- * p7zip 16.02 builds still shipping as `7za` on older distributions.
+ * Exclusions are expressed per tool (`-x!<path>` for 7-Zip, a `-x`
+ * list for Info-ZIP) rather than with 7-Zip's `-snl-` (skip symlinks),
+ * which only exists from 21.02 and would break the p7zip 16.02 builds
+ * still shipping as `7za` on older distributions. Both tools treat the
+ * exclusion argument as a wildcard pattern, not a literal name — see
+ * {@see self::isSafeExclusionName()} for how that is contained.
  *
  * @psalm-suppress MissingImmutableAnnotation
  *         stateless wrapper, but `listEntries`/`extractTo` perform I/O
@@ -50,12 +45,11 @@ final readonly class CliUnpacker implements ArchiveUnpacker
      * @param non-empty-string $executablePath absolute path to the binary
      * @param non-empty-list<string> $extractArgsTemplate argv template with `{file}` / `{dir}` placeholders.
      * @param list<string> $excludeArgsTemplate tokens appended once, ahead of the excluded
-     *        paths, when the archive holds any symlink entry. Info-ZIP takes a single `-x`
-     *        that opens a list; 7-Zip needs no opener, so this is empty for it. Nothing is
-     *        appended when the archive has no symlinks.
-     * @param non-empty-string|null $excludePathTemplate per-path template with a `{path}`
-     *        placeholder — `-x!{path}` for 7-Zip, `{path}` for Info-ZIP. `null` marks a tool
-     *        that cannot express exclusions, in which case extraction runs unfiltered.
+     *        paths, when anything is excluded. Info-ZIP takes a single `-x` that opens a
+     *        list; 7-Zip needs no opener, so this is empty for it. Nothing is appended
+     *        when nothing is excluded.
+     * @param non-empty-string $excludePathTemplate per-path template with a `{path}`
+     *        placeholder — `-x!{path}` for 7-Zip, `{path}` for Info-ZIP.
      *
      * @psalm-mutation-free
      */
@@ -63,8 +57,8 @@ final readonly class CliUnpacker implements ArchiveUnpacker
         private string $id,
         private string $executablePath,
         private array $extractArgsTemplate,
-        private array $excludeArgsTemplate = [],
-        private ?string $excludePathTemplate = null,
+        private array $excludeArgsTemplate,
+        private string $excludePathTemplate,
         private ZipCentralDirectoryReader $cdReader = new ZipCentralDirectoryReader(),
         /**
          * Hard cap on `Process::setTimeout()` — extraction of a typical
@@ -89,11 +83,11 @@ final readonly class CliUnpacker implements ArchiveUnpacker
     #[\Override]
     public function listEntries(string $zipPath): array
     {
-        return $this->cdReader->readNames($zipPath);
+        return $this->cdReader->readEntries($zipPath);
     }
 
     #[\Override]
-    public function extractTo(string $zipPath, string $targetDir): void
+    public function extractTo(string $zipPath, string $targetDir, array $excludeNames = []): void
     {
         $argv = [$this->executablePath];
         foreach ($this->extractArgsTemplate as $arg) {
@@ -107,7 +101,7 @@ final readonly class CliUnpacker implements ArchiveUnpacker
         // the end of the command line, so it cannot precede `{file}` or
         // `-d {dir}`. 7-Zip accepts `-x!` anywhere, so one ordering
         // serves both.
-        foreach ($this->buildExclusions($zipPath) as $arg) {
+        foreach ($this->buildExclusionArgs($excludeNames) as $arg) {
             $argv[] = $arg;
         }
 
@@ -134,42 +128,51 @@ final readonly class CliUnpacker implements ArchiveUnpacker
     }
 
     /**
-     * Argv tail excluding every symlink entry in the archive, or an
-     * empty list when there are none (the overwhelmingly common case)
-     * or when the tool has no exclusion syntax.
+     * Whether an entry name can be passed to the CLI tool as an
+     * exclusion without changing the command's meaning:
      *
-     * A malformed Central Directory is swallowed here rather than
-     * raised: the fetcher already ran {@see self::listEntries()} over
-     * the same archive and would have rejected it, so a throw at this
-     * point could only turn a readable archive into a failure. Losing
-     * the exclusions degrades to the previous behaviour.
+     * - a leading `-` reads as an option — Info-ZIP terminates its `-x`
+     *   list at the next switch-looking token and would apply the name
+     *   as a flag (`-j`, `-d …`) instead of an exclusion;
+     * - `*` / `?` / `[` are wildcard metacharacters in both tools'
+     *   exclusion patterns, so such a name could exclude entries other
+     *   than itself (silently dropping wanted files);
+     * - `\` doubles as a path separator / escape on Windows tool
+     *   builds, making the match platform-dependent.
      *
-     * @param non-empty-string $zipPath
+     * Neither tool offers list-terminating `--` semantics or a
+     * universally supported literal-match switch inside the supported
+     * version range, so unexpressible names are simply not excluded.
+     *
+     * @psalm-pure
+     */
+    private static function isSafeExclusionName(string $name): bool
+    {
+        return !\str_starts_with($name, '-') && \strpbrk($name, '*?[\\') === false;
+    }
+
+    /**
+     * Argv tail excluding the given entry names, or an empty list when
+     * nothing (expressible) is excluded.
+     *
+     * Names that {@see self::isSafeExclusionName()} rejects are dropped
+     * from the exclusion list, not from the archive: the tool extracts
+     * them like any other entry. That keeps a hostile name from
+     * touching the command line while never widening an exclusion
+     * beyond what the caller asked for.
+     *
+     * @param list<string> $excludeNames
      *
      * @return list<string>
+     *
+     * @psalm-mutation-free
      */
-    private function buildExclusions(string $zipPath): array
+    private function buildExclusionArgs(array $excludeNames): array
     {
-        if ($this->excludePathTemplate === null) {
-            return [];
-        }
-
-        try {
-            $entries = $this->cdReader->readEntries($zipPath);
-        } catch (UnpackerException) {
-            return [];
-        }
-
         $paths = [];
-        foreach ($entries as $entry) {
-            if ($entry->isSymlink) {
-                // 7-Zip reads `-x!` patterns as wildcards, so an entry
-                // name containing `*` or `?` can exclude more than
-                // itself. Over-excluding only ever drops files the copy
-                // step would not have wanted (and cannot widen what
-                // gets written), so it is left as-is rather than
-                // guarded with a version-dependent literal-match switch.
-                $paths[] = \strtr($this->excludePathTemplate, ['{path}' => $entry->name]);
+        foreach ($excludeNames as $name) {
+            if (self::isSafeExclusionName($name)) {
+                $paths[] = \strtr($this->excludePathTemplate, ['{path}' => $name]);
             }
         }
 

--- a/src/Unpacker/UnpackerFactory.php
+++ b/src/Unpacker/UnpackerFactory.php
@@ -144,10 +144,15 @@ final class UnpackerFactory
         // `-qq` quiet, `-d` target dir. Modern `unzip` strips leading
         // slashes and `..` segments on its own, but we do not rely on
         // it — entries are validated by the fetcher beforehand.
+        //
+        // `-x` opens an exclusion list that extends to the end of the
+        // command line, so the paths follow it as bare tokens.
         return new CliUnpacker(
             id: 'unzip',
             executablePath: $path,
             extractArgsTemplate: ['-qq', '{file}', '-d', '{dir}'],
+            excludeArgsTemplate: ['-x'],
+            excludePathTemplate: '{path}',
         );
     }
 
@@ -164,10 +169,15 @@ final class UnpackerFactory
         // scratch dir, so there's nothing to overwrite anyway).
         // `-o<dir>` is intentionally one token — 7z does not accept a
         // space between `-o` and the path.
+        //
+        // Each exclusion is its own `-x!<path>` token; there is no
+        // list-opening switch, hence the empty `excludeArgsTemplate`.
         return new CliUnpacker(
             id: $id,
             executablePath: $path,
             extractArgsTemplate: ['x', '-bb0', '-y', '{file}', '-o{dir}'],
+            excludeArgsTemplate: [],
+            excludePathTemplate: '-x!{path}',
         );
     }
 }

--- a/src/Unpacker/ZipArchiveUnpacker.php
+++ b/src/Unpacker/ZipArchiveUnpacker.php
@@ -137,7 +137,10 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
      */
     private static function keptNames(\ZipArchive $zip, array $excludeNames): array
     {
-        $excluded = \array_flip($excludeNames);
+        $excluded = [];
+        foreach ($excludeNames as $excludeName) {
+            $excluded["\0" . $excludeName] = true;
+        }
         $keep = [];
         $count = $zip->numFiles;
 
@@ -147,7 +150,7 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
             if (!\is_string($name)) {
                 throw new UnpackerException(\sprintf('entry %d has an unreadable name', $i));
             }
-            if (!isset($excluded[$name])) {
+            if (!isset($excluded["\0" . $name])) {
                 $keep[] = $name;
             }
         }

--- a/src/Unpacker/ZipArchiveUnpacker.php
+++ b/src/Unpacker/ZipArchiveUnpacker.php
@@ -12,6 +12,14 @@ namespace LLM\Skills\Unpacker;
  * Used in-process so no subprocess is spawned and no temp files beyond
  * the scratch directory are involved.
  *
+ * Symlink entries are skipped, matching {@see CliUnpacker}. `ext-zip`
+ * does not hit the Windows privilege wall the CLI tools do — it writes
+ * the link target as ordinary file content — but that leaves a file
+ * whose bytes are a path, which the copy step would then treat as real
+ * content. Since {@see \LLM\Skills\Filesystem\LinkGuard} drops symlinks
+ * on the way into the target anyway, dropping them at extraction keeps
+ * both unpackers producing the same tree.
+ *
  * @psalm-suppress MissingImmutableAnnotation
  *         stateless wrapper, but `listEntries`/`extractTo` perform I/O
  */
@@ -83,10 +91,72 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
             );
         }
 
-        $extracted = $zip->extractTo($targetDir);
-        $zip->close();
-        if ($extracted === false) {
-            throw new UnpackerException('failed to extract archive into ' . $targetDir);
+        try {
+            $keep = self::nonSymlinkNames($zip);
+
+            // An archive of nothing but symlinks leaves no work; calling
+            // extractTo() with an empty list is not portable.
+            if ($keep === []) {
+                return;
+            }
+
+            // Pass the explicit name list only when something was
+            // filtered out — the unfiltered call is the well-trodden
+            // path and stays byte-identical to the previous behaviour
+            // for the overwhelming majority of archives.
+            $extracted = $keep === null
+                ? $zip->extractTo($targetDir)
+                : $zip->extractTo($targetDir, $keep);
+            if ($extracted === false) {
+                throw new UnpackerException('failed to extract archive into ' . $targetDir);
+            }
+        } finally {
+            $zip->close();
         }
+    }
+
+    /**
+     * Names to extract, or `null` when the archive holds no symlink and
+     * the caller should extract everything.
+     *
+     * The Unix mode lives in the high 16 bits of the entry's external
+     * attributes and is only meaningful when the entry was written by a
+     * Unix-family host — an MS-DOS-host entry keeps DOS attribute flags
+     * there instead, so reading a mode out of it would classify
+     * arbitrary files as links.
+     *
+     * @return list<string>|null
+     *
+     * @psalm-suppress UndefinedClass,MixedAssignment,MixedMethodCall,MixedPropertyFetch,MixedArgument,MixedArgumentTypeCoercion
+     *         ext-zip is a soft requirement — guarded by the caller's class_exists
+     */
+    private static function nonSymlinkNames(\ZipArchive $zip): ?array
+    {
+        $keep = [];
+        $sawSymlink = false;
+        $count = $zip->numFiles;
+
+        for ($i = 0; $i < $count; $i++) {
+            /** @var string|false $name */
+            $name = $zip->getNameIndex($i);
+            if (!\is_string($name)) {
+                throw new UnpackerException(\sprintf('entry %d has an unreadable name', $i));
+            }
+
+            $opsys = 0;
+            $attr = 0;
+            if (
+                $zip->getExternalAttributesIndex($i, $opsys, $attr)
+                && $opsys === \ZipArchive::OPSYS_UNIX
+                && ((($attr >> 16) & 0xFFFF) & 0xF000) === 0xA000
+            ) {
+                $sawSymlink = true;
+                continue;
+            }
+
+            $keep[] = $name;
+        }
+
+        return $sawSymlink ? $keep : null;
     }
 }

--- a/src/Unpacker/ZipArchiveUnpacker.php
+++ b/src/Unpacker/ZipArchiveUnpacker.php
@@ -12,13 +12,10 @@ namespace LLM\Skills\Unpacker;
  * Used in-process so no subprocess is spawned and no temp files beyond
  * the scratch directory are involved.
  *
- * Symlink entries are skipped, matching {@see CliUnpacker}. `ext-zip`
- * does not hit the Windows privilege wall the CLI tools do — it writes
- * the link target as ordinary file content — but that leaves a file
- * whose bytes are a path, which the copy step would then treat as real
- * content. Since {@see \LLM\Skills\Filesystem\LinkGuard} drops symlinks
- * on the way into the target anyway, dropping them at extraction keeps
- * both unpackers producing the same tree.
+ * Exclusions are honoured exactly: `\ZipArchive::extractTo()` takes a
+ * literal name list, so every name the caller excludes is guaranteed to
+ * stay out of the target tree — unlike the pattern-based CLI switches
+ * in {@see CliUnpacker}.
  *
  * @psalm-suppress MissingImmutableAnnotation
  *         stateless wrapper, but `listEntries`/`extractTo` perform I/O
@@ -35,7 +32,7 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
     }
 
     /**
-     * @psalm-suppress UndefinedClass,MixedAssignment,MixedMethodCall,MixedPropertyFetch,MixedArgument
+     * @psalm-suppress UndefinedClass,MixedAssignment,MixedMethodCall,MixedPropertyFetch,MixedArgument,MixedArgumentTypeCoercion
      *         ext-zip is a soft requirement — guarded by class_exists above
      */
     #[\Override]
@@ -56,7 +53,7 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
         }
 
         try {
-            $names = [];
+            $entries = [];
             $count = $zip->numFiles;
             for ($i = 0; $i < $count; $i++) {
                 /** @var string|false $name */
@@ -64,9 +61,20 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
                 if (!\is_string($name)) {
                     throw new UnpackerException(\sprintf('entry %d has an unreadable name', $i));
                 }
-                $names[] = $name;
+
+                // `$opsys` is the same APPNOTE §4.4.2.2 host byte the
+                // raw Central Directory reader derives from
+                // `version_made_by`, so both paths share one symlink
+                // definition.
+                $opsys = 0;
+                $attr = 0;
+                $entries[] = new ZipEntry(
+                    name: $name,
+                    isSymlink: $zip->getExternalAttributesIndex($i, $opsys, $attr)
+                        && ZipEntry::isSymlinkAttributes($opsys, $attr),
+                );
             }
-            return $names;
+            return $entries;
         } finally {
             $zip->close();
         }
@@ -77,7 +85,7 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
      *         ext-zip is a soft requirement — guarded by class_exists above
      */
     #[\Override]
-    public function extractTo(string $zipPath, string $targetDir): void
+    public function extractTo(string $zipPath, string $targetDir, array $excludeNames = []): void
     {
         if (!\class_exists(\ZipArchive::class)) {
             throw new UnpackerException('ZipArchive is not available');
@@ -92,18 +100,17 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
         }
 
         try {
-            $keep = self::nonSymlinkNames($zip);
+            $keep = $excludeNames === [] ? null : self::keptNames($zip, $excludeNames);
 
-            // An archive of nothing but symlinks leaves no work; calling
-            // extractTo() with an empty list is not portable.
+            // Everything excluded leaves no work; calling extractTo()
+            // with an empty list is not portable.
             if ($keep === []) {
                 return;
             }
 
-            // Pass the explicit name list only when something was
-            // filtered out — the unfiltered call is the well-trodden
-            // path and stays byte-identical to the previous behaviour
-            // for the overwhelming majority of archives.
+            // The single-argument call is the far more exercised
+            // ext-zip code path and avoids any name round-trip through
+            // getNameIndex(); take it whenever nothing is excluded.
             $extracted = $keep === null
                 ? $zip->extractTo($targetDir)
                 : $zip->extractTo($targetDir, $keep);
@@ -116,24 +123,22 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
     }
 
     /**
-     * Names to extract, or `null` when the archive holds no symlink and
-     * the caller should extract everything.
+     * Entry names to pass to `\ZipArchive::extractTo()` — everything
+     * except `$excludeNames`. Reading the names back from the same
+     * `\ZipArchive` instance keeps them byte-identical to what
+     * `extractTo()` matches against.
      *
-     * The Unix mode lives in the high 16 bits of the entry's external
-     * attributes and is only meaningful when the entry was written by a
-     * Unix-family host — an MS-DOS-host entry keeps DOS attribute flags
-     * there instead, so reading a mode out of it would classify
-     * arbitrary files as links.
+     * @param non-empty-list<string> $excludeNames
      *
-     * @return list<string>|null
+     * @return list<string>
      *
      * @psalm-suppress UndefinedClass,MixedAssignment,MixedMethodCall,MixedPropertyFetch,MixedArgument,MixedArgumentTypeCoercion
      *         ext-zip is a soft requirement — guarded by the caller's class_exists
      */
-    private static function nonSymlinkNames(\ZipArchive $zip): ?array
+    private static function keptNames(\ZipArchive $zip, array $excludeNames): array
     {
+        $excluded = \array_flip($excludeNames);
         $keep = [];
-        $sawSymlink = false;
         $count = $zip->numFiles;
 
         for ($i = 0; $i < $count; $i++) {
@@ -142,21 +147,11 @@ final readonly class ZipArchiveUnpacker implements ArchiveUnpacker
             if (!\is_string($name)) {
                 throw new UnpackerException(\sprintf('entry %d has an unreadable name', $i));
             }
-
-            $opsys = 0;
-            $attr = 0;
-            if (
-                $zip->getExternalAttributesIndex($i, $opsys, $attr)
-                && $opsys === \ZipArchive::OPSYS_UNIX
-                && ((($attr >> 16) & 0xFFFF) & 0xF000) === 0xA000
-            ) {
-                $sawSymlink = true;
-                continue;
+            if (!isset($excluded[$name])) {
+                $keep[] = $name;
             }
-
-            $keep[] = $name;
         }
 
-        return $sawSymlink ? $keep : null;
+        return $keep;
     }
 }

--- a/src/Unpacker/ZipCentralDirectoryReader.php
+++ b/src/Unpacker/ZipCentralDirectoryReader.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace LLM\Skills\Unpacker;
 
 /**
- * Minimal zip Central Directory parser — enumerates entry names from
- * a `.zip` file **without** depending on `ext-zip`.
+ * Minimal zip Central Directory parser — enumerates entries from a
+ * `.zip` file **without** depending on `ext-zip`.
  *
- * Used by the CLI unpacker to validate every entry name lexically
- * (zip-slip guard) before invoking `unzip` / `7z`. The CLI tools do
- * not expose a pre-extraction validation hook and apply `-y`-style
- * overwrite semantics by default, so the only safe place to reject a
- * traversal entry is *here*, before any byte hits disk.
+ * Used by the CLI unpacker for two things: validating every entry name
+ * lexically (zip-slip guard) before invoking `unzip` / `7z`, and
+ * spotting symlink entries so they can be excluded from the extraction.
+ * The CLI tools expose no pre-extraction validation hook and apply
+ * `-y`-style overwrite semantics by default, so the only safe place to
+ * decide what gets written is *here*, before any byte hits disk.
  *
  * Scope:
  *
  * - reads the End-of-Central-Directory record by scanning back from
  *   EOF (signature `PK\x05\x06`, comment up to 65 535 bytes);
  * - walks the Central Directory file headers (signature `PK\x01\x02`),
- *   reading only the file-name field;
+ *   reading the file name plus `version_made_by` / `external_attr`;
  * - fails loud on zip64 sentinels — supported archives must fit in
  *   plain-zip metadata (entries < 65 535, sizes < 4 GiB). GitHub
  *   zipballs and Composer-shaped donor archives are comfortably under
@@ -43,6 +44,19 @@ final class ZipCentralDirectoryReader
     private const CD_HEADER_FIXED_SIZE = 46;
 
     /**
+     * `version_made_by` high byte for the Unix host (APPNOTE.TXT
+     * §4.4.2.2). Only archives written by a Unix-family host put a
+     * Unix mode in the high half of `external_attr`; on an MS-DOS-host
+     * archive those bits mean nothing and must not be read as one.
+     */
+    private const HOST_UNIX = 3;
+
+    /** Mask and value selecting `S_IFLNK` out of a Unix `st_mode`. */
+    private const S_IFMT = 0xF000;
+
+    private const S_IFLNK = 0xA000;
+
+    /**
      * @param non-empty-string $zipPath
      *
      * @return list<string> entry names in central-directory order
@@ -50,6 +64,24 @@ final class ZipCentralDirectoryReader
      * @throws UnpackerException on missing / truncated / zip64 archives
      */
     public function readNames(string $zipPath): array
+    {
+        return \array_map(
+            static fn(ZipEntry $entry): string => $entry->name,
+            $this->readEntries($zipPath),
+        );
+    }
+
+    /**
+     * Same walk as {@see self::readNames()}, keeping the symlink flag
+     * each entry carries.
+     *
+     * @param non-empty-string $zipPath
+     *
+     * @return list<ZipEntry> entries in central-directory order
+     *
+     * @throws UnpackerException on missing / truncated / zip64 archives
+     */
+    public function readEntries(string $zipPath): array
     {
         $size = @\filesize($zipPath);
         if ($size === false || $size < self::EOCD_MIN_SIZE) {
@@ -125,13 +157,13 @@ final class ZipCentralDirectoryReader
     }
 
     /**
-     * @return list<string>
+     * @return list<ZipEntry>
      *
      * @psalm-pure
      */
     private static function parseCentralDirectory(string $cd, int $entries): array
     {
-        $names = [];
+        $out = [];
         $pos = 0;
         $len = \strlen($cd);
 
@@ -149,6 +181,12 @@ final class ZipCentralDirectoryReader
                 ));
             }
 
+            /** @var array{made_by: int}|false $madeBy */
+            $madeBy = @\unpack('vmade_by', \substr($cd, $pos + 4, 2));
+            if ($madeBy === false) {
+                throw new UnpackerException('failed to parse central-directory version_made_by');
+            }
+
             /** @var array{name_len: int, extra_len: int, comment_len: int}|false $lengths */
             $lengths = @\unpack(
                 'vname_len/vextra_len/vcomment_len',
@@ -156,6 +194,12 @@ final class ZipCentralDirectoryReader
             );
             if ($lengths === false) {
                 throw new UnpackerException('failed to parse central-directory header lengths');
+            }
+
+            /** @var array{external_attr: int}|false $attrs */
+            $attrs = @\unpack('Vexternal_attr', \substr($cd, $pos + 38, 4));
+            if ($attrs === false) {
+                throw new UnpackerException('failed to parse central-directory external_attr');
             }
 
             $nameLen = $lengths['name_len'];
@@ -167,11 +211,35 @@ final class ZipCentralDirectoryReader
                 throw new UnpackerException('central directory truncated mid-name');
             }
 
-            $names[] = \substr($cd, $nameStart, $nameLen);
+            $out[] = new ZipEntry(
+                name: \substr($cd, $nameStart, $nameLen),
+                isSymlink: self::isSymlink($madeBy['made_by'], $attrs['external_attr']),
+            );
             $pos = $nameStart + $nameLen + $extraLen + $commentLen;
         }
 
-        return $names;
+        return $out;
+    }
+
+    /**
+     * Decide whether a Central Directory header describes a symlink.
+     *
+     * The Unix mode lives in the high 16 bits of `external_attr`, but
+     * only when `version_made_by`'s high byte says the archive was
+     * written by a Unix-family host. On an MS-DOS-host archive the low
+     * bits are DOS attribute flags and the high half is unspecified, so
+     * reading a mode out of it would classify arbitrary entries as
+     * links.
+     *
+     * @psalm-pure
+     */
+    private static function isSymlink(int $versionMadeBy, int $externalAttr): bool
+    {
+        if (($versionMadeBy >> 8) !== self::HOST_UNIX) {
+            return false;
+        }
+
+        return ((($externalAttr >> 16) & 0xFFFF) & self::S_IFMT) === self::S_IFLNK;
     }
 
     /**

--- a/src/Unpacker/ZipCentralDirectoryReader.php
+++ b/src/Unpacker/ZipCentralDirectoryReader.php
@@ -8,9 +8,9 @@ namespace LLM\Skills\Unpacker;
  * Minimal zip Central Directory parser — enumerates entries from a
  * `.zip` file **without** depending on `ext-zip`.
  *
- * Used by the CLI unpacker for two things: validating every entry name
- * lexically (zip-slip guard) before invoking `unzip` / `7z`, and
- * spotting symlink entries so they can be excluded from the extraction.
+ * Backs {@see CliUnpacker::listEntries()}: the fetcher uses the listing
+ * to validate every entry name lexically (zip-slip guard) and to spot
+ * symlink entries it wants excluded, all before invoking `unzip` / `7z`.
  * The CLI tools expose no pre-extraction validation hook and apply
  * `-y`-style overwrite semantics by default, so the only safe place to
  * decide what gets written is *here*, before any byte hits disk.
@@ -42,19 +42,6 @@ final class ZipCentralDirectoryReader
     private const ZIP64_UINT16_SENTINEL = 0xFFFF;
     private const EOCD_MIN_SIZE = 22;
     private const CD_HEADER_FIXED_SIZE = 46;
-
-    /**
-     * `version_made_by` high byte for the Unix host (APPNOTE.TXT
-     * §4.4.2.2). Only archives written by a Unix-family host put a
-     * Unix mode in the high half of `external_attr`; on an MS-DOS-host
-     * archive those bits mean nothing and must not be read as one.
-     */
-    private const HOST_UNIX = 3;
-
-    /** Mask and value selecting `S_IFLNK` out of a Unix `st_mode`. */
-    private const S_IFMT = 0xF000;
-
-    private const S_IFLNK = 0xA000;
 
     /**
      * @param non-empty-string $zipPath
@@ -172,39 +159,21 @@ final class ZipCentralDirectoryReader
                 throw new UnpackerException('central directory truncated mid-header');
             }
 
-            /** @var array{sig: int}|false $sig */
-            $sig = @\unpack('Vsig', \substr($cd, $pos, 4));
-            if ($sig === false || $sig['sig'] !== self::CD_FILE_HEADER_SIGNATURE) {
+            // One unpack over the fixed 46-byte header; `@n` repositions
+            // to the field offsets given in APPNOTE.TXT §4.3.12.
+            /** @var array{sig: int, made_by: int, name_len: int, extra_len: int, comment_len: int, external_attr: int}|false $fields */
+            $fields = @\unpack(
+                'Vsig/vmade_by/@28/vname_len/vextra_len/vcomment_len/@38/Vexternal_attr',
+                \substr($cd, $pos, self::CD_HEADER_FIXED_SIZE),
+            );
+            if ($fields === false || $fields['sig'] !== self::CD_FILE_HEADER_SIGNATURE) {
                 throw new UnpackerException(\sprintf(
                     'unexpected signature at central-directory offset %d — archive is malformed',
                     $pos,
                 ));
             }
 
-            /** @var array{made_by: int}|false $madeBy */
-            $madeBy = @\unpack('vmade_by', \substr($cd, $pos + 4, 2));
-            if ($madeBy === false) {
-                throw new UnpackerException('failed to parse central-directory version_made_by');
-            }
-
-            /** @var array{name_len: int, extra_len: int, comment_len: int}|false $lengths */
-            $lengths = @\unpack(
-                'vname_len/vextra_len/vcomment_len',
-                \substr($cd, $pos + 28, 6),
-            );
-            if ($lengths === false) {
-                throw new UnpackerException('failed to parse central-directory header lengths');
-            }
-
-            /** @var array{external_attr: int}|false $attrs */
-            $attrs = @\unpack('Vexternal_attr', \substr($cd, $pos + 38, 4));
-            if ($attrs === false) {
-                throw new UnpackerException('failed to parse central-directory external_attr');
-            }
-
-            $nameLen = $lengths['name_len'];
-            $extraLen = $lengths['extra_len'];
-            $commentLen = $lengths['comment_len'];
+            $nameLen = $fields['name_len'];
 
             $nameStart = $pos + self::CD_HEADER_FIXED_SIZE;
             if ($nameStart + $nameLen > $len) {
@@ -213,33 +182,15 @@ final class ZipCentralDirectoryReader
 
             $out[] = new ZipEntry(
                 name: \substr($cd, $nameStart, $nameLen),
-                isSymlink: self::isSymlink($madeBy['made_by'], $attrs['external_attr']),
+                isSymlink: ZipEntry::isSymlinkAttributes(
+                    $fields['made_by'] >> 8,
+                    $fields['external_attr'],
+                ),
             );
-            $pos = $nameStart + $nameLen + $extraLen + $commentLen;
+            $pos = $nameStart + $nameLen + $fields['extra_len'] + $fields['comment_len'];
         }
 
         return $out;
-    }
-
-    /**
-     * Decide whether a Central Directory header describes a symlink.
-     *
-     * The Unix mode lives in the high 16 bits of `external_attr`, but
-     * only when `version_made_by`'s high byte says the archive was
-     * written by a Unix-family host. On an MS-DOS-host archive the low
-     * bits are DOS attribute flags and the high half is unspecified, so
-     * reading a mode out of it would classify arbitrary entries as
-     * links.
-     *
-     * @psalm-pure
-     */
-    private static function isSymlink(int $versionMadeBy, int $externalAttr): bool
-    {
-        if (($versionMadeBy >> 8) !== self::HOST_UNIX) {
-            return false;
-        }
-
-        return ((($externalAttr >> 16) & 0xFFFF) & self::S_IFMT) === self::S_IFLNK;
     }
 
     /**

--- a/src/Unpacker/ZipEntry.php
+++ b/src/Unpacker/ZipEntry.php
@@ -13,13 +13,31 @@ namespace LLM\Skills\Unpacker;
 final readonly class ZipEntry
 {
     /**
+     * `version_made_by` high byte for the Unix host (APPNOTE.TXT
+     * §4.4.2.2, value 3).
+     */
+    public const HOST_UNIX = 3;
+
+    /**
+     * `version_made_by` high byte for the OS X / Darwin host
+     * (APPNOTE.TXT §4.4.2.2, value 19). Darwin is a Unix family member
+     * and stores the same `st_mode` layout in `external_attr`.
+     */
+    public const HOST_DARWIN = 19;
+
+    /** Mask and value selecting `S_IFLNK` out of a Unix `st_mode`. */
+    private const S_IFMT = 0xF000;
+
+    private const S_IFLNK = 0xA000;
+
+    /**
      * @param string $name raw entry name exactly as encoded in the archive —
      *        no decoding, no separator normalisation. The zip-slip check and the
      *        CLI exclusion switches both need the archive's own spelling.
      * @param bool $isSymlink entry stores a symlink target rather than file content.
      *        Only ever true for archives written by a Unix-family host: the flag is
      *        derived from the Unix mode in `external_attr`, which MS-DOS-host
-     *        archives do not carry. See {@see ZipCentralDirectoryReader}.
+     *        archives do not carry. See {@see self::isSymlinkAttributes()}.
      *
      * @psalm-mutation-free
      */
@@ -27,4 +45,30 @@ final readonly class ZipEntry
         public string $name,
         public bool $isSymlink,
     ) {}
+
+    /**
+     * Decide whether Central Directory attributes describe a symlink.
+     *
+     * The Unix mode lives in the high 16 bits of `external_attr`, but
+     * only when the entry was written by a Unix-family host. On an
+     * MS-DOS-host entry those bits are unspecified (the low bits are
+     * DOS attribute flags), so reading a mode out of them would
+     * classify arbitrary entries as links.
+     *
+     * `$hostByte` is APPNOTE.TXT §4.4.2.2's "version made by" high
+     * byte. `\ZipArchive::getExternalAttributesIndex()` yields the
+     * same value as its `$opsys` out-parameter, so both the raw
+     * Central Directory reader and the ext-zip path can share this
+     * single definition.
+     *
+     * @psalm-pure
+     */
+    public static function isSymlinkAttributes(int $hostByte, int $externalAttr): bool
+    {
+        if ($hostByte !== self::HOST_UNIX && $hostByte !== self::HOST_DARWIN) {
+            return false;
+        }
+
+        return (($externalAttr >> 16) & self::S_IFMT) === self::S_IFLNK;
+    }
 }

--- a/src/Unpacker/ZipEntry.php
+++ b/src/Unpacker/ZipEntry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Unpacker;
+
+/**
+ * One Central Directory entry, reduced to the two facts the extraction
+ * pipeline acts on: the raw name and whether it is a symbolic link.
+ *
+ * @psalm-immutable
+ */
+final readonly class ZipEntry
+{
+    /**
+     * @param string $name raw entry name exactly as encoded in the archive —
+     *        no decoding, no separator normalisation. The zip-slip check and the
+     *        CLI exclusion switches both need the archive's own spelling.
+     * @param bool $isSymlink entry stores a symlink target rather than file content.
+     *        Only ever true for archives written by a Unix-family host: the flag is
+     *        derived from the Unix mode in `external_attr`, which MS-DOS-host
+     *        archives do not carry. See {@see ZipCentralDirectoryReader}.
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public string $name,
+        public bool $isSymlink,
+    ) {}
+}

--- a/tests/Feature/SourceProviderEndToEndTest.php
+++ b/tests/Feature/SourceProviderEndToEndTest.php
@@ -16,6 +16,7 @@ use LLM\Skills\Discovery\Provider\Source\RemoteDonorRef;
 use LLM\Skills\Discovery\Provider\Source\RemoteFetcher;
 use LLM\Skills\Discovery\Provider\Source\SourceProvider;
 use LLM\Skills\Discovery\Provider\Source\SkillsJsonDonorRefSource;
+use LLM\Skills\Tests\Fixture\ZipFixtures;
 use LLM\Skills\Tests\Testo\Filesystem;
 use LLM\Skills\Unpacker\ArchiveUnpacker;
 use LLM\Skills\Unpacker\CliUnpacker;
@@ -54,6 +55,8 @@ use Testo\Test;
 #[Covers(HttpArchiveFetcher::class)]
 final class SourceProviderEndToEndTest
 {
+    use ZipFixtures;
+
     private string $tmp;
 
     public function SourceEntryResolvesFetchesAndProducesDonor(): void
@@ -127,12 +130,49 @@ final class SourceProviderEndToEndTest
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
         }
 
-        // Real-world shape: a skills repo whose AGENTS.md is a symlink
-        // to CLAUDE.md. The whole donor used to be lost over that one
-        // entry — 7-Zip cannot recreate a link on Windows without
-        // SeCreateSymbolicLinkPrivilege and exits non-zero. The link is
-        // now excluded at extraction, and since LinkGuard refuses to
-        // copy symlinks anyway, nothing downstream misses it.
+        $this->runSymlinkDonorScenario(unpacker: null);
+    }
+
+    public function donorShippingASymlinkAlsoSurvivesTheCliFallbackPath(): void
+    {
+        // Same scenario forced onto the CLI unpacker: the exclusion has
+        // to travel through the real `unzip` / `7z` argv (`-x` list /
+        // `-x!<path>` pattern) with the nested `<topDir>/AGENTS.md`
+        // name every GitHub zipball produces. This is the environment
+        // the original failure occurred in — machines without ext-zip.
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+        if (!\function_exists('proc_open')) {
+            Assert::true(true);
+            return;
+        }
+
+        $cli = (new UnpackerFactory(
+            finder: new ExecutableFinder(),
+            hasZipArchive: static fn(): bool => false,
+            hasProcOpen: static fn(): bool => true,
+        ))->detect();
+        if (!$cli instanceof CliUnpacker) {
+            // No `unzip` / `7z*` on this machine — the CLI path is not
+            // exercisable. The ZipArchive variant above still ran.
+            Assert::true(true);
+            return;
+        }
+
+        $this->runSymlinkDonorScenario(unpacker: $cli);
+    }
+
+    /**
+     * Real-world shape: a skills repo whose AGENTS.md is a symlink to
+     * CLAUDE.md. The whole donor used to be lost over that one entry —
+     * 7-Zip cannot recreate a link on Windows without
+     * SeCreateSymbolicLinkPrivilege and exits non-zero. The fetcher
+     * excludes the link at extraction, and since LinkGuard refuses to
+     * copy symlinks anyway, nothing downstream misses it.
+     */
+    private function runSymlinkDonorScenario(?ArchiveUnpacker $unpacker): void
+    {
         \file_put_contents($this->tmp . '/skills.json', \json_encode([
             'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
@@ -162,7 +202,7 @@ final class SourceProviderEndToEndTest
 
         $provider = new SourceProvider(
             new SkillsJsonDonorRefSource(new HostAdapterRegistry(new GithubAdapter($http))),
-            new HttpArchiveFetcher($http, Path::create($this->tmp)),
+            new HttpArchiveFetcher($http, Path::create($this->tmp), unpacker: $unpacker),
         );
 
         $result = $provider->discover(Path::create($this->tmp));
@@ -783,9 +823,6 @@ final class SourceProviderEndToEndTest
      *
      * @param non-empty-string $topDir
      * @param array<string, string> $files relative paths inside the top dir → file contents
-     */
-    /**
-     * @param array<string, string> $files
      * @param list<string> $symlinks keys of `$files` to store as symlink entries —
      *        flagged with the Unix mode (`S_IFLNK | 0777`) in the high half of
      *        `external_attr`, exactly as a GitHub zipball of a repo containing
@@ -809,7 +846,7 @@ final class SourceProviderEndToEndTest
             $entry = $topDir . '/' . $relPath;
             $zip->addFromString($entry, $content);
             if (\in_array($relPath, $symlinks, true)) {
-                $zip->setExternalAttributesName($entry, \ZipArchive::OPSYS_UNIX, 0xA1FF << 16);
+                $zip->setExternalAttributesName($entry, \ZipArchive::OPSYS_UNIX, self::ZIP_MODE_SYMLINK << 16);
             }
         }
         $zip->close();

--- a/tests/Feature/SourceProviderEndToEndTest.php
+++ b/tests/Feature/SourceProviderEndToEndTest.php
@@ -121,6 +121,67 @@ final class SourceProviderEndToEndTest
         Assert::true(\str_contains((string) \file_get_contents($skillFile), 'name: hello'));
     }
 
+    public function donorShippingASymlinkStillProducesItsSkills(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // Real-world shape: a skills repo whose AGENTS.md is a symlink
+        // to CLAUDE.md. The whole donor used to be lost over that one
+        // entry — 7-Zip cannot recreate a link on Windows without
+        // SeCreateSymbolicLinkPrivilege and exits non-zero. The link is
+        // now excluded at extraction, and since LinkGuard refuses to
+        // copy symlinks anyway, nothing downstream misses it.
+        \file_put_contents($this->tmp . '/skills.json', \json_encode([
+            'sources' => [
+                ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $zipBytes = $this->buildGithubStyleZip(
+            topDir: 'acme-skills-v1.0.0',
+            files: [
+                'composer.json' => \json_encode([
+                    'name' => 'acme/skills',
+                    'extra' => ['skills' => ['source' => 'skills']],
+                ], \JSON_THROW_ON_ERROR),
+                'CLAUDE.md' => 'real content',
+                'AGENTS.md' => 'CLAUDE.md',
+                'skills/hello/SKILL.md' => "---\nname: hello\n---\nhi",
+            ],
+            symlinks: ['AGENTS.md'],
+        );
+
+        $http = self::stubHttp([
+            'https://api.github.com/repos/acme/skills/zipball/v1.0.0' => new HttpResponse(
+                statusCode: 200,
+                body: $zipBytes,
+            ),
+        ]);
+
+        $provider = new SourceProvider(
+            new SkillsJsonDonorRefSource(new HostAdapterRegistry(new GithubAdapter($http))),
+            new HttpArchiveFetcher($http, Path::create($this->tmp)),
+        );
+
+        $result = $provider->discover(Path::create($this->tmp));
+
+        Assert::same($result->failures, []);
+        Assert::count($result->donors, 1);
+
+        $root = $result->donors[0]->packageRoot;
+        Assert::true(
+            \is_file((string) $root->join('skills/hello/SKILL.md')),
+            'the symlink must not cost the donor its skills',
+        );
+        Assert::true(\is_file((string) $root->join('CLAUDE.md')));
+        Assert::false(
+            \file_exists((string) $root->join('AGENTS.md')),
+            'the symlink entry itself must be skipped',
+        );
+    }
+
     public function tildeConstraintResolvesThroughTagListingToTheHighestMatch(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
@@ -723,7 +784,14 @@ final class SourceProviderEndToEndTest
      * @param non-empty-string $topDir
      * @param array<string, string> $files relative paths inside the top dir → file contents
      */
-    private function buildGithubStyleZip(string $topDir, array $files): string
+    /**
+     * @param array<string, string> $files
+     * @param list<string> $symlinks keys of `$files` to store as symlink entries —
+     *        flagged with the Unix mode (`S_IFLNK | 0777`) in the high half of
+     *        `external_attr`, exactly as a GitHub zipball of a repo containing
+     *        symlinks does
+     */
+    private function buildGithubStyleZip(string $topDir, array $files, array $symlinks = []): string
     {
         $tmpZip = \tempnam(\sys_get_temp_dir(), 'feature-zip-');
         if ($tmpZip === false) {
@@ -738,7 +806,11 @@ final class SourceProviderEndToEndTest
         // entry so the extracted tree has a clear root. Mimic that.
         $zip->addEmptyDir($topDir);
         foreach ($files as $relPath => $content) {
-            $zip->addFromString($topDir . '/' . $relPath, $content);
+            $entry = $topDir . '/' . $relPath;
+            $zip->addFromString($entry, $content);
+            if (\in_array($relPath, $symlinks, true)) {
+                $zip->setExternalAttributesName($entry, \ZipArchive::OPSYS_UNIX, 0xA1FF << 16);
+            }
         }
         $zip->close();
 

--- a/tests/Fixture/ZipFixtures.php
+++ b/tests/Fixture/ZipFixtures.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Fixture;
+
+/**
+ * Builders for `.zip` fixture archives, shared by every test that needs
+ * one. All builders require `ext-zip` — callers self-skip when
+ * `\ZipArchive` is unavailable.
+ *
+ * The Unix-mode constants encode the `external_attr` high half exactly
+ * as `git archive` and GitHub's zipball endpoint store it, so archives
+ * built here match the real-world donor shape byte-for-byte where the
+ * extraction pipeline cares.
+ */
+trait ZipFixtures
+{
+    /** Unix `st_mode` of a symlink entry: `S_IFLNK | 0777`. */
+    private const ZIP_MODE_SYMLINK = 0xA1FF;
+
+    /** Unix `st_mode` of a regular file entry: `S_IFREG | 0644`. */
+    private const ZIP_MODE_REGULAR = 0x81A4;
+
+    /**
+     * Fixture archive with default (MS-DOS-host) entries — no Unix
+     * modes in `external_attr`.
+     *
+     * @param non-empty-string $dir existing directory to place the archive in
+     * @param array<string, string> $files entry name → file contents
+     *
+     * @return non-empty-string absolute path of the built archive
+     */
+    private static function buildZipIn(string $dir, array $files): string
+    {
+        $zipPath = $dir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+        }
+        $zip->close();
+        return $zipPath;
+    }
+
+    /**
+     * Fixture archive whose entries carry Unix modes: `$symlinks` names
+     * get {@see self::ZIP_MODE_SYMLINK} in the high half of
+     * `external_attr`, everything else {@see self::ZIP_MODE_REGULAR}.
+     * For a symlink entry the content is the link target, exactly as a
+     * real archive stores it.
+     *
+     * @param non-empty-string $dir existing directory to place the archive in
+     * @param array<string, string> $files entry name → file contents
+     * @param list<string> $symlinks names from `$files` to flag as links
+     *
+     * @return non-empty-string absolute path of the built archive
+     */
+    private static function buildUnixZipIn(string $dir, array $files, array $symlinks = []): string
+    {
+        $zipPath = $dir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+            $zip->setExternalAttributesName(
+                $name,
+                \ZipArchive::OPSYS_UNIX,
+                (\in_array($name, $symlinks, true) ? self::ZIP_MODE_SYMLINK : self::ZIP_MODE_REGULAR) << 16,
+            );
+        }
+        $zip->close();
+        return $zipPath;
+    }
+}

--- a/tests/Unit/Unpacker/CliUnpackerTest.php
+++ b/tests/Unit/Unpacker/CliUnpackerTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Unpacker;
 
+use LLM\Skills\Tests\Fixture\ZipFixtures;
 use LLM\Skills\Unpacker\CliUnpacker;
 use LLM\Skills\Unpacker\UnpackerException;
 use LLM\Skills\Unpacker\UnpackerFactory;
+use LLM\Skills\Unpacker\ZipEntry;
 use Symfony\Component\Process\ExecutableFinder;
 use Testo\Assert;
 use Testo\Codecov\Covers;
@@ -31,6 +33,8 @@ use Testo\Test;
 #[Covers(CliUnpacker::class)]
 final class CliUnpackerTest
 {
+    use ZipFixtures;
+
     private string $tmpDir;
 
     #[BeforeTest]
@@ -53,7 +57,7 @@ final class CliUnpackerTest
         }
         $unpacker = $this->pickCliUnpackerOrSkip();
 
-        $zipPath = $this->buildZip([
+        $zipPath = self::buildZipIn($this->tmpDir, [
             'root.txt' => 'top-level',
             'sub/nested.txt' => 'nested content',
         ]);
@@ -74,15 +78,18 @@ final class CliUnpackerTest
         }
         $unpacker = $this->pickCliUnpackerOrSkip();
 
-        $zipPath = $this->buildZip([
+        $zipPath = self::buildZipIn($this->tmpDir, [
             'one.txt' => 'a',
             'dir/two.txt' => 'b',
         ]);
 
-        Assert::same($unpacker->listEntries($zipPath), ['one.txt', 'dir/two.txt']);
+        Assert::same(
+            \array_map(static fn(ZipEntry $e): string => $e->name, $unpacker->listEntries($zipPath)),
+            ['one.txt', 'dir/two.txt'],
+        );
     }
 
-    public function liveCliExtractorSkipsSymlinkEntriesInsteadOfFailing(): void
+    public function liveCliExtractorSkipsExcludedSymlinkEntriesInsteadOfFailing(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
@@ -90,33 +97,77 @@ final class CliUnpackerTest
         $unpacker = $this->pickCliUnpackerOrSkip();
 
         // Reproduces the reported break: a donor shipping AGENTS.md as
-        // a symlink to CLAUDE.md. 7-Zip on Windows cannot create the
-        // link without SeCreateSymbolicLinkPrivilege and used to exit 2,
-        // taking the entire donor down with it.
-        $zipPath = $this->buildZipWithSymlinks(
+        // a symlink to CLAUDE.md, nested under the top-level directory
+        // every GitHub zipball wraps its contents in. 7-Zip on Windows
+        // cannot create the link without SeCreateSymbolicLinkPrivilege
+        // and used to exit 2, taking the entire donor down with it. The
+        // nesting matters: the exclusion pattern must match a name with
+        // a `/` separator against the real tool.
+        $zipPath = self::buildUnixZipIn(
+            $this->tmpDir,
             [
-                'CLAUDE.md' => 'real content',
-                'AGENTS.md' => 'CLAUDE.md',
-                'skills/hello/SKILL.md' => 'hi',
+                'acme-skills-v1/CLAUDE.md' => 'real content',
+                'acme-skills-v1/AGENTS.md' => 'CLAUDE.md',
+                'acme-skills-v1/skills/hello/SKILL.md' => 'hi',
             ],
-            symlinks: ['AGENTS.md'],
+            symlinks: ['acme-skills-v1/AGENTS.md'],
         );
+
+        // Mirror the fetcher's contract: symlink entries flagged by
+        // listEntries() are handed back to extractTo() as exclusions.
+        $exclude = [];
+        foreach ($unpacker->listEntries($zipPath) as $entry) {
+            if ($entry->isSymlink) {
+                $exclude[] = $entry->name;
+            }
+        }
+        Assert::same($exclude, ['acme-skills-v1/AGENTS.md']);
 
         $target = $this->tmpDir . '/out-symlink';
         \mkdir($target, 0o777, true);
 
-        $unpacker->extractTo($zipPath, $target);
+        $unpacker->extractTo($zipPath, $target, $exclude);
 
         Assert::true(
-            \is_file($target . '/CLAUDE.md'),
+            \is_file($target . '/acme-skills-v1/CLAUDE.md'),
             'a symlink entry must not stop the rest of the archive from extracting',
         );
-        Assert::same(\file_get_contents($target . '/CLAUDE.md'), 'real content');
-        Assert::true(\is_file($target . '/skills/hello/SKILL.md'));
+        Assert::same(\file_get_contents($target . '/acme-skills-v1/CLAUDE.md'), 'real content');
+        Assert::true(\is_file($target . '/acme-skills-v1/skills/hello/SKILL.md'));
         Assert::false(
-            \file_exists($target . '/AGENTS.md') || \is_link($target . '/AGENTS.md'),
-            'the symlink entry must be excluded from the extraction',
+            \file_exists($target . '/acme-skills-v1/AGENTS.md') || \is_link($target . '/acme-skills-v1/AGENTS.md'),
+            'the excluded symlink entry must not be extracted',
         );
+    }
+
+    public function liveCliExtractorNeverPassesOptionOrWildcardShapedExclusions(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+        $unpacker = $this->pickCliUnpackerOrSkip();
+
+        $zipPath = self::buildZipIn($this->tmpDir, [
+            'root.txt' => 'top-level',
+            'sub/keep.txt' => 'kept',
+            'sub/skip.txt' => 'skipped',
+        ]);
+
+        $target = $this->tmpDir . '/out-guard';
+        \mkdir($target, 0o777, true);
+
+        // `-j` reads as an Info-ZIP option (junk paths) and `sub/*` as
+        // a wildcard covering keep.txt — passing either verbatim would
+        // corrupt or over-shrink the extraction. Both must be dropped
+        // from the argv; only the literal name may take effect.
+        $unpacker->extractTo($zipPath, $target, ['-j', 'sub/*', 'sub/skip.txt']);
+
+        Assert::true(\is_file($target . '/root.txt'));
+        Assert::true(
+            \is_file($target . '/sub/keep.txt'),
+            'a wildcard-shaped exclusion must not widen to sibling entries',
+        );
+        Assert::false(\file_exists($target . '/sub/skip.txt'));
     }
 
     public function failedExtractionSurfacesAsUnpackerException(): void
@@ -155,47 +206,6 @@ final class CliUnpackerTest
             throw new SkipTest('no CLI extractor (unzip / 7z / 7zz / 7za) on PATH');
         }
         return $unpacker;
-    }
-
-    /**
-     * Fixture archive whose `$symlinks` entries carry the Unix mode a
-     * real symlink has (`S_IFLNK | 0777`) in the high half of
-     * `external_attr` — the shape `git archive` and GitHub zipballs
-     * produce, and the one the CLI tools act on.
-     *
-     * @param array<string, string> $files
-     * @param list<string> $symlinks names from `$files` to flag as links
-     */
-    private function buildZipWithSymlinks(array $files, array $symlinks): string
-    {
-        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        foreach ($files as $name => $content) {
-            $zip->addFromString($name, $content);
-            $zip->setExternalAttributesName(
-                $name,
-                \ZipArchive::OPSYS_UNIX,
-                (\in_array($name, $symlinks, true) ? 0xA1FF : 0x81A4) << 16,
-            );
-        }
-        $zip->close();
-        return $zipPath;
-    }
-
-    /**
-     * @param array<string, string> $files
-     */
-    private function buildZip(array $files): string
-    {
-        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        foreach ($files as $name => $content) {
-            $zip->addFromString($name, $content);
-        }
-        $zip->close();
-        return $zipPath;
     }
 
     private function cleanup(string $path): void

--- a/tests/Unit/Unpacker/CliUnpackerTest.php
+++ b/tests/Unit/Unpacker/CliUnpackerTest.php
@@ -82,6 +82,43 @@ final class CliUnpackerTest
         Assert::same($unpacker->listEntries($zipPath), ['one.txt', 'dir/two.txt']);
     }
 
+    public function liveCliExtractorSkipsSymlinkEntriesInsteadOfFailing(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+        $unpacker = $this->pickCliUnpackerOrSkip();
+
+        // Reproduces the reported break: a donor shipping AGENTS.md as
+        // a symlink to CLAUDE.md. 7-Zip on Windows cannot create the
+        // link without SeCreateSymbolicLinkPrivilege and used to exit 2,
+        // taking the entire donor down with it.
+        $zipPath = $this->buildZipWithSymlinks(
+            [
+                'CLAUDE.md' => 'real content',
+                'AGENTS.md' => 'CLAUDE.md',
+                'skills/hello/SKILL.md' => 'hi',
+            ],
+            symlinks: ['AGENTS.md'],
+        );
+
+        $target = $this->tmpDir . '/out-symlink';
+        \mkdir($target, 0o777, true);
+
+        $unpacker->extractTo($zipPath, $target);
+
+        Assert::true(
+            \is_file($target . '/CLAUDE.md'),
+            'a symlink entry must not stop the rest of the archive from extracting',
+        );
+        Assert::same(\file_get_contents($target . '/CLAUDE.md'), 'real content');
+        Assert::true(\is_file($target . '/skills/hello/SKILL.md'));
+        Assert::false(
+            \file_exists($target . '/AGENTS.md') || \is_link($target . '/AGENTS.md'),
+            'the symlink entry must be excluded from the extraction',
+        );
+    }
+
     public function failedExtractionSurfacesAsUnpackerException(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
@@ -118,6 +155,32 @@ final class CliUnpackerTest
             throw new SkipTest('no CLI extractor (unzip / 7z / 7zz / 7za) on PATH');
         }
         return $unpacker;
+    }
+
+    /**
+     * Fixture archive whose `$symlinks` entries carry the Unix mode a
+     * real symlink has (`S_IFLNK | 0777`) in the high half of
+     * `external_attr` — the shape `git archive` and GitHub zipballs
+     * produce, and the one the CLI tools act on.
+     *
+     * @param array<string, string> $files
+     * @param list<string> $symlinks names from `$files` to flag as links
+     */
+    private function buildZipWithSymlinks(array $files, array $symlinks): string
+    {
+        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+            $zip->setExternalAttributesName(
+                $name,
+                \ZipArchive::OPSYS_UNIX,
+                (\in_array($name, $symlinks, true) ? 0xA1FF : 0x81A4) << 16,
+            );
+        }
+        $zip->close();
+        return $zipPath;
     }
 
     /**

--- a/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
+++ b/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
@@ -62,6 +62,78 @@ final class ZipCentralDirectoryReaderTest
         Assert::same($names, ['first.txt', 'sub/second.txt', 'sub/third.txt']);
     }
 
+    public function flagsUnixSymlinkEntriesAndLeavesRegularFilesAlone(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // The shape that broke extraction in the wild: a repo shipping
+        // AGENTS.md as a symlink to CLAUDE.md. 7-Zip on Windows cannot
+        // recreate the link without SeCreateSymbolicLinkPrivilege and
+        // aborts the whole archive, so the entry has to be identifiable
+        // before extraction starts.
+        $zipPath = $this->buildZipWithSymlinks(
+            [
+                'CLAUDE.md' => 'real content',
+                'AGENTS.md' => 'CLAUDE.md',
+                'skills/hello/SKILL.md' => 'hi',
+            ],
+            symlinks: ['AGENTS.md'],
+        );
+
+        $entries = (new ZipCentralDirectoryReader())->readEntries($zipPath);
+
+        $flags = [];
+        foreach ($entries as $entry) {
+            $flags[$entry->name] = $entry->isSymlink;
+        }
+
+        Assert::same($flags, [
+            'CLAUDE.md' => false,
+            'AGENTS.md' => true,
+            'skills/hello/SKILL.md' => false,
+        ]);
+    }
+
+    public function doesNotReadASymlinkModeOutOfADosHostArchive(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // `buildZip()` leaves the default MS-DOS host, so the high half
+        // of external_attr carries no Unix mode. Reading one anyway
+        // would classify arbitrary entries as links and silently drop
+        // them from every extraction.
+        $entries = (new ZipCentralDirectoryReader())->readEntries(
+            $this->buildZip(['plain.txt' => 'x']),
+        );
+
+        Assert::count($entries, 1);
+        Assert::false($entries[0]->isSymlink);
+    }
+
+    public function readNamesKeepsSymlinkEntriesInTheZipSlipListing(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // Excluding symlinks from extraction must not exclude them from
+        // validation: a link named `../escape` still has to reach the
+        // fetcher's lexical zip-slip check.
+        $zipPath = $this->buildZipWithSymlinks(
+            ['keep.txt' => 'x', 'link' => 'keep.txt'],
+            symlinks: ['link'],
+        );
+
+        Assert::same(
+            (new ZipCentralDirectoryReader())->readNames($zipPath),
+            ['keep.txt', 'link'],
+        );
+    }
+
     public function survivesAnArchiveCommentThatLooksLikeAnEocdSignature(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
@@ -163,6 +235,32 @@ final class ZipCentralDirectoryReaderTest
     /**
      * @param array<string, string> $files
      */
+    /**
+     * Build a fixture archive, marking `$symlinks` with the Unix mode a
+     * real symlink entry carries (`S_IFLNK | 0777`) in the high half of
+     * `external_attr` — the same shape `git archive` and GitHub zipballs
+     * produce.
+     *
+     * @param array<string, string> $files
+     * @param list<string> $symlinks names from `$files` to flag as links
+     */
+    private function buildZipWithSymlinks(array $files, array $symlinks): string
+    {
+        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+            $zip->setExternalAttributesName(
+                $name,
+                \ZipArchive::OPSYS_UNIX,
+                (\in_array($name, $symlinks, true) ? 0xA1FF : 0x81A4) << 16,
+            );
+        }
+        $zip->close();
+        return $zipPath;
+    }
+
     private function buildZip(array $files): string
     {
         $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';

--- a/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
+++ b/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LLM\Skills\Tests\Unit\Unpacker;
 
+use LLM\Skills\Tests\Fixture\ZipFixtures;
 use LLM\Skills\Unpacker\UnpackerException;
 use LLM\Skills\Unpacker\ZipCentralDirectoryReader;
 use Testo\Assert;
@@ -31,6 +32,8 @@ use Testo\Test;
 #[Covers(ZipCentralDirectoryReader::class)]
 final class ZipCentralDirectoryReaderTest
 {
+    use ZipFixtures;
+
     private string $tmpDir;
 
     #[BeforeTest]
@@ -52,7 +55,7 @@ final class ZipCentralDirectoryReaderTest
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
         }
 
-        $zipPath = $this->buildZip([
+        $zipPath = self::buildZipIn($this->tmpDir,[
             'first.txt' => 'a',
             'sub/second.txt' => 'bb',
             'sub/third.txt' => 'ccc',
@@ -73,7 +76,8 @@ final class ZipCentralDirectoryReaderTest
         // recreate the link without SeCreateSymbolicLinkPrivilege and
         // aborts the whole archive, so the entry has to be identifiable
         // before extraction starts.
-        $zipPath = $this->buildZipWithSymlinks(
+        $zipPath = self::buildUnixZipIn(
+            $this->tmpDir,
             [
                 'CLAUDE.md' => 'real content',
                 'AGENTS.md' => 'CLAUDE.md',
@@ -96,18 +100,47 @@ final class ZipCentralDirectoryReaderTest
         ]);
     }
 
+    public function flagsSymlinkEntriesWrittenByADarwinHost(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // APPNOTE.TXT §4.4.2.2 lists OS X (Darwin, host byte 19)
+        // separately from UNIX (3), but Darwin tools store the same
+        // `st_mode` layout in external_attr — a link written on macOS
+        // must be recognised just like a Linux-written one.
+        $zipPath = $this->tmpDir . '/darwin.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('file.txt', 'x');
+        $zip->addFromString('link', 'file.txt');
+        $zip->setExternalAttributesName('file.txt', 19, self::ZIP_MODE_REGULAR << 16);
+        $zip->setExternalAttributesName('link', 19, self::ZIP_MODE_SYMLINK << 16);
+        $zip->close();
+
+        $entries = (new ZipCentralDirectoryReader())->readEntries($zipPath);
+
+        $flags = [];
+        foreach ($entries as $entry) {
+            $flags[$entry->name] = $entry->isSymlink;
+        }
+
+        Assert::same($flags, ['file.txt' => false, 'link' => true]);
+    }
+
     public function doesNotReadASymlinkModeOutOfADosHostArchive(): void
     {
         if (!\class_exists(\ZipArchive::class)) {
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
         }
 
-        // `buildZip()` leaves the default MS-DOS host, so the high half
-        // of external_attr carries no Unix mode. Reading one anyway
-        // would classify arbitrary entries as links and silently drop
-        // them from every extraction.
+        // `buildZipIn()` leaves the default MS-DOS host, so the high
+        // half of external_attr carries no Unix mode. Reading one
+        // anyway would classify arbitrary entries as links and silently
+        // drop them from every extraction.
         $entries = (new ZipCentralDirectoryReader())->readEntries(
-            $this->buildZip(['plain.txt' => 'x']),
+            self::buildZipIn($this->tmpDir,['plain.txt' => 'x']),
         );
 
         Assert::count($entries, 1);
@@ -123,7 +156,8 @@ final class ZipCentralDirectoryReaderTest
         // Excluding symlinks from extraction must not exclude them from
         // validation: a link named `../escape` still has to reach the
         // fetcher's lexical zip-slip check.
-        $zipPath = $this->buildZipWithSymlinks(
+        $zipPath = self::buildUnixZipIn(
+            $this->tmpDir,
             ['keep.txt' => 'x', 'link' => 'keep.txt'],
             symlinks: ['link'],
         );
@@ -232,46 +266,6 @@ final class ZipCentralDirectoryReaderTest
         Assert::same($names, ['safe.txt', '../escape.txt']);
     }
 
-    /**
-     * @param array<string, string> $files
-     */
-    /**
-     * Build a fixture archive, marking `$symlinks` with the Unix mode a
-     * real symlink entry carries (`S_IFLNK | 0777`) in the high half of
-     * `external_attr` — the same shape `git archive` and GitHub zipballs
-     * produce.
-     *
-     * @param array<string, string> $files
-     * @param list<string> $symlinks names from `$files` to flag as links
-     */
-    private function buildZipWithSymlinks(array $files, array $symlinks): string
-    {
-        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        foreach ($files as $name => $content) {
-            $zip->addFromString($name, $content);
-            $zip->setExternalAttributesName(
-                $name,
-                \ZipArchive::OPSYS_UNIX,
-                (\in_array($name, $symlinks, true) ? 0xA1FF : 0x81A4) << 16,
-            );
-        }
-        $zip->close();
-        return $zipPath;
-    }
-
-    private function buildZip(array $files): string
-    {
-        $zipPath = $this->tmpDir . '/' . \bin2hex(\random_bytes(4)) . '.zip';
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        foreach ($files as $name => $content) {
-            $zip->addFromString($name, $content);
-        }
-        $zip->close();
-        return $zipPath;
-    }
 
     private function cleanup(string $path): void
     {

--- a/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
+++ b/tests/Unit/Unpacker/ZipCentralDirectoryReaderTest.php
@@ -55,7 +55,7 @@ final class ZipCentralDirectoryReaderTest
             throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
         }
 
-        $zipPath = self::buildZipIn($this->tmpDir,[
+        $zipPath = self::buildZipIn($this->tmpDir, [
             'first.txt' => 'a',
             'sub/second.txt' => 'bb',
             'sub/third.txt' => 'ccc',


### PR DESCRIPTION
## 🔍 What was changed

- Symlink entries are skipped when extracting a donor archive. The decision now lives in one place — `HttpArchiveFetcher` inspects the listing (`ArchiveUnpacker::listEntries()` returns `ZipEntry` objects with an `isSymlink` flag) and passes the names to `extractTo(..., $excludeNames)`; each unpacker only translates the list into its tool's vocabulary — `-x!<path>` for 7-Zip, one `-x` opening a path list for Info-ZIP, a literal keep-list for `ZipArchive::extractTo()`. Both paths produce an identical tree, and the CLI path no longer parses the Central Directory twice per extraction.
- The symlink bit-test is defined once, in `ZipEntry::isSymlinkAttributes()`, shared by the raw CD reader and the ext-zip path (`$opsys` and `version_made_by >> 8` are the same APPNOTE §4.4.2.2 host byte). It also recognises Darwin-host (19) entries, which store the same `st_mode` layout as Unix (3).
- `CliUnpacker` refuses to place option- or wildcard-shaped names on the command line: a leading `-` reads as an Info-ZIP option after `-x`, and `*` / `?` / `[` are wildcard metacharacters in both tools' exclusion patterns, so a crafted entry name could inject flags or silently exclude wanted files. Such names are left unexcluded instead — the tool treats them like any other entry, which at worst reproduces the tool's own symlink failure loudly.
- Nothing changes for archives without symlinks: the exclusion tail is only built when a flagged entry exists, and `ZipArchiveUnpacker` still makes the unfiltered `extractTo()` call.

## Why?

A donor whose repo ships a symlink was lost entirely on Windows. Recreating one needs `SeCreateSymbolicLinkPrivilege`, which an unelevated process outside Developer Mode does not hold; 7-Zip treats the refusal as fatal and exits 2, so `CliUnpacker` threw and took the whole archive with it. The trigger in the field was `mattpocock/skills`, where `AGENTS.md` is a symlink to `CLAUDE.md` — one file, and the donor disappeared.

Skipping costs nothing: `LinkGuard` already refuses to copy symlinks into the target, so an extracted link could never have reached a skill directory. A donor whose *content* rides on symlinks (e.g. a symlinked `composer.json`) is unsupported by design.

## Review notes

- The privilege error arrives OEM-encoded, so it reaches the user as mojibake (`?????? ?? ???????? ?ॡ㥬묨 ?ࠢ???` is «Клиент не обладает требуемыми правами»). Worth knowing before chasing it as an encoding bug in our own output.
- Exclusions are spelled per tool rather than with 7-Zip's `-snl-`, which reads as the obvious one-flag fix. `-snl` only exists from 21.02, so it would fail outright on the p7zip 16.02 builds still shipping as `7za` on older distributions.
- Based on #32 — the added Feature test asserts on `DonorDiscoveryResult::$failures`, which that PR introduces. Merge #32 first and GitHub will retarget this to `master`.

## Checklist

- How was this tested:
  - [x] Unit tests added — symlink flagging (Unix and Darwin hosts), the MS-DOS-host guard (a DOS entry must not be read as a link), and `readNames()` still listing symlinks so the zip-slip check keeps seeing them
  - [x] Unit tests added — `CliUnpacker` drives a real 7-Zip / Info-ZIP subprocess: a nested `<topDir>/AGENTS.md` symlink exclusion travels through the real argv, and option-/wildcard-shaped exclusion names are dropped from it (`-j` must not junk paths, `sub/*` must not widen). Self-skips where no CLI extractor is on PATH
  - [x] Feature tests added — offline end-to-end through the real adapter, fetcher and unpacker: a donor with a symlinked `AGENTS.md` still yields its skills, on both the ext-zip and the forced-CLI path
  - [x] Verified the regression is real: the same fixture through 7-Zip 26.01 without the exclusion exits 2 (`Sub items Errors: 1`), and the reporter's live `mattpocock/skills` zipball reproduced it
  - [x] Full suite green locally (904 passed, 1 skipped), psalm clean, `cs:diff` clean
  - [ ] Not covered by an acceptance test — forcing the CLI extractor needs a PHP without `ext-zip`, which the sandbox cannot control; the `php -S`-served acceptance fixture remains the documented follow-up. The Feature test forces the CLI unpacker through the real fetcher instead, which is what actually broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
