### PR TITLE
feat: accept a list of directories in `extra.skills.source`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ After `skills:update`, the consumer project gets:
 - Loose files at the root of `source` (e.g. `README.md`) are ignored.
 - A package without `extra.skills` is not a donor by default — see [Auto-discovery](#auto-discovery).
 
+`source` also accepts a **list** of directories — useful for a monorepo published as a
+single package whose skills live per component:
+
+```jsonc
+// vendor/acme/components/composer.json
+{
+  "extra": {
+    "skills": { "source": ["packages/dto/skills", "packages/auth/skills"] }
+  }
+}
+```
+
+Every listed directory is scanned the same way as a single `source`; skills from all of
+them are synced together.
+
 
 ## Project configuration
 

--- a/src/Config/Mapper/VendorConfigMapper.php
+++ b/src/Config/Mapper/VendorConfigMapper.php
@@ -10,8 +10,15 @@ use LLM\Skills\Config\VendorConfig;
 
 /**
  * Maps a donor package's `extra` array (as returned by
- * {@see \Composer\Package\PackageInterface::getExtra()}) into a typed
- * {@see VendorConfig}.
+ * {@see \Composer\Package\PackageInterface::getExtra()}) into typed
+ * {@see VendorConfig} rows.
+ *
+ * `extra.skills.source` is either a single relative directory or a list
+ * of them (a monorepo published as one package may ship skills in
+ * several non-contiguous locations). Each entry becomes its own
+ * {@see VendorConfig} row — the same one-row-per-container shape
+ * auto-discovery already produces — so nothing downstream has to know
+ * how many directories the donor declared.
  *
  * Two distinct outcomes:
  *
@@ -55,9 +62,11 @@ final readonly class VendorConfigMapper
      * @param Path $packageRoot absolute install path of the package
      * @param mixed $extra raw value of `composer.json` `extra` field
      *
+     * @return non-empty-list<VendorConfig> one row per declared source directory
+     *
      * @throws MalformedVendorConfig when `extra.skills` is present but invalid
      */
-    public function fromExtra(string $packageName, Path $packageRoot, mixed $extra): VendorConfig
+    public function fromExtra(string $packageName, Path $packageRoot, mixed $extra): array
     {
         if (!\is_array($extra)) {
             throw new MalformedVendorConfig($packageName, 'extra must be an object');
@@ -68,32 +77,56 @@ final readonly class VendorConfigMapper
             throw new MalformedVendorConfig($packageName, 'extra.skills must be an object');
         }
 
+        /** @var mixed $source */
         $source = $skills['source'] ?? null;
-        if (!\is_string($source) || $source === '') {
+        $sources = \is_array($source) ? \array_values($source) : [$source];
+        if ($sources === []) {
             throw new MalformedVendorConfig(
                 $packageName,
-                'extra.skills.source must be a non-empty string',
+                'extra.skills.source must not be an empty list',
             );
         }
 
-        if (Path::create($source)->isAbsolute()) {
-            throw new MalformedVendorConfig(
-                $packageName,
-                'extra.skills.source must be a relative path',
+        $donors = [];
+        $seen = [];
+        /** @var mixed $entry */
+        foreach ($sources as $entry) {
+            if (!\is_string($entry) || $entry === '') {
+                throw new MalformedVendorConfig(
+                    $packageName,
+                    'extra.skills.source must be a non-empty string or a list of non-empty strings',
+                );
+            }
+
+            if (Path::create($entry)->isAbsolute()) {
+                throw new MalformedVendorConfig(
+                    $packageName,
+                    'extra.skills.source must be a relative path',
+                );
+            }
+
+            if (!$packageRoot->join($entry)->match($packageRoot->join('*'))) {
+                throw new MalformedVendorConfig(
+                    $packageName,
+                    'extra.skills.source must not escape the package root',
+                );
+            }
+
+            if (isset($seen[$entry])) {
+                throw new MalformedVendorConfig(
+                    $packageName,
+                    'extra.skills.source must not contain duplicate entries',
+                );
+            }
+            $seen[$entry] = true;
+
+            $donors[] = new VendorConfig(
+                packageName: $packageName,
+                packageRoot: $packageRoot,
+                source: $entry,
             );
         }
 
-        if (!$packageRoot->join($source)->match($packageRoot->join('*'))) {
-            throw new MalformedVendorConfig(
-                $packageName,
-                'extra.skills.source must not escape the package root',
-            );
-        }
-
-        return new VendorConfig(
-            packageName: $packageName,
-            packageRoot: $packageRoot,
-            source: $source,
-        );
+        return $donors;
     }
 }

--- a/src/Discovery/DonorDiscovery.php
+++ b/src/Discovery/DonorDiscovery.php
@@ -13,7 +13,8 @@ use LLM\Skills\Config\VendorConfig;
 
 /**
  * Walks Composer's local repository and maps every package's
- * `extra.skills` block into a {@see \LLM\Skills\Config\VendorConfig}.
+ * `extra.skills` block into {@see \LLM\Skills\Config\VendorConfig} rows —
+ * one per declared source directory.
  *
  * Non-donors (no `extra.skills` block) are skipped silently. Donors with
  * a malformed block become entries in the returned `warnings` list — one
@@ -65,7 +66,9 @@ final readonly class DonorDiscovery
             }
 
             try {
-                $donors[] = $this->vendorMapper->fromExtra($name, Path::create($installPath), $extra);
+                foreach ($this->vendorMapper->fromExtra($name, Path::create($installPath), $extra) as $donor) {
+                    $donors[] = $donor;
+                }
             } catch (MalformedVendorConfig $e) {
                 $warnings[] = $e->getMessage();
                 // Strip the `Package "..." :` prefix the exception adds, so the

--- a/src/Discovery/Provider/CompositeDonorProvider.php
+++ b/src/Discovery/Provider/CompositeDonorProvider.php
@@ -12,11 +12,14 @@ use LLM\Skills\Discovery\MalformedDonor;
  * Stacks several {@see DonorProvider}s behind a single interface so the
  * sync/show runners stay provider-agnostic.
  *
- * Children are queried in **declaration order**; on duplicate
- * `packageName` collisions the later child wins (the displaced earlier
- * entry is reported as a `-v` warning). Wire the composite with locals
- * first and remote last so an explicit `sources[]` entry naturally
- * overrides a transitive local discovery of the same package name.
+ * Children are queried in **declaration order**; when two children
+ * provide the same `packageName` the later child wins and displaces
+ * every row the earlier one contributed (reported as a `-v` warning).
+ * Multiple rows for one package from the SAME child are siblings — a
+ * multi-directory `source` declaration — and all survive. Wire the
+ * composite with locals first and remote last so an explicit
+ * `sources[]` entry naturally overrides a transitive local discovery
+ * of the same package name.
  *
  * `isActive()` is the OR of all children. `directDependencies()` is the
  * union (deduplicated, order-preserved). `discover()` concatenates
@@ -58,8 +61,10 @@ final readonly class CompositeDonorProvider implements DonorProvider
     #[\Override]
     public function discover(Path $projectRoot): DonorDiscoveryResult
     {
-        /** @var array<non-empty-string, \LLM\Skills\Config\VendorConfig> $donorsByName */
+        /** @var array<non-empty-string, non-empty-list<\LLM\Skills\Config\VendorConfig>> $donorsByName */
         $donorsByName = [];
+        /** @var array<non-empty-string, int> $ownerIndex which child currently owns the package */
+        $ownerIndex = [];
         /** @var list<string> $warnings */
         $warnings = [];
         /** @var list<MalformedDonor> $malformed */
@@ -69,7 +74,7 @@ final readonly class CompositeDonorProvider implements DonorProvider
         /** @var list<\LLM\Skills\Discovery\SourceFailure> $failures */
         $failures = [];
 
-        foreach ($this->children as $child) {
+        foreach ($this->children as $index => $child) {
             if (!$child->isActive($projectRoot)) {
                 continue;
             }
@@ -77,25 +82,32 @@ final readonly class CompositeDonorProvider implements DonorProvider
             $result = $child->discover($projectRoot);
 
             foreach ($result->donors as $donor) {
-                if (isset($donorsByName[$donor->packageName])) {
-                    // Later child wins. The displaced earlier entry
-                    // becomes a warning so `-v` users can see what
-                    // got overridden; the sync proceeds normally. The
-                    // composite is generic — the winner is "whichever
-                    // provider declared the package last" (typically
-                    // remote, since callers wire it last to honour the
-                    // explicit-over-transitive rule), not necessarily
-                    // remote in every wiring.
-                    $loser = $donorsByName[$donor->packageName];
+                $name = $donor->packageName;
+                if (isset($donorsByName[$name]) && $ownerIndex[$name] !== $index) {
+                    // Later child wins and displaces every row the
+                    // earlier child contributed for this package. The
+                    // takeover becomes a warning so `-v` users can see
+                    // what got overridden; the sync proceeds normally.
+                    // The composite is generic — the winner is
+                    // "whichever provider declared the package last"
+                    // (typically remote, since callers wire it last to
+                    // honour the explicit-over-transitive rule), not
+                    // necessarily remote in every wiring. Rows arriving
+                    // from the SAME child are siblings, not conflicts: a
+                    // multi-directory `source` declaration is one donor
+                    // spread over several rows.
+                    $loser = $donorsByName[$name][0];
                     $warnings[] = \sprintf(
                         'donor "%s" was provided by multiple providers — '
                         . 'later "%s" overrides earlier "%s"',
-                        $donor->packageName,
+                        $name,
                         $donor->provenance,
                         $loser->provenance,
                     );
+                    unset($donorsByName[$name]);
                 }
-                $donorsByName[$donor->packageName] = $donor;
+                $ownerIndex[$name] = $index;
+                $donorsByName[$name][] = $donor;
             }
 
             foreach ($result->warnings as $w) {
@@ -113,7 +125,7 @@ final readonly class CompositeDonorProvider implements DonorProvider
         }
 
         return new DonorDiscoveryResult(
-            donors: \array_values($donorsByName),
+            donors: \array_merge([], ...\array_values($donorsByName)),
             warnings: $warnings,
             malformed: $malformed,
             discoverable: $discoverable,

--- a/src/Discovery/Provider/Source/SourceProvider.php
+++ b/src/Discovery/Provider/Source/SourceProvider.php
@@ -94,8 +94,7 @@ final readonly class SourceProvider implements DonorProvider
 
         foreach ($this->source->refs($projectRoot) as $ref) {
             if ($ref instanceof DirDonorRef) {
-                $donor = $this->resolveDirRef($ref, $failures, $malformed);
-                if ($donor !== null) {
+                foreach ($this->resolveDirRef($ref, $failures, $malformed) as $donor) {
                     $donors[] = $donor;
                 }
                 continue;
@@ -127,8 +126,7 @@ final readonly class SourceProvider implements DonorProvider
                 continue;
             }
 
-            $donor = $this->buildDonor($ref, $path, $failures, $malformed);
-            if ($donor !== null) {
+            foreach ($this->buildDonor($ref, $path, $failures, $malformed) as $donor) {
                 $donors[] = $donor;
             }
         }
@@ -174,8 +172,9 @@ final readonly class SourceProvider implements DonorProvider
     }
 
     /**
-     * Resolve a `dir` ref into a `VendorConfig`, or `null` when the
-     * directory is absent or not a donor. The "fetch" for a dir ref is
+     * Resolve a `dir` ref into `VendorConfig` rows (one per declared
+     * source directory), or an empty list when the directory is absent
+     * or not a donor. The "fetch" for a dir ref is
      * simply confirming the directory exists — no download, no cache,
      * no unpacker — and then running the shared inspector against the
      * live directory, exactly as the remote path does against an
@@ -188,6 +187,8 @@ final readonly class SourceProvider implements DonorProvider
      * @param list<SourceFailure>      $failures  appended to in place
      * @param list<MalformedDonor>     $malformed appended to in place
      *
+     * @return list<VendorConfig>
+     *
      * @param-out list<SourceFailure>  $failures
      * @param-out list<MalformedDonor> $malformed
      */
@@ -195,29 +196,30 @@ final readonly class SourceProvider implements DonorProvider
         DirDonorRef $ref,
         array &$failures,
         array &$malformed,
-    ): ?VendorConfig {
+    ): array {
         if (!$ref->directory->isDir()) {
             $failures[] = new SourceFailure(
                 label: $ref->label(),
                 summary: 'directory does not exist',
                 detail: (string) $ref->directory,
             );
-            return null;
+            return [];
         }
 
         return $this->buildDonor($ref, $ref->directory, $failures, $malformed);
     }
 
     /**
-     * Resolve a single ref into a `VendorConfig`, or `null` when the
-     * archive cannot be turned into a donor. Accumulates per-ref
-     * warnings + malformed entries into the caller's lists.
+     * Resolve a single ref into `VendorConfig` rows (one per declared
+     * source directory), or an empty list when the archive cannot be
+     * turned into a donor. Accumulates per-ref warnings + malformed
+     * entries into the caller's lists.
      *
      * The parse-and-classify step is delegated to the shared
      * {@see DonorArchiveInspector} — the same inspector `skills:add`
      * runs when it fetches the archive, so what the two paths accept as
      * a donor never drifts. This method only turns the inspection into
-     * a {@see VendorConfig} (or a warning):
+     * {@see VendorConfig} rows (or a warning):
      *
      * - **Composer-shaped** → hand the name + raw `extra` to the mapper;
      *   a mapper rejection lifts to a {@see MalformedDonor}.
@@ -228,6 +230,8 @@ final readonly class SourceProvider implements DonorProvider
      * @param list<SourceFailure>      $failures  appended to in place
      * @param list<MalformedDonor>     $malformed appended to in place
      *
+     * @return list<VendorConfig>
+     *
      * @param-out list<SourceFailure>  $failures
      * @param-out list<MalformedDonor> $malformed
      */
@@ -236,7 +240,7 @@ final readonly class SourceProvider implements DonorProvider
         Path $path,
         array &$failures,
         array &$malformed,
-    ): ?VendorConfig {
+    ): array {
         $inspection = $this->inspector->inspect($path, $ref->packageHint);
 
         $rejection = $inspection->rejection;
@@ -245,14 +249,14 @@ final readonly class SourceProvider implements DonorProvider
                 label: $ref->label(),
                 summary: $this->describeRejection($rejection, $inspection->detail),
             );
-            return null;
+            return [];
         }
 
         if ($inspection->isComposerShaped) {
             /** @var non-empty-string $packageName */
             $packageName = $inspection->packageName;
             try {
-                $donor = $this->vendorMapper->fromExtra($packageName, $path, $inspection->extra);
+                $donors = $this->vendorMapper->fromExtra($packageName, $path, $inspection->extra);
             } catch (MalformedVendorConfig $e) {
                 /** @var non-empty-string $reason */
                 $reason = \preg_replace('/^Package "[^"]+": /', '', $e->getMessage())
@@ -265,9 +269,9 @@ final readonly class SourceProvider implements DonorProvider
                     packageName: $e->packageName,
                     reason: $reason,
                 );
-                return null;
+                return [];
             }
-            return $this->decorate($donor, $ref);
+            return \array_map(fn(VendorConfig $donor): VendorConfig => $this->decorate($donor, $ref), $donors);
         }
 
         // Bare skill repo. NOTE: `discovered: false` even though the
@@ -283,7 +287,7 @@ final readonly class SourceProvider implements DonorProvider
         $packageName = $inspection->packageName;
         /** @var non-empty-string $source */
         $source = $inspection->source;
-        return $this->decorate(
+        return [$this->decorate(
             new VendorConfig(
                 packageName: $packageName,
                 packageRoot: $path,
@@ -291,7 +295,7 @@ final readonly class SourceProvider implements DonorProvider
                 discoveredSkillDirs: $inspection->discoveredSkillDirs,
             ),
             $ref,
-        );
+        )];
     }
 
     /**

--- a/src/Discovery/SkillEnumerator.php
+++ b/src/Discovery/SkillEnumerator.php
@@ -42,6 +42,14 @@ final readonly class SkillEnumerator
         $skills = [];
         $warnings = [];
 
+        // Allowlist bookkeeping spans donor rows: a multi-source donor
+        // arrives as several rows sharing one package name, and a
+        // declared skill living in any of its source directories must
+        // not be reported missing by the sibling rows. Keyed
+        // package → declared name → seen anywhere.
+        /** @var array<non-empty-string, array<string, bool>> $allowlistSeen */
+        $allowlistSeen = [];
+
         foreach ($donors as $donor) {
             // Auto-discovered donors carry their skill directories explicitly
             // (they may sit at a catalog depth the immediate-subdir scan below
@@ -77,7 +85,12 @@ final readonly class SkillEnumerator
             // we actually saw so the "declared but missing" warning can
             // call them out without false positives from typos elsewhere.
             $filter = $donor->skillFilter;
-            $filterSet = $filter === null ? null : \array_fill_keys($filter, false);
+            if ($filter !== null) {
+                foreach ($filter as $declared) {
+                    $allowlistSeen[$donor->packageName][$declared] ??= false;
+                }
+            }
+            $filterSet = $filter === null ? null : \array_fill_keys($filter, true);
 
             foreach ($candidates as [$entry, $skillPath]) {
                 $canonicalName = $this->readCanonicalName(Path::create($skillPath), $entry);
@@ -91,7 +104,7 @@ final readonly class SkillEnumerator
                         // drown out the legitimate diagnostics.
                         continue;
                     }
-                    $filterSet[$canonicalName] = true;
+                    $allowlistSeen[$donor->packageName][$canonicalName] = true;
                 }
 
                 $skills[] = new Skill(
@@ -101,20 +114,20 @@ final readonly class SkillEnumerator
                     packageName: $donor->packageName,
                 );
             }
+        }
 
-            // Allowlist names that never matched any directory in the
-            // donor are most likely typos or stale entries. Surface them
-            // as `-v` warnings without aborting — the rest of the
-            // allowlist still syncs.
-            if ($filterSet !== null) {
-                foreach ($filterSet as $name => $seen) {
-                    if (!$seen) {
-                        $warnings[] = \sprintf(
-                            '%s: skill "%s" declared in the skill allowlist but not found in the donor',
-                            $donor->packageName,
-                            $name,
-                        );
-                    }
+        // Allowlist names that never matched a directory in any of the
+        // donor's rows are most likely typos or stale entries. Surface
+        // them as `-v` warnings without aborting — the rest of the
+        // allowlist still syncs.
+        foreach ($allowlistSeen as $packageName => $names) {
+            foreach ($names as $name => $seen) {
+                if (!$seen) {
+                    $warnings[] = \sprintf(
+                        '%s: skill "%s" declared in the skill allowlist but not found in the donor',
+                        $packageName,
+                        $name,
+                    );
                 }
             }
         }

--- a/tests/Acceptance/SandboxIsolationTest.php
+++ b/tests/Acceptance/SandboxIsolationTest.php
@@ -71,7 +71,7 @@ final class SandboxIsolationTest
         );
         Assert::same(
             $this->inlineSkillsBlock(),
-            ['trusted' => ['acme/skills-basic', 'acme/skills-pro']],
+            ['trusted' => ['acme/skills-basic', 'acme/skills-pro', 'mono/skills-repo']],
             'the previous test migrated composer.json; its inline block must be back',
         );
     }

--- a/tests/Acceptance/SkillsSyncTest.php
+++ b/tests/Acceptance/SkillsSyncTest.php
@@ -39,9 +39,15 @@ use Testo\Test;
  *                            non-`skills/` locations — `.claude/skills/hidden-claude/`
  *                            and a catalog layout `skills/php/hidden-catalog/` — to
  *                            exercise recursive `SKILL.md` auto-discovery.
+ * - `mono/skills-repo`     — trusted. Declares `extra.skills.source` as a **list**
+ *                            (`packages/dto/skills`, `packages/auth/skills`); each
+ *                            component dir also carries its own `composer.json`
+ *                            (gitsplit monorepo layout). Skills: `dto-guides/`,
+ *                            `auth-guides/`.
  *
- * Sandbox project config: `extra.skills.trusted = ["acme/skills-basic", "acme/skills-pro"]`
- * with the default `trusted-replace: false` — so built-in patterns still apply.
+ * Sandbox project config: `extra.skills.trusted = ["acme/skills-basic", "acme/skills-pro",
+ * "mono/skills-repo"]` with the default `trusted-replace: false` — so built-in patterns
+ * still apply.
  */
 #[Test]
 final class SkillsSyncTest
@@ -129,13 +135,46 @@ final class SkillsSyncTest
     {
         // internal/path declares no extra.skills; acme/skills-broken has malformed
         // extra; clash/skills-conflict and evil/payload are untrusted. The default
-        // sync yields: the four skills from acme/* (project trust) plus the one
-        // skill from spiral/skills-demo (built-in `spiral/*` trust).
+        // sync yields: the four skills from acme/* (project trust), the one skill
+        // from spiral/skills-demo (built-in `spiral/*` trust), and the two skills
+        // from mono/skills-repo (project trust).
         $this->runSync();
 
         $entries = $this->listTargetEntries();
 
-        Assert::same($entries, ['code-review', 'demo', 'greeting', 'migrate', 'refactor']);
+        Assert::same(
+            $entries,
+            ['auth-guides', 'code-review', 'demo', 'dto-guides', 'greeting', 'migrate', 'refactor'],
+        );
+    }
+
+    // ── multi-directory source declaration ──────────────────────────────────
+
+    public function sourceListSyncsSkillsFromEveryDeclaredDirectory(): void
+    {
+        // mono/skills-repo declares `extra.skills.source` as a list of two
+        // per-component directories; skills from both must land in the target.
+        $process = $this->runSync('mono/skills-repo');
+
+        Assert::same($process->getExitCode(), 0);
+        Assert::same(
+            $this->listTargetEntries(),
+            ['auth-guides', 'dto-guides'],
+            'both declared source directories must be synced. stderr: '
+            . $process->getErrorOutput(),
+        );
+    }
+
+    public function sourceListEntriesAreNotHiddenByNestedComposerJson(): void
+    {
+        // Each component directory of mono/skills-repo carries its own
+        // composer.json (the gitsplit layout); a declared source list must read
+        // straight through it, unlike the fallback scanner which treats a nested
+        // manifest as a foreign distribution boundary.
+        $this->runSync('mono/skills-repo');
+
+        Assert::true(\is_file(self::TARGET_DIR . '/dto-guides/SKILL.md'));
+        Assert::true(\is_file(self::TARGET_DIR . '/auth-guides/SKILL.md'));
     }
 
     // ── trust policy ────────────────────────────────────────────────────────
@@ -310,7 +349,7 @@ final class SkillsSyncTest
         Assert::same($process->getExitCode(), 0);
         Assert::same(
             $this->listTargetEntries(),
-            ['code-review', 'demo', 'greeting', 'migrate', 'refactor', 'tutorial'],
+            ['auth-guides', 'code-review', 'demo', 'dto-guides', 'greeting', 'migrate', 'refactor', 'tutorial'],
             'project wildcard unlocks evil/payload; direct-dep trust covers the rest. stderr: '
             . $process->getErrorOutput(),
         );
@@ -389,7 +428,7 @@ final class SkillsSyncTest
         Assert::same($process->getExitCode(), 0);
         Assert::same(
             $this->listTargetEntries(),
-            ['code-review', 'demo', 'greeting', 'migrate', 'refactor'],
+            ['auth-guides', 'code-review', 'demo', 'dto-guides', 'greeting', 'migrate', 'refactor'],
         );
     }
 

--- a/tests/Sandbox/packages/mono/skills-repo/composer.json
+++ b/tests/Sandbox/packages/mono/skills-repo/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "mono/skills-repo",
+    "description": "Stub monorepo package: one Packagist distribution, skills spread across per-component directories declared as a source list",
+    "type": "library",
+    "license": "MIT",
+    "replace": {
+        "mono/dto": "self.version",
+        "mono/auth": "self.version"
+    },
+    "extra": {
+        "skills": {
+            "source": [
+                "packages/dto/skills",
+                "packages/auth/skills"
+            ]
+        }
+    }
+}

--- a/tests/Sandbox/packages/mono/skills-repo/packages/auth/composer.json
+++ b/tests/Sandbox/packages/mono/skills-repo/packages/auth/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "mono/auth",
+    "description": "Gitsplit component manifest; its presence must not hide the sibling skills directory",
+    "type": "library",
+    "license": "MIT"
+}

--- a/tests/Sandbox/packages/mono/skills-repo/packages/auth/skills/auth-guides/SKILL.md
+++ b/tests/Sandbox/packages/mono/skills-repo/packages/auth/skills/auth-guides/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: auth-guides
+description: Best practices for the Auth component.
+---
+
+Keep token lifetimes short; rotate refresh tokens on every use.

--- a/tests/Sandbox/packages/mono/skills-repo/packages/dto/composer.json
+++ b/tests/Sandbox/packages/mono/skills-repo/packages/dto/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "mono/dto",
+    "description": "Gitsplit component manifest; its presence must not hide the sibling skills directory",
+    "type": "library",
+    "license": "MIT"
+}

--- a/tests/Sandbox/packages/mono/skills-repo/packages/dto/skills/dto-guides/SKILL.md
+++ b/tests/Sandbox/packages/mono/skills-repo/packages/dto/skills/dto-guides/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: dto-guides
+description: Best practices for the DTO component.
+---
+
+Prefer immutable DTOs with named constructors; validate at the boundary.

--- a/tests/Sandbox/project/composer.json
+++ b/tests/Sandbox/project/composer.json
@@ -15,6 +15,7 @@
         "acme/skills-broken": "@dev",
         "acme/skills-rootlike": "@dev",
         "acme/skills-undeclared": "@dev",
+        "mono/skills-repo": "@dev",
         "nested/skills-tree": "@dev",
         "spiral/skills-demo": "@dev",
         "transit/untrusted-relay": "@dev"
@@ -26,7 +27,7 @@
     },
     "extra": {
         "skills": {
-            "trusted": ["acme/skills-basic", "acme/skills-pro"]
+            "trusted": ["acme/skills-basic", "acme/skills-pro", "mono/skills-repo"]
         }
     }
 }

--- a/tests/Unit/Config/Mapper/VendorConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/VendorConfigMapperTest.php
@@ -62,13 +62,83 @@ final class VendorConfigMapperTest
         $mapper = new VendorConfigMapper();
         $root = Path::create(__DIR__);
 
-        $cfg = $mapper->fromExtra('acme/skills-pro', $root, [
+        $donors = $mapper->fromExtra('acme/skills-pro', $root, [
             'skills' => ['source' => 'resources/skills'],
         ]);
 
-        Assert::same($cfg->packageName, 'acme/skills-pro');
-        Assert::same($cfg->source, 'resources/skills');
-        Assert::same((string) $cfg->packageRoot, (string) $root);
+        Assert::count($donors, 1);
+        Assert::same($donors[0]->packageName, 'acme/skills-pro');
+        Assert::same($donors[0]->source, 'resources/skills');
+        Assert::same((string) $donors[0]->packageRoot, (string) $root);
+    }
+
+    public function fromExtraMapsSourceListToOneDonorRowPerEntry(): void
+    {
+        // A monorepo published as one package may ship skills in several
+        // non-contiguous directories; each list entry becomes its own donor
+        // row so downstream stays single-source.
+        $mapper = new VendorConfigMapper();
+        $root = Path::create(__DIR__);
+
+        $donors = $mapper->fromExtra('acme/monorepo', $root, [
+            'skills' => ['source' => ['packages/dto/skills', 'packages/auth/skills']],
+        ]);
+
+        Assert::count($donors, 2);
+        Assert::same($donors[0]->source, 'packages/dto/skills');
+        Assert::same($donors[1]->source, 'packages/auth/skills');
+        Assert::same($donors[0]->packageName, 'acme/monorepo');
+        Assert::same($donors[1]->packageName, 'acme/monorepo');
+    }
+
+    public function fromExtraThrowsWhenSourceListIsEmpty(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('must not be an empty list');
+
+        (new VendorConfigMapper())->fromExtra(
+            'acme/foo',
+            Path::create(__DIR__),
+            ['skills' => ['source' => []]],
+        );
+    }
+
+    public function fromExtraThrowsWhenSourceListContainsNonString(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('extra.skills.source');
+
+        (new VendorConfigMapper())->fromExtra(
+            'acme/foo',
+            Path::create(__DIR__),
+            ['skills' => ['source' => ['resources/skills', 42]]],
+        );
+    }
+
+    public function fromExtraThrowsWhenSourceListContainsDuplicates(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('must not contain duplicate entries');
+
+        (new VendorConfigMapper())->fromExtra(
+            'acme/foo',
+            Path::create(__DIR__),
+            ['skills' => ['source' => ['resources/skills', 'resources/skills']]],
+        );
+    }
+
+    public function fromExtraThrowsWhenAnySourceListEntryEscapesPackageRoot(): void
+    {
+        // Every entry is held to the same rules as a single-string source: one
+        // escaping entry poisons the whole declaration.
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('must not escape the package root');
+
+        (new VendorConfigMapper())->fromExtra(
+            'acme/foo',
+            Path::create(__DIR__),
+            ['skills' => ['source' => ['resources/skills', '../outside']]],
+        );
     }
 
     public function fromExtraThrowsWhenExtraIsNotAnArray(): void
@@ -118,7 +188,7 @@ final class VendorConfigMapperTest
         );
     }
 
-    public function fromExtraThrowsWhenSourceIsNotAString(): void
+    public function fromExtraThrowsWhenSourceIsNeitherStringNorList(): void
     {
         Expect::exception(MalformedVendorConfig::class)
             ->withMessageContaining('extra.skills.source');
@@ -126,7 +196,7 @@ final class VendorConfigMapperTest
         (new VendorConfigMapper())->fromExtra(
             'acme/foo',
             Path::create(__DIR__),
-            ['skills' => ['source' => ['nested']]],
+            ['skills' => ['source' => 42]],
         );
     }
 

--- a/tests/Unit/Discovery/SkillEnumeratorTest.php
+++ b/tests/Unit/Discovery/SkillEnumeratorTest.php
@@ -135,6 +135,42 @@ final class SkillEnumeratorTest
         Assert::true(\str_contains($result->warnings[0], 'not found'));
     }
 
+    public function skillFilterDoesNotWarnWhenSkillLivesInASiblingSourceRow(): void
+    {
+        // A multi-directory `source` declaration arrives as several donor
+        // rows sharing one package name. A declared skill that lives in one
+        // of the directories must not be reported missing by the rows that
+        // don't contain it.
+        $rowA = $this->makeDonor('acme/mono', 'src-a', ['alpha/SKILL.md' => 'A'])
+            ->withSkillFilter(['alpha', 'beta']);
+        $rowB = $this->makeDonor('acme/mono', 'src-b', ['beta/SKILL.md' => 'B'])
+            ->withSkillFilter(['alpha', 'beta']);
+
+        $result = (new SkillEnumerator())->enumerate([$rowA, $rowB]);
+
+        $names = \array_map(static fn($s) => $s->name, $result->skills);
+        \sort($names);
+        Assert::same($names, ['alpha', 'beta']);
+        Assert::same($result->warnings, []);
+    }
+
+    public function skillFilterWarnsOnceForANameMissingFromEverySiblingRow(): void
+    {
+        // A name absent from ALL of the package's source directories is a
+        // genuine typo/stale entry — one warning for the package, not one
+        // per row.
+        $rowA = $this->makeDonor('acme/mono', 'src-a', ['alpha/SKILL.md' => 'A'])
+            ->withSkillFilter(['alpha', 'oops']);
+        $rowB = $this->makeDonor('acme/mono', 'src-b', ['beta/SKILL.md' => 'B'])
+            ->withSkillFilter(['alpha', 'oops']);
+
+        $result = (new SkillEnumerator())->enumerate([$rowA, $rowB]);
+
+        Assert::same(\count($result->warnings), 1);
+        Assert::true(\str_contains($result->warnings[0], 'acme/mono'));
+        Assert::true(\str_contains($result->warnings[0], '"oops"'));
+    }
+
     public function emptySkillFilterDropsAllSkillsAndEmitsNoWarnings(): void
     {
         // An explicitly empty allowlist means "the donor is on file but


### PR DESCRIPTION
## 🔍 What was changed

- `extra.skills.source` now accepts a list of relative directories in addition to a single string; each entry is scanned exactly like a single `source`, and skills from all of them sync together.
- The normalisation lives in `VendorConfigMapper::fromExtra()` (now returning a list of `VendorConfig` rows, one per directory), so the array form works identically for Composer-installed donors and for remote donors fetched via `sources[]`.
- Validation holds every list entry to the existing single-string rules (non-empty, relative, confined to the package root) and additionally rejects an empty list and duplicate entries as malformed.
- Skill-allowlist "declared but not found" warnings now aggregate across a package's source directories, so a skill found in one directory is not reported missing by its siblings.

### How it works

- Each declared directory becomes its own donor row — the same one-row-per-container shape auto-discovery already produces — so trust checks, planning, and reporting stay single-source downstream.
- Name collisions between two source directories of one package follow the same policy as collisions between two packages; no new rules.
- Glob patterns (the optional part of the proposal) are intentionally out of scope; the explicit list covers the monorepo use case.

## Review notes

- `CompositeDonorProvider` deduplicated donors by `packageName`, which silently dropped every source directory after the first — the acceptance test caught one of two skills missing. The dedup now displaces rows only when a *later provider* supplies the same package; sibling rows from one provider coexist.

## Checklist

- Closes #35
- How was this tested:
  - [x] Unit tests added (mapper list handling, validation of empty/duplicate/escaping entries)
  - [x] Acceptance tests added against a new `mono/skills-repo` sandbox fixture (gitsplit monorepo layout with nested `composer.json` per component)
  - [x] Full suite, psalm, and php-cs-fixer run locally

## Documentation

- README "Shipping skills (vendor side)" section documents the list form with a monorepo example.
