### PR TITLE
fix(discovery): deduplicate donors sharing an install path

### DIFF
--- a/src/Discovery/DonorDiscovery.php
+++ b/src/Discovery/DonorDiscovery.php
@@ -40,15 +40,30 @@ final readonly class DonorDiscovery
         $warnings = [];
         $malformed = [];
         $discoverable = [];
+        $seenPaths = [];
 
         /** @var PackageInterface $package */
         foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
             $extra = $package->getExtra();
             /** @var non-empty-string $name */
             $name = $package->getName();
+            $installPath = $composer->getInstallationManager()->getInstallPath($package);
+
+            // A dependency installed from a dev branch without a `branch-alias`
+            // surfaces twice here: the real package and the synthetic
+            // default-branch AliasPackage (`9999999-dev`) Composer pairs with
+            // it, both resolving to one install path. Enumerating that path
+            // once keeps a donor from being counted against itself as a
+            // self-conflict. An empty path (metapackage) carries no skills, so
+            // it never contends for deduplication.
+            if ($installPath !== null && $installPath !== '') {
+                if (isset($seenPaths[$installPath])) {
+                    continue;
+                }
+                $seenPaths[$installPath] = true;
+            }
 
             if (!VendorConfigMapper::declaresSkills($extra)) {
-                $installPath = $composer->getInstallationManager()->getInstallPath($package);
                 if ($installPath === null) {
                     continue;
                 }
@@ -59,7 +74,6 @@ final readonly class DonorDiscovery
                 continue;
             }
 
-            $installPath = $composer->getInstallationManager()->getInstallPath($package);
             if ($installPath === null) {
                 $warnings[] = \sprintf('%s: install path unavailable', $name);
                 continue;

--- a/tests/Acceptance/SkillsSyncTest.php
+++ b/tests/Acceptance/SkillsSyncTest.php
@@ -44,6 +44,11 @@ use Testo\Test;
  *                            component dir also carries its own `composer.json`
  *                            (gitsplit monorepo layout). Skills: `dto-guides/`,
  *                            `auth-guides/`.
+ * - `alias/skills-dev`     — untrusted (transitive via `transit/untrusted-relay`).
+ *                            Pinned to `dev-main` with `default-branch: true`, so
+ *                            Composer loads it twice — the real package plus a
+ *                            `9999999-dev` `AliasPackage` sharing one install path.
+ *                            One `alias-guide` skill; exercises donor deduplication.
  *
  * Sandbox project config: `extra.skills.trusted = ["acme/skills-basic", "acme/skills-pro",
  * "mono/skills-repo"]` with the default `trusted-replace: false` — so built-in patterns
@@ -535,6 +540,35 @@ final class SkillsSyncTest
         Assert::false(
             \is_file(self::TARGET_DIR . '/refactor/SKILL.md'),
             'unrelated skills must not be written either — the engine is transactional',
+        );
+    }
+
+    // ── dev-branch alias deduplication ──────────────────────────────────────
+
+    public function devBranchDonorWithDefaultBranchAliasSyncsOnceWithoutSelfConflict(): void
+    {
+        // alias/skills-dev is installed from a dev branch with
+        // `default-branch: true` and no `branch-alias`, so Composer's local
+        // repository returns it twice — the real `dev-main` package and a
+        // synthetic `9999999-dev` AliasPackage at the same install path.
+        // Trusting it must sync its one skill exactly once, not abort with a
+        // conflict of the package against itself.
+        $process = $this->runSync('--trust=alias/skills-dev');
+
+        Assert::same(
+            $process->getExitCode(),
+            0,
+            'a dev-branch donor and its default-branch alias must not self-conflict. stderr: '
+            . $process->getErrorOutput(),
+        );
+        Assert::true(
+            \is_file(self::TARGET_DIR . '/alias-guide/SKILL.md'),
+            'the aliased donor\'s skill must be synced. stderr: ' . $process->getErrorOutput(),
+        );
+        Assert::false(
+            \str_contains($process->getErrorOutput(), 'Sync aborted'),
+            'sync must not abort for a package aliased against itself. Got: '
+            . $process->getErrorOutput(),
         );
     }
 

--- a/tests/Sandbox/packages/alias/skills-dev/composer.json
+++ b/tests/Sandbox/packages/alias/skills-dev/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "alias/skills-dev",
+    "description": "Stub donor pinned to dev-main with default-branch set and no branch-alias, so Composer loads it as a real package plus a `9999999-dev` AliasPackage sharing one install path — the shape a dev-branch dependency produces. Used to prove donor deduplication.",
+    "type": "library",
+    "license": "MIT",
+    "version": "dev-main",
+    "default-branch": true,
+    "extra": {
+        "skills": {
+            "source": "skills"
+        }
+    }
+}

--- a/tests/Sandbox/packages/alias/skills-dev/skills/alias-guide/SKILL.md
+++ b/tests/Sandbox/packages/alias/skills-dev/skills/alias-guide/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: alias-guide
+description: Placeholder skill shipped by a dev-branch donor with a default-branch alias.
+---
+
+This skill exists only so the acceptance suite can prove a dev-branch donor and
+its `9999999-dev` alias are synced once, not flagged as a self-conflict.

--- a/tests/Sandbox/packages/transit/untrusted-relay/composer.json
+++ b/tests/Sandbox/packages/transit/untrusted-relay/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "transit/untrusted-relay",
-    "description": "Meta-package that pulls in evil/payload and clash/skills-conflict as transitive dependencies. Exists so the sandbox can install those donors without listing them under the consumer project's direct `require`, which would now (with direct-dep auto-trust) bypass the trust gate the tests are designed to exercise.",
+    "description": "Meta-package that pulls in evil/payload, clash/skills-conflict and alias/skills-dev as transitive dependencies. Exists so the sandbox can install those donors without listing them under the consumer project's direct `require`, which would now (with direct-dep auto-trust) bypass the trust gate the tests are designed to exercise.",
     "type": "library",
     "license": "MIT",
     "require": {
         "evil/payload": "@dev",
-        "clash/skills-conflict": "@dev"
+        "clash/skills-conflict": "@dev",
+        "alias/skills-dev": "@dev"
     }
 }

--- a/tests/Unit/Discovery/DonorDiscoveryTest.php
+++ b/tests/Unit/Discovery/DonorDiscoveryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Discovery;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Installer\InstallationManager;
+use Composer\Installer\InstallerInterface;
+use Composer\IO\NullIO;
+use Composer\Package\AliasPackage;
+use Composer\Package\CompletePackage;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use Composer\Util\HttpDownloader;
+use Composer\Util\Loop;
+use LLM\Skills\Discovery\DonorDiscovery;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+/**
+ * Unit coverage for {@see DonorDiscovery} walking Composer's local
+ * repository.
+ *
+ * Composer creates two package objects for a dependency installed from a
+ * dev branch without a `branch-alias`: the real `dev-main` package and an
+ * {@see AliasPackage} carrying the default branch alias `9999999-dev`.
+ * Both share one install path, so `getLocalRepository()->getPackages()`
+ * returns the donor twice. Discovery must fold that pair back into a
+ * single donor row — otherwise the same skill names are enumerated twice
+ * and later flagged as a self-conflict.
+ */
+#[Test]
+#[Covers(DonorDiscovery::class)]
+final class DonorDiscoveryTest
+{
+    public function devBranchAliasDoesNotDoubleTheDonor(): void
+    {
+        $real = new CompletePackage('webman-tech/components-monorepo', 'dev-main', 'dev-main');
+        $real->setType('library');
+        $real->setExtra(['skills' => ['source' => 'skills']]);
+
+        // The default-branch alias Composer synthesises for a dev-branch
+        // dependency without an explicit `branch-alias`.
+        $alias = new AliasPackage($real, '9999999-dev', '9999999-dev');
+
+        $composer = $this->composerWith($real, $alias);
+
+        $result = (new DonorDiscovery())->discover($composer);
+
+        Assert::same(
+            \count($result->donors),
+            1,
+            'a dev-branch package and its default-branch alias share one install path '
+            . 'and must yield a single donor row',
+        );
+        Assert::same($result->donors[0]->packageName, 'webman-tech/components-monorepo');
+        Assert::same($result->donors[0]->source, 'skills');
+    }
+
+    /**
+     * Build a Composer whose local repository returns exactly the given
+     * packages, with every package resolving to `<vendor>/<name>` under a
+     * fixed install root. No real Composer bootstrap or filesystem access.
+     */
+    private function composerWith(PackageInterface ...$packages): Composer
+    {
+        $io = new NullIO();
+        $config = new Config(false, \sys_get_temp_dir());
+
+        $local = new InstalledArrayRepository();
+        foreach ($packages as $package) {
+            $local->addPackage($package);
+        }
+
+        $http = new HttpDownloader($io, $config);
+        $repositoryManager = new RepositoryManager($io, $config, $http);
+        $repositoryManager->setLocalRepository($local);
+
+        $installationManager = new InstallationManager(new Loop($http), $io);
+        $installationManager->addInstaller($this->pathStubInstaller());
+
+        $composer = new Composer();
+        $composer->setConfig($config);
+        $composer->setRepositoryManager($repositoryManager);
+        $composer->setInstallationManager($installationManager);
+
+        return $composer;
+    }
+
+    /**
+     * A no-op installer that only answers {@see InstallerInterface::getInstallPath()},
+     * mapping every package to `<vendor-dir>/<name>`. That is all discovery
+     * needs, and it keeps a real installer's filesystem work out of the test.
+     */
+    private function pathStubInstaller(): InstallerInterface
+    {
+        return new class implements InstallerInterface {
+            public function supports(string $packageType): bool
+            {
+                return true;
+            }
+
+            public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package): bool
+            {
+                return true;
+            }
+
+            public function download(PackageInterface $package, ?PackageInterface $prevPackage = null)
+            {
+                return null;
+            }
+
+            public function prepare(string $type, PackageInterface $package, ?PackageInterface $prevPackage = null)
+            {
+                return null;
+            }
+
+            public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+            {
+                return null;
+            }
+
+            public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+            {
+                return null;
+            }
+
+            public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+            {
+                return null;
+            }
+
+            public function cleanup(string $type, PackageInterface $package, ?PackageInterface $prevPackage = null)
+            {
+                return null;
+            }
+
+            public function getInstallPath(PackageInterface $package): string
+            {
+                return \sys_get_temp_dir() . '/vendor/' . $package->getName();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🔍 What was changed

- `DonorDiscovery` now enumerates each install path once, folding Composer's default-branch `AliasPackage` back into the single donor it aliases.
- The install path is resolved once per package rather than separately in each branch of the loop.
- Added a `DonorDiscovery` regression test that wires a real Composer local repository containing a `dev-main` package and its `9999999-dev` alias, asserting one donor row.

## Why?

- A dependency installed from a dev branch (`dev-main`, `dev-master`, …) without an `extra.branch-alias` is returned twice by Composer's local repository: the real package and a synthetic `AliasPackage` at the default branch alias `9999999-dev`, both pointing at one install path.
- Discovery treated each as its own donor, so every skill the package ships collided with itself and `composer skills:update` aborted with a spurious `[conflict]` for each skill, writing nothing.

## Checklist

- Closes #38
- How was this tested:
  - [x] Unit tests added

## Review notes

- The doubling happens at Composer's `getPackages()` layer, so it cannot be reproduced through the sandbox's path repositories (those resolve to a concrete `dev-<branch>` version and never receive the default-branch alias). The regression test therefore builds the Composer local repository directly with the real + alias pair — the same shape the issue observed empirically — rather than through an acceptance fixture.
