### PR TITLE
feat: vendor packages can declare external skill sources (`extra.skills.sources`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,46 @@ single package whose skills live per component:
 Every listed directory is scanned the same way as a single `source`; skills from all of
 them are synced together.
 
+### External sources (`extra.skills.sources`)
+
+A package can also advertise skills that live **outside** the package itself — a separate
+skills repository, or a bundle shared by several integration packages — using the same
+`sources[]` vocabulary as `skills.json`:
+
+```jsonc
+// vendor/acme/foo/composer.json
+{
+  "extra": {
+    "skills": {
+      "source": "resources/skills",                 // optional: in-package skills
+      "sources": [                                   // external skills
+        { "from": "github", "package": "acme/project-skills", "ref": "self.version" },
+        { "from": "gitlab", "package": "acme/shared-skills", "skills": ["deploy"] }
+      ]
+    }
+  }
+}
+```
+
+- **Trust follows the declaring package.** The external bundle is fetched and synced exactly
+  when `acme/foo` itself would be allowed to donate skills (built-in/project trust list,
+  direct dependency, or a positional `skills:update acme/foo`). Unlike the project's own
+  `sources[]`, a vendor-declared entry is never implicitly trusted. Projects can turn the
+  feature off entirely with `"vendor-sources": false` in `skills.json`.
+- **`ref: "self.version"`** pins the external source to the installed version of the
+  declaring package — made for monorepos that tag the skills repository in lockstep. A
+  released version resolves to the matching tag (`1.4.2` finds `v1.4.2` or `1.4.2`); a
+  branch install maps to the branch (`dev-main` → `main`, `1.x-dev` → `1.x`). A plain
+  exact pin is also available as `"ref": "=1.4.2"` (works in `skills.json` too).
+- **Shared bundles dedupe.** Several packages pointing at the same source and ref produce a
+  single fetch and a single donor; their `skills` allowlists are merged (an entry without
+  an allowlist means "all skills" and wins the merge).
+- **No chaining.** The fetched archive's own `extra.skills.sources` is ignored — depth is
+  exactly one. Its `extra.skills.source` (path inside the archive) works as usual.
+- The `dir` adapter is not allowed here — for in-package paths use `extra.skills.source`.
+- Failures (unknown adapter, unresolvable ref, fetch error) are reported per entry as
+  `acme/foo → github:acme/project-skills — <reason>` and never block the rest of the sync.
+
 
 ## Project configuration
 
@@ -210,6 +250,7 @@ where to put it, who to trust, whether to auto-sync.
 | `auto-sync`       | bool        | `true`           | Run `skills:update` after `composer install` / `update`. Set to `false` to opt out.     |
 | `path-from-root`  | string      | _(unset)_        | The project's own location below an intended outer root, e.g. `packages/api`. When set, `target` and aliases resolve against (and stay inside) that verified root instead of the project directory. See [path-from-root](#path-from-root). |
 | `dependencies`    | object      | `{}`             | Per-package-manager config: `<id>` → `bool` (walk toggle) or `{ enabled, trusted, trusted-replace }`. Ids: `composer` (walk default `true`), `npm`/`go` (future, default `false`). `trusted` extends the manager's trust list; `trusted-replace` makes it fully replace the built-in and direct-dependency trust. Deprecated aliases `trusted`, `trusted-replace`, `local` fold into this block. See [Trust](#trust) and [Donor sources](#donor-sources). |
+| `vendor-sources`  | bool        | `true`           | Allow installed packages to advertise external sources via their own `extra.skills.sources` (gated by the same trust rules as the declaring package). Set to `false` to ignore them entirely. See [External sources](#external-sources-extraskillssources). |
 | `sources`         | object[]    | `[]`             | Explicit donor source entries. Managed by `skills:add`; documented in [Donor sources](#donor-sources). |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
@@ -440,10 +481,10 @@ Shipped in [`resources/trusted-composer.txt`](resources/trusted-composer.txt); e
 `llm/skills` reads donors from two axes:
 
 - **Local providers** — walk a manifest the project already owns. Today only `composer`; `npm` and `go` are reserved in the vocabulary but ship later.
-- **Remote providers** — fetch an explicit ref from a URL (currently GitHub and GitLab; the format is forward-compatible with Bitbucket, npm registry, Go module proxy, private Packagist, `http`/`zip`).
+- **Remote providers** — fetch an explicit ref from a URL (currently GitHub and GitLab; the format is forward-compatible with Bitbucket, npm registry, Go module proxy, private Packagist, `http`/`zip`). Entries come from the project's own `sources[]` **and** from installed packages' `extra.skills.sources` (see [External sources](#external-sources-extraskillssources)).
 - **Local directory donors** — the `dir` adapter reads a directory already on disk (a shared skills folder next to the repo, a monorepo sibling); no fetch, no cache. See [Local directory donors](#local-directory-donors-dir).
 
-Both axes coexist. When the same package name arrives via both, the **`sources` entry wins** (you typed it; the transitive Composer pickup is treated as stale) and the displaced donor is logged under `-v`.
+The axes coexist. When the same package name arrives via more than one, the later origin wins — project `sources[]` over vendor-declared, either of those over the transitive Composer pickup — and the displaced donor is logged under `-v`.
 
 ### `skills:add` — register a remote donor
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,15 @@ them are synced together.
 
 A package can also advertise skills that live **outside** the package itself — a separate
 skills repository, or a bundle shared by several integration packages — using the same
-`sources[]` vocabulary as `skills.json`:
+`sources[]` vocabulary as `skills.json`.
+
+The two lists share one syntax but answer different questions. `sources[]` in
+**`skills.json`** is the consumer's pull list: *"my project takes skills from here"* —
+you wrote it, so every entry is trusted by declaration. `sources[]` in a **package's
+`composer.json`** is a donor's address book: *"my skills live over there"* — the same
+statement `extra.skills.source` makes for in-package paths, just pointing outside. It is
+third-party input, so it only takes effect when the declaring package clears the exact
+same trust gate as its bundled skills would:
 
 ```jsonc
 // vendor/acme/foo/composer.json
@@ -218,8 +226,11 @@ skills repository, or a bundle shared by several integration packages — using 
 ## Project configuration
 
 Project-level settings live in a dedicated **`skills.json`** at the project root. The file
-is the single source of truth for everything the plugin does in your project — what to copy,
-where to put it, who to trust, whether to auto-sync.
+is the single source of truth for every decision the plugin makes in your project — what to
+copy, where to put it, who to trust, whether to auto-sync. Skill *content* may arrive from
+manifests you did not write (vendor packages, their
+[external sources](#external-sources-extraskillssources)), but whether it is allowed in is
+always governed here, by the trust lists and the `vendor-sources` toggle.
 
 ```jsonc
 // <project-root>/skills.json
@@ -251,7 +262,7 @@ where to put it, who to trust, whether to auto-sync.
 | `path-from-root`  | string      | _(unset)_        | The project's own location below an intended outer root, e.g. `packages/api`. When set, `target` and aliases resolve against (and stay inside) that verified root instead of the project directory. See [path-from-root](#path-from-root). |
 | `dependencies`    | object      | `{}`             | Per-package-manager config: `<id>` → `bool` (walk toggle) or `{ enabled, trusted, trusted-replace }`. Ids: `composer` (walk default `true`), `npm`/`go` (future, default `false`). `trusted` extends the manager's trust list; `trusted-replace` makes it fully replace the built-in and direct-dependency trust. Deprecated aliases `trusted`, `trusted-replace`, `local` fold into this block. See [Trust](#trust) and [Donor sources](#donor-sources). |
 | `vendor-sources`  | bool        | `true`           | Allow installed packages to advertise external sources via their own `extra.skills.sources` (gated by the same trust rules as the declaring package). Set to `false` to ignore them entirely. See [External sources](#external-sources-extraskillssources). |
-| `sources`         | object[]    | `[]`             | Explicit donor source entries. Managed by `skills:add`; documented in [Donor sources](#donor-sources). |
+| `sources`         | object[]    | `[]`             | The project's own donor source entries — implicitly trusted, you wrote them. Managed by `skills:add`; documented in [Donor sources](#donor-sources). Not to be confused with the trust-gated [`extra.skills.sources`](#external-sources-extraskillssources) a vendor package declares for itself. |
 
 `.agents/skills/` is tool-agnostic so Claude Code, Cursor, Aider, … can read the same
 directory. Redirect to `.claude/skills`, `.cursor/skills`, etc. for single-agent projects.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ same trust gate as its bundled skills would:
   exact pin is also available as `"ref": "=1.4.2"` (works in `skills.json` too).
 - **Shared bundles dedupe.** Several packages pointing at the same source and ref produce a
   single fetch and a single donor; their `skills` allowlists are merged (an entry without
-  an allowlist means "all skills" and wins the merge).
+  an allowlist means "all skills" and wins the merge), and the donor is approved when
+  **any** of the declaring packages is trusted (or named positionally).
 - **No chaining.** The fetched archive's own `extra.skills.sources` is ignored — depth is
   exactly one. Its `extra.skills.source` (path inside the archive) works as usual.
 - The `dir` adapter is not allowed here — for in-package paths use `extra.skills.source`.

--- a/resources/skills.schema.json
+++ b/resources/skills.schema.json
@@ -68,6 +68,11 @@
                 }
             }
         },
+        "vendor-sources": {
+            "type": "boolean",
+            "description": "When true (default), installed vendor packages may advertise external skill sources via their own extra.skills.sources; each such source is gated by the same trust rules as the declaring package itself. Set to false to ignore vendor-declared external sources entirely — only the project's own sources[] and local package directories contribute donors.",
+            "default": true
+        },
         "sources": {
             "type": "array",
             "description": "Explicit donor sources. Each entry tells the provider what to fetch and from where: an adapter id in `from`, an identifier in `package` or `url`, and optional `host`/`ref`/`skills`/adapter-specific extras.",
@@ -75,7 +80,6 @@
             "items": {
                 "oneOf": [
                     { "$ref": "#/$defs/sourceByPackage" },
-                    { "$ref": "#/$defs/sourceByUrl" },
                     { "$ref": "#/$defs/sourceByDir" }
                 ]
             }
@@ -164,43 +168,6 @@
                         "type": "string",
                         "minLength": 1
                     }
-                }
-            }
-        },
-        "sourceByUrl": {
-            "type": "object",
-            "description": "Donor source entry for URL-only adapters (http, zip).",
-            "required": ["from", "url"],
-            "properties": {
-                "from": {
-                    "type": "string",
-                    "enum": ["http", "zip"]
-                },
-                "url": {
-                    "type": "string",
-                    "minLength": 1,
-                    "format": "uri"
-                },
-                "host": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "ref": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "skills": {
-                    "type": "array",
-                    "description": "Optional allowlist of skill directory names to sync from this donor. Absent / omitted → sync every skill the donor ships; empty list → donor is registered but no skills are pulled (matches `sourceByPackage` semantics).",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    }
-                },
-                "sha256": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Optional integrity hash (zip adapter)."
                 }
             }
         },

--- a/src/Config/Exception/MalformedSourceEntry.php
+++ b/src/Config/Exception/MalformedSourceEntry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Exception;
+
+/**
+ * Raised by {@see \LLM\Skills\Config\Mapper\SourceEntryMapper} when a
+ * `sources[]` entry does not match the expected shape.
+ *
+ * This exception is an internal signal, not a policy decision: the entry
+ * mapper is shared between the project config (where a broken entry is
+ * fatal) and vendor packages (where it only skips the offending donor).
+ * Each caller catches it and rethrows as {@see MalformedProjectConfig}
+ * or {@see MalformedVendorConfig} respectively.
+ */
+final class MalformedSourceEntry extends ConfigException
+{
+    /**
+     * @param non-empty-string $reason human-readable cause, already carrying the
+     *        field path the caller passed to the mapper
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public readonly string $reason,
+    ) {
+        parent::__construct($reason);
+    }
+}

--- a/src/Config/Mapper/ExternalProjectConfigLoader.php
+++ b/src/Config/Mapper/ExternalProjectConfigLoader.php
@@ -56,6 +56,7 @@ final readonly class ExternalProjectConfigLoader
         'auto-sync',
         'path-from-root',
         'local',
+        'vendor-sources',
         'sources',
         'remote',
     ];

--- a/src/Config/Mapper/ProjectConfigMapper.php
+++ b/src/Config/Mapper/ProjectConfigMapper.php
@@ -7,13 +7,13 @@ namespace LLM\Skills\Config\Mapper;
 use Internal\Path;
 use LLM\Skills\Config\DependencyConfig;
 use LLM\Skills\Config\Exception\MalformedProjectConfig;
+use LLM\Skills\Config\Exception\MalformedSourceEntry;
 use LLM\Skills\Config\ProjectConfig;
 use LLM\Skills\Config\ProjectConfigResolution;
 use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Config\TrustedVendors;
 use LLM\Skills\Config\VendorPattern;
 use LLM\Skills\Discovery\Provider\ProviderId;
-use LLM\Skills\Discovery\Provider\Source\RefResolver;
 
 /**
  * Maps the consumer project's configuration into a typed
@@ -95,6 +95,7 @@ final readonly class ProjectConfigMapper
         'auto-sync',
         'path-from-root',
         'local',
+        'vendor-sources',
         self::SOURCES_KEY,
         self::DEPRECATED_SOURCES_KEY,
     ];
@@ -194,150 +195,6 @@ final readonly class ProjectConfigMapper
     }
 
     /**
-     * Read an optional string field that must be non-empty when present.
-     * Returns null when the key is absent.
-     *
-     * @param non-empty-string $field path prefix for error messages, e.g. `skills.json: sources[0]`
-     * @param non-empty-string $name field name inside the entry
-     *
-     * @return non-empty-string|null
-     *
-     * @throws MalformedProjectConfig
-     *
-     * @psalm-pure
-     */
-    private static function optionalNonEmptyString(mixed $value, string $field, string $name): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-        if (!\is_string($value) || $value === '') {
-            throw new MalformedProjectConfig(
-                $field . '.' . $name . ' must be a non-empty string',
-            );
-        }
-        return $value;
-    }
-
-    /**
-     * Pick adapter-specific extras out of a `sources[]` entry — anything
-     * that is not one of the well-known keys (`from`, `package`, `url`,
-     * `host`, `ref`, `skills`, `path`). Stored verbatim so adapters can
-     * read their own keys (`sha256` on `zip`, custom proxy options on
-     * `go`, …) without a mapper-level schema for every adapter.
-     *
-     * @param array<array-key, mixed> $entry
-     *
-     * @return array<string, mixed>
-     *
-     * @psalm-pure
-     */
-    private static function collectExtras(array $entry): array
-    {
-        /** @var array<string, mixed> $extras */
-        $extras = [];
-        /** @var mixed $value */
-        foreach ($entry as $key => $value) {
-            if (!\is_string($key)) {
-                continue;
-            }
-            if (
-                $key === 'from'
-                || $key === 'package'
-                || $key === 'url'
-                || $key === 'host'
-                || $key === 'ref'
-                || $key === 'skills'
-                || $key === 'path'
-            ) {
-                continue;
-            }
-            /** @psalm-suppress MixedAssignment intentional — adapter-specific extras are stored verbatim */
-            $extras[$key] = $value;
-        }
-
-        return $extras;
-    }
-
-    /**
-     * Parse the optional `sources[].skills` allowlist. Three states:
-     *
-     * - absent / `null` → no filter, every skill is synced (default);
-     * - non-empty list → only the listed skills are synced;
-     * - empty list (`[]`) → the donor is registered but no skills are
-     *   pulled from it (useful for staging or temporary opt-out
-     *   without deleting the entry).
-     *
-     * Non-list values, or lists with non-string / empty-string
-     * elements, are load-time errors.
-     *
-     * @return list<non-empty-string>|null
-     *
-     * @throws MalformedProjectConfig
-     *
-     * @psalm-pure
-     */
-    private static function mapSourceSkills(mixed $raw, string $field): ?array
-    {
-        if ($raw === null) {
-            return null;
-        }
-        if (!\is_array($raw) || !\array_is_list($raw)) {
-            throw new MalformedProjectConfig(
-                $field . '.skills must be a list of skill names',
-            );
-        }
-        /** @var list<non-empty-string> $out */
-        $out = [];
-        /** @var mixed $name */
-        foreach ($raw as $i => $name) {
-            if (!\is_string($name) || $name === '') {
-                throw new MalformedProjectConfig(\sprintf(
-                    '%s.skills[%d] must be a non-empty string',
-                    $field,
-                    $i,
-                ));
-            }
-            $out[] = $name;
-        }
-        return $out;
-    }
-
-    /**
-     * Reject a `ref` that carries version-constraint syntax the
-     * {@see RefResolver} cannot satisfy.
-     *
-     * Adapters treat any `ref` they do not recognise as a constraint as
-     * a literal tag / branch / SHA and hand it to the host verbatim.
-     * That is the right default for `main` or `v1.2.3`, but it turns a
-     * near-miss like `~1.2.3` (before tilde support) or `>=1.0` into a
-     * bare 404 from the archive endpoint — a wrong-looking network error
-     * for what is really a typo in `skills.json`. Catching it here
-     * names the field and lists what is accepted.
-     *
-     * @param non-empty-string $ref
-     * @param non-empty-string $field
-     *
-     * @throws MalformedProjectConfig
-     *
-     * @psalm-pure
-     */
-    private static function assertSupportedRef(string $ref, string $field): void
-    {
-        $resolver = new RefResolver();
-        if (!$resolver->looksLikeConstraint($ref) || $resolver->isConstraint($ref)) {
-            return;
-        }
-
-        throw new MalformedProjectConfig(\sprintf(
-            '%s.ref "%s" is not a supported version constraint — use a caret (^1.2.3), '
-            . 'a tilde (~1.2), or a literal tag / branch / commit (v1.2.3, main)',
-            $field,
-            $ref,
-        ));
-    }
-
-    /**
      * Map an inline `extra` array, keeping the deprecation flag that
      * {@see self::fromExtra()} discards for back-compat. Shared by
      * {@see self::forProject()}'s inline branch.
@@ -406,6 +263,13 @@ final readonly class ProjectConfigMapper
             );
         }
 
+        $vendorSources = $skills['vendor-sources'] ?? true;
+        if (!\is_bool($vendorSources)) {
+            throw new MalformedProjectConfig(
+                self::field($prefix, 'vendor-sources') . ' must be a boolean',
+            );
+        }
+
         $pathFromRoot = $this->mapPathFromRoot($skills['path-from-root'] ?? null, $prefix);
 
         // `dependencies` is canonical; `trusted`, `trusted-replace` and
@@ -462,6 +326,7 @@ final readonly class ProjectConfigMapper
             managerEnabled: $managerEnabled,
             sources: $sources,
             dependencies: $dependencies,
+            vendorSources: $vendorSources,
         );
 
         return new MappedSkillsBlock($config, $usedDeprecatedSourcesKey, $usedDeprecatedDependencyKeys);
@@ -832,159 +697,32 @@ final readonly class ProjectConfigMapper
      */
     private function mapSources(mixed $raw, string $prefix, string $key): array
     {
-        if ($raw === [] || $raw === null) {
-            return [];
-        }
-        if (!\is_array($raw) || !\array_is_list($raw)) {
-            throw new MalformedProjectConfig(
-                self::field($prefix, $key) . ' must be a list of objects',
-            );
+        $field = self::field($prefix, $key);
+
+        try {
+            $entries = SourceEntryMapper::mapList($raw, $field);
+        } catch (MalformedSourceEntry $e) {
+            throw new MalformedProjectConfig($e->reason);
         }
 
-        $out = [];
-        $seen = [];
-        /**
-         * @var int $index
-         * @var mixed $entry
-         */
-        foreach ($raw as $index => $entry) {
-            $parsed = $this->mapSourceEntry($entry, $prefix, $key, $index);
-
-            $compositeKey = $parsed->compositeKey();
-            if (isset($seen[$compositeKey])) {
+        // `self.version` binds a ref to the installed version of the
+        // package that declares the entry — meaningful only inside a
+        // vendor package's `extra.skills.sources`. Project config has no
+        // declaring package to bind to, so the alias is a load-time
+        // error here rather than a literal ref that would 404 at the
+        // archive endpoint.
+        foreach ($entries as $index => $entry) {
+            if ($entry->ref === SourceEntry::SELF_VERSION) {
                 throw new MalformedProjectConfig(\sprintf(
-                    '%s[%d] duplicates an earlier entry (composite key: %s)',
-                    self::field($prefix, $key),
+                    '%s[%d].ref "%s" is only supported in a vendor package\'s extra.skills.sources',
+                    $field,
                     $index,
-                    $compositeKey,
+                    SourceEntry::SELF_VERSION,
                 ));
             }
-            $seen[$compositeKey] = true;
-            $out[] = $parsed;
         }
 
-        return $out;
-    }
-
-    /**
-     * @param non-empty-string $prefix
-     * @param non-empty-string $key config key the entry was read from (`sources` or its
-     *        deprecated `remote` alias)
-     *
-     * @throws MalformedProjectConfig
-     *
-     * @psalm-pure
-     */
-    private function mapSourceEntry(mixed $entry, string $prefix, string $key, int $index): SourceEntry
-    {
-        $field = self::field($prefix, $key) . '[' . $index . ']';
-
-        if (!\is_array($entry) || \array_is_list($entry)) {
-            throw new MalformedProjectConfig($field . ' must be an object');
-        }
-
-        /** @var mixed $rawFrom */
-        $rawFrom = $entry['from'] ?? null;
-        if (!\is_string($rawFrom) || $rawFrom === '') {
-            throw new MalformedProjectConfig(
-                $field . '.from must be a non-empty string',
-            );
-        }
-        if (!ProviderId::isKnownSource($rawFrom)) {
-            throw new MalformedProjectConfig(\sprintf(
-                '%s.from "%s" is not a known source adapter (known: %s)',
-                $field,
-                $rawFrom,
-                \implode(', ', ProviderId::SOURCE_IDS),
-            ));
-        }
-        /** @var non-empty-string $from */
-        $from = $rawFrom;
-
-        $package = self::optionalNonEmptyString($entry['package'] ?? null, $field, 'package');
-        $url = self::optionalNonEmptyString($entry['url'] ?? null, $field, 'url');
-        $host = self::optionalNonEmptyString($entry['host'] ?? null, $field, 'host');
-        $ref = self::optionalNonEmptyString($entry['ref'] ?? null, $field, 'ref');
-        $path = self::optionalNonEmptyString($entry['path'] ?? null, $field, 'path');
-
-        // Identifier rules by adapter kind: path-only adapters (dir)
-        // take `path`; URL-only adapters take `url`; name-based adapters
-        // take `package`. The identifier must be the one the adapter
-        // expects — a typo (e.g. `package` on a `zip` entry, or `url`
-        // on a `dir` entry) is a silent footgun if we accept it, so it
-        // surfaces as a load-time error instead.
-        if (ProviderId::isPathOnlySource($from)) {
-            // `path` is the identifier; `package` stays optional as a
-            // donor-name override; `url`/`host`/`ref` are meaningless.
-            if ($path === null) {
-                throw new MalformedProjectConfig(
-                    $field . '.path is required for adapter "' . $from . '"',
-                );
-            }
-            if ($url !== null) {
-                throw new MalformedProjectConfig(
-                    $field . '.url is not allowed for adapter "' . $from . '" (use path)',
-                );
-            }
-            if ($host !== null) {
-                throw new MalformedProjectConfig(
-                    $field . '.host is not allowed for adapter "' . $from . '"',
-                );
-            }
-            if ($ref !== null) {
-                throw new MalformedProjectConfig(
-                    $field . '.ref is not allowed for adapter "' . $from . '"',
-                );
-            }
-        } else {
-            if ($path !== null) {
-                throw new MalformedProjectConfig(
-                    $field . '.path is not allowed for adapter "' . $from . '" (dir only)',
-                );
-            }
-            if (ProviderId::isUrlOnlySource($from)) {
-                if ($url === null) {
-                    throw new MalformedProjectConfig(
-                        $field . '.url is required for adapter "' . $from . '"',
-                    );
-                }
-                if ($package !== null) {
-                    throw new MalformedProjectConfig(
-                        $field . '.package is not allowed for adapter "' . $from . '" (use url)',
-                    );
-                }
-            } else {
-                if ($package === null) {
-                    throw new MalformedProjectConfig(
-                        $field . '.package is required for adapter "' . $from . '"',
-                    );
-                }
-                if ($url !== null) {
-                    throw new MalformedProjectConfig(
-                        $field . '.url is not allowed for adapter "' . $from . '" (use package)',
-                    );
-                }
-            }
-        }
-
-        if ($ref !== null) {
-            self::assertSupportedRef($ref, $field);
-        }
-
-        $skills = self::mapSourceSkills($entry['skills'] ?? null, $field);
-
-        $extras = self::collectExtras($entry);
-
-        return new SourceEntry(
-            from: $from,
-            package: $package,
-            url: $url,
-            host: $host,
-            ref: $ref,
-            extras: $extras,
-            skills: $skills,
-            path: $path,
-        );
+        return $entries;
     }
 
     /**

--- a/src/Config/Mapper/SourceEntryMapper.php
+++ b/src/Config/Mapper/SourceEntryMapper.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Config\Mapper;
+
+use LLM\Skills\Config\Exception\MalformedSourceEntry;
+use LLM\Skills\Config\SourceEntry;
+use LLM\Skills\Discovery\Provider\ProviderId;
+use LLM\Skills\Discovery\Provider\Source\RefResolver;
+
+/**
+ * Maps raw JSON `sources[]` entries into typed {@see SourceEntry} values.
+ *
+ * Shared between the two config surfaces that declare donor sources:
+ *
+ * - the consumer project's `skills.json` / inline `extra.skills`
+ *   ({@see ProjectConfigMapper}), where a broken entry is fatal;
+ * - a vendor package's `extra.skills.sources`
+ *   ({@see VendorConfigMapper}), where a broken entry only skips the
+ *   offending donor.
+ *
+ * The mapper itself is policy-free: every failure is a
+ * {@see MalformedSourceEntry} carrying the caller-supplied field path,
+ * and each caller rethrows it as its own fatal / non-fatal exception
+ * type. Surface-specific rules (rejecting `dir` in vendor packages,
+ * rejecting `self.version` in project config) also live in the callers —
+ * this class validates only what a `sources[]` entry means everywhere.
+ *
+ * @psalm-immutable
+ */
+final readonly class SourceEntryMapper
+{
+    /**
+     * Parse and validate a `sources[]` list. Each entry is structurally
+     * an object with a mandatory `from` (adapter id), an identifier
+     * matching the adapter kind (`path` for dir, `url` for URL-only,
+     * `package` otherwise), and optional `host` / `ref` plus
+     * adapter-specific extras. Composite uniqueness on
+     * `(from, host, path|package|url)` is enforced inside this method so
+     * the caller does not have to.
+     *
+     * @param non-empty-string $field rendered path of the list for error messages,
+     *        e.g. `skills.json: sources` or `extra.skills.sources`
+     *
+     * @return list<SourceEntry>
+     *
+     * @throws MalformedSourceEntry
+     *
+     * @psalm-pure
+     */
+    public static function mapList(mixed $raw, string $field): array
+    {
+        if ($raw === [] || $raw === null) {
+            return [];
+        }
+        if (!\is_array($raw) || !\array_is_list($raw)) {
+            throw new MalformedSourceEntry(
+                $field . ' must be a list of objects',
+            );
+        }
+
+        $out = [];
+        $seen = [];
+        /**
+         * @var int $index
+         * @var mixed $entry
+         */
+        foreach ($raw as $index => $entry) {
+            $parsed = self::mapEntry($entry, $field . '[' . $index . ']');
+
+            $compositeKey = $parsed->compositeKey();
+            if (isset($seen[$compositeKey])) {
+                throw new MalformedSourceEntry(\sprintf(
+                    '%s[%d] duplicates an earlier entry (composite key: %s)',
+                    $field,
+                    $index,
+                    $compositeKey,
+                ));
+            }
+            $seen[$compositeKey] = true;
+            $out[] = $parsed;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param non-empty-string $field rendered path of the entry for error messages,
+     *        e.g. `skills.json: sources[0]`
+     *
+     * @throws MalformedSourceEntry
+     *
+     * @psalm-pure
+     */
+    public static function mapEntry(mixed $entry, string $field): SourceEntry
+    {
+        if (!\is_array($entry) || \array_is_list($entry)) {
+            throw new MalformedSourceEntry($field . ' must be an object');
+        }
+
+        /** @var mixed $rawFrom */
+        $rawFrom = $entry['from'] ?? null;
+        if (!\is_string($rawFrom) || $rawFrom === '') {
+            throw new MalformedSourceEntry(
+                $field . '.from must be a non-empty string',
+            );
+        }
+        if (!ProviderId::isKnownSource($rawFrom)) {
+            throw new MalformedSourceEntry(\sprintf(
+                '%s.from "%s" is not a known source adapter (known: %s)',
+                $field,
+                $rawFrom,
+                \implode(', ', ProviderId::SOURCE_IDS),
+            ));
+        }
+        /** @var non-empty-string $from */
+        $from = $rawFrom;
+
+        $package = self::optionalNonEmptyString($entry['package'] ?? null, $field, 'package');
+        $url = self::optionalNonEmptyString($entry['url'] ?? null, $field, 'url');
+        $host = self::optionalNonEmptyString($entry['host'] ?? null, $field, 'host');
+        $ref = self::optionalNonEmptyString($entry['ref'] ?? null, $field, 'ref');
+        $path = self::optionalNonEmptyString($entry['path'] ?? null, $field, 'path');
+
+        // Identifier rules by adapter kind: path-only adapters (dir)
+        // take `path`; URL-only adapters take `url`; name-based adapters
+        // take `package`. The identifier must be the one the adapter
+        // expects — a typo (e.g. `package` on a `zip` entry, or `url`
+        // on a `dir` entry) is a silent footgun if we accept it, so it
+        // surfaces as a load-time error instead.
+        if (ProviderId::isPathOnlySource($from)) {
+            // `path` is the identifier; `package` stays optional as a
+            // donor-name override; `url`/`host`/`ref` are meaningless.
+            if ($path === null) {
+                throw new MalformedSourceEntry(
+                    $field . '.path is required for adapter "' . $from . '"',
+                );
+            }
+            if ($url !== null) {
+                throw new MalformedSourceEntry(
+                    $field . '.url is not allowed for adapter "' . $from . '" (use path)',
+                );
+            }
+            if ($host !== null) {
+                throw new MalformedSourceEntry(
+                    $field . '.host is not allowed for adapter "' . $from . '"',
+                );
+            }
+            if ($ref !== null) {
+                throw new MalformedSourceEntry(
+                    $field . '.ref is not allowed for adapter "' . $from . '"',
+                );
+            }
+        } else {
+            if ($path !== null) {
+                throw new MalformedSourceEntry(
+                    $field . '.path is not allowed for adapter "' . $from . '" (dir only)',
+                );
+            }
+            if (ProviderId::isUrlOnlySource($from)) {
+                if ($url === null) {
+                    throw new MalformedSourceEntry(
+                        $field . '.url is required for adapter "' . $from . '"',
+                    );
+                }
+                if ($package !== null) {
+                    throw new MalformedSourceEntry(
+                        $field . '.package is not allowed for adapter "' . $from . '" (use url)',
+                    );
+                }
+            } else {
+                if ($package === null) {
+                    throw new MalformedSourceEntry(
+                        $field . '.package is required for adapter "' . $from . '"',
+                    );
+                }
+                if ($url !== null) {
+                    throw new MalformedSourceEntry(
+                        $field . '.url is not allowed for adapter "' . $from . '" (use package)',
+                    );
+                }
+            }
+        }
+
+        if ($ref !== null && $ref !== SourceEntry::SELF_VERSION) {
+            self::assertSupportedRef($ref, $field);
+        }
+
+        $skills = self::mapSourceSkills($entry['skills'] ?? null, $field);
+
+        $extras = self::collectExtras($entry);
+
+        return new SourceEntry(
+            from: $from,
+            package: $package,
+            url: $url,
+            host: $host,
+            ref: $ref,
+            extras: $extras,
+            skills: $skills,
+            path: $path,
+        );
+    }
+
+    /**
+     * Read an optional string field that must be non-empty when present.
+     * Returns null when the key is absent.
+     *
+     * @param non-empty-string $field path prefix for error messages, e.g. `skills.json: sources[0]`
+     * @param non-empty-string $name field name inside the entry
+     *
+     * @return non-empty-string|null
+     *
+     * @throws MalformedSourceEntry
+     *
+     * @psalm-pure
+     */
+    private static function optionalNonEmptyString(mixed $value, string $field, string $name): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        if (!\is_string($value) || $value === '') {
+            throw new MalformedSourceEntry(
+                $field . '.' . $name . ' must be a non-empty string',
+            );
+        }
+        return $value;
+    }
+
+    /**
+     * Pick adapter-specific extras out of a `sources[]` entry — anything
+     * that is not one of the well-known keys (`from`, `package`, `url`,
+     * `host`, `ref`, `skills`, `path`). Stored verbatim so adapters can
+     * read their own keys (`sha256` on `zip`, custom proxy options on
+     * `go`, …) without a mapper-level schema for every adapter.
+     *
+     * @param array<array-key, mixed> $entry
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-pure
+     */
+    private static function collectExtras(array $entry): array
+    {
+        /** @var array<string, mixed> $extras */
+        $extras = [];
+        /** @var mixed $value */
+        foreach ($entry as $key => $value) {
+            if (!\is_string($key)) {
+                continue;
+            }
+            if (
+                $key === 'from'
+                || $key === 'package'
+                || $key === 'url'
+                || $key === 'host'
+                || $key === 'ref'
+                || $key === 'skills'
+                || $key === 'path'
+            ) {
+                continue;
+            }
+            /** @psalm-suppress MixedAssignment intentional — adapter-specific extras are stored verbatim */
+            $extras[$key] = $value;
+        }
+
+        return $extras;
+    }
+
+    /**
+     * Parse the optional `sources[].skills` allowlist. Three states:
+     *
+     * - absent / `null` → no filter, every skill is synced (default);
+     * - non-empty list → only the listed skills are synced;
+     * - empty list (`[]`) → the donor is registered but no skills are
+     *   pulled from it (useful for staging or temporary opt-out
+     *   without deleting the entry).
+     *
+     * Non-list values, or lists with non-string / empty-string
+     * elements, are load-time errors.
+     *
+     * @return list<non-empty-string>|null
+     *
+     * @throws MalformedSourceEntry
+     *
+     * @psalm-pure
+     */
+    private static function mapSourceSkills(mixed $raw, string $field): ?array
+    {
+        if ($raw === null) {
+            return null;
+        }
+        if (!\is_array($raw) || !\array_is_list($raw)) {
+            throw new MalformedSourceEntry(
+                $field . '.skills must be a list of skill names',
+            );
+        }
+        /** @var list<non-empty-string> $out */
+        $out = [];
+        /** @var mixed $name */
+        foreach ($raw as $i => $name) {
+            if (!\is_string($name) || $name === '') {
+                throw new MalformedSourceEntry(\sprintf(
+                    '%s.skills[%d] must be a non-empty string',
+                    $field,
+                    $i,
+                ));
+            }
+            $out[] = $name;
+        }
+        return $out;
+    }
+
+    /**
+     * Reject a `ref` that carries version-constraint syntax the
+     * {@see RefResolver} cannot satisfy.
+     *
+     * Adapters treat any `ref` they do not recognise as a constraint as
+     * a literal tag / branch / SHA and hand it to the host verbatim.
+     * That is the right default for `main` or `v1.2.3`, but it turns a
+     * near-miss like `>=1.0` into a bare 404 from the archive endpoint —
+     * a wrong-looking network error for what is really a typo in the
+     * config. Catching it here names the field and lists what is
+     * accepted.
+     *
+     * @param non-empty-string $ref
+     * @param non-empty-string $field
+     *
+     * @throws MalformedSourceEntry
+     *
+     * @psalm-pure
+     */
+    private static function assertSupportedRef(string $ref, string $field): void
+    {
+        $resolver = new RefResolver();
+        if (!$resolver->looksLikeConstraint($ref) || $resolver->isConstraint($ref)) {
+            return;
+        }
+
+        throw new MalformedSourceEntry(\sprintf(
+            '%s.ref "%s" is not a supported version constraint — use a caret (^1.2.3), '
+            . 'a tilde (~1.2), an exact version (=1.2.3), '
+            . 'or a literal tag / branch / commit (v1.2.3, main)',
+            $field,
+            $ref,
+        ));
+    }
+}

--- a/src/Config/Mapper/VendorConfigMapper.php
+++ b/src/Config/Mapper/VendorConfigMapper.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace LLM\Skills\Config\Mapper;
 
 use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedSourceEntry;
 use LLM\Skills\Config\Exception\MalformedVendorConfig;
+use LLM\Skills\Config\SourceEntry;
 use LLM\Skills\Config\VendorConfig;
+use LLM\Skills\Discovery\Provider\ProviderId;
 
 /**
  * Maps a donor package's `extra` array (as returned by
@@ -55,6 +58,36 @@ final readonly class VendorConfigMapper
         /** @var mixed $skills */
         $skills = $extra['skills'] ?? null;
         return \is_array($skills) && \array_key_exists('source', $skills);
+    }
+
+    /**
+     * Quick predicate: does the package declare external skill sources
+     * (`extra.skills.sources`, a non-empty list)?
+     *
+     * Deliberately cheap and shape-only — a malformed list still answers
+     * `true` so the ref source runs the full parse and can surface the
+     * error instead of silently skipping the donor. Orthogonal to
+     * {@see self::declaresSkills()}: a package may declare either key or
+     * both, and each feeds its own discovery path (local rows vs
+     * fetched refs).
+     *
+     * @psalm-pure
+     */
+    public static function declaresSources(mixed $extra): bool
+    {
+        if (!\is_array($extra)) {
+            return false;
+        }
+
+        /** @var mixed $skills */
+        $skills = $extra['skills'] ?? null;
+        if (!\is_array($skills)) {
+            return false;
+        }
+
+        /** @var mixed $sources */
+        $sources = $skills['sources'] ?? null;
+        return \is_array($sources) && $sources !== [];
     }
 
     /**
@@ -128,5 +161,73 @@ final readonly class VendorConfigMapper
         }
 
         return $donors;
+    }
+
+    /**
+     * Parse a donor package's `extra.skills.sources` list — external
+     * sources the package advertises in addition to (or instead of) its
+     * in-package `source` directories. Entries share the `sources[]`
+     * vocabulary of `skills.json` with two vendor-side differences:
+     *
+     * - path-only adapters (`dir`) are rejected — an in-package path is
+     *   what `extra.skills.source` is for, and a vendor-controlled
+     *   filesystem path outside its own root has no safe meaning;
+     * - the {@see SourceEntry::SELF_VERSION} ref alias is allowed (the
+     *   ref source later binds it to the package's installed version).
+     *
+     * The `sources` key is ignored by {@see self::fromExtra()} on
+     * purpose: local rows and external refs feed different discovery
+     * paths, and a fetched archive's own `sources` must never be
+     * honoured (no transitive remote chains).
+     *
+     * @param non-empty-string $packageName
+     * @param mixed $extra raw value of `composer.json` `extra` field
+     *
+     * @return list<SourceEntry>
+     *
+     * @throws MalformedVendorConfig when `extra.skills.sources` is present but invalid
+     *
+     * @psalm-mutation-free
+     */
+    public function sourceEntriesFromExtra(string $packageName, mixed $extra): array
+    {
+        if (!\is_array($extra)) {
+            return [];
+        }
+
+        /** @var mixed $skills */
+        $skills = $extra['skills'] ?? null;
+        if (!\is_array($skills) || !\array_key_exists('sources', $skills)) {
+            return [];
+        }
+
+        /** @var mixed $raw */
+        $raw = $skills['sources'];
+
+        // Tailored `dir` rejection runs against the raw list so the
+        // message names the actual mistake (declaring a path-only
+        // adapter at all) rather than whichever shape rule the shared
+        // mapper trips over first.
+        if (\is_array($raw) && \array_is_list($raw)) {
+            /** @var mixed $entry */
+            foreach ($raw as $index => $entry) {
+                /** @var mixed $from */
+                $from = \is_array($entry) ? ($entry['from'] ?? null) : null;
+                if (\is_string($from) && ProviderId::isPathOnlySource($from)) {
+                    throw new MalformedVendorConfig($packageName, \sprintf(
+                        'extra.skills.sources[%d].from "%s" is not allowed in a vendor package '
+                        . '(use extra.skills.source for in-package paths)',
+                        $index,
+                        $from,
+                    ));
+                }
+            }
+        }
+
+        try {
+            return SourceEntryMapper::mapList($raw, 'extra.skills.sources');
+        } catch (MalformedSourceEntry $e) {
+            throw new MalformedVendorConfig($packageName, $e->reason);
+        }
     }
 }

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -63,6 +63,11 @@ final readonly class ProjectConfig
      *         model until the per-manager providers land. Empty when the block is absent
      *         (legacy `trusted` / `local` forms leave it empty and feed the flat fields
      *         directly).
+     * @param bool $vendorSources honours the `vendor-sources` toggle. When `false`, external
+     *         sources declared by vendor packages under their own `extra.skills.sources` are
+     *         ignored entirely — only the project's own `sources[]` and local package
+     *         directories contribute donors. Default `true`: a vendor-declared source is
+     *         still gated by the same trust rules as the declaring package itself.
      *
      * @psalm-mutation-free
      */
@@ -77,6 +82,7 @@ final readonly class ProjectConfig
         public array $managerEnabled = [],
         public array $sources = [],
         public array $dependencies = [],
+        public bool $vendorSources = true,
     ) {}
 
     /**
@@ -98,6 +104,7 @@ final readonly class ProjectConfig
             managerEnabled: [],
             sources: [],
             dependencies: [],
+            vendorSources: true,
         );
     }
 
@@ -136,6 +143,7 @@ final readonly class ProjectConfig
             $this->managerEnabled,
             $this->sources,
             $this->dependencies,
+            $this->vendorSources,
         );
     }
 
@@ -157,6 +165,7 @@ final readonly class ProjectConfig
             $this->managerEnabled,
             $this->sources,
             $this->dependencies,
+            $this->vendorSources,
         );
     }
 }

--- a/src/Config/SourceEntry.php
+++ b/src/Config/SourceEntry.php
@@ -35,6 +35,16 @@ use LLM\Skills\Discovery\Provider\ProviderId;
 final readonly class SourceEntry
 {
     /**
+     * Ref alias that binds the entry to the installed version of the
+     * vendor package declaring it (`extra.skills.sources` only): a
+     * released version resolves to the tag whose normalized form equals
+     * that version, a branch install (`dev-main`, `1.x-dev`) resolves to
+     * the branch itself. Rejected in project config, where there is no
+     * declaring package to bind to.
+     */
+    public const SELF_VERSION = 'self.version';
+
+    /**
      * @param non-empty-string $from adapter id, e.g. {@see ProviderId::GITHUB}
      * @param non-empty-string|null $package adapter-namespaced identifier (`acme/skills`,
      *         `@scope/pkg`, `github.com/owner/mod`, …). The identifier for name-based
@@ -46,8 +56,9 @@ final readonly class SourceEntry
      *         "use the adapter's default" (e.g. `https://api.github.com` for github).
      * @param non-empty-string|null $ref version pin — either a constraint the
      *         {@see \LLM\Skills\Discovery\Provider\Source\RefResolver} resolves against the
-     *         donor's tag list (`^1.2.3`, `~1.2`) or a literal ref the host accepts verbatim
-     *         (`v1.2.3`, `main`, a full SHA). Absent means the adapter picks the latest
+     *         donor's tag list (`^1.2.3`, `~1.2`, `=1.2.3`) or a literal ref the host accepts
+     *         verbatim (`v1.2.3`, `main`, a full SHA). Vendor-declared entries may also use
+     *         the {@see self::SELF_VERSION} alias. Absent means the adapter picks the latest
      *         stable tag, falling back to the default branch HEAD. Constraint flavours the
      *         resolver does not implement (`1.*`, `>=1.0`, `^1 || ^2`) are rejected by the
      *         config mapper rather than passed through as a literal ref.

--- a/src/Config/VendorConfig.php
+++ b/src/Config/VendorConfig.php
@@ -49,12 +49,14 @@ final readonly class VendorConfig
      *         catalog depth (`<source>/<category>/<name>/`). Always `null` for declared
      *         donors, whose `source` directory is the contract. Orthogonal to
      *         {@see $skillFilter}, which still applies on top.
-     * @param non-empty-string|null $declaredBy name of the installed Composer package whose
-     *         `extra.skills.sources` produced this donor; `null` for every other origin.
-     *         {@see \LLM\Skills\Sync\SyncPlanner} evaluates trust (and positional package
-     *         filters) against `declaredBy ?? packageName`, so a vendor-declared external
-     *         source is approved exactly when the declaring package itself would be —
-     *         unlike project `sources[]` entries, it is never implicit-trusted.
+     * @param list<non-empty-string> $declaredBy names of the installed Composer packages whose
+     *         `extra.skills.sources` produced this donor (several when they share one source
+     *         and ref); empty for every other origin. {@see \LLM\Skills\Sync\SyncPlanner}
+     *         evaluates trust (and positional package filters) against these names instead
+     *         of `packageName`, approving the donor when **any** declarer clears the gate —
+     *         so a vendor-declared external source is approved exactly when at least one
+     *         package that declared it would be. Unlike project `sources[]` entries, it is
+     *         never implicit-trusted.
      *
      * @psalm-mutation-free
      */
@@ -67,8 +69,22 @@ final readonly class VendorConfig
         public bool $implicitTrust = false,
         public ?array $skillFilter = null,
         public ?array $discoveredSkillDirs = null,
-        public ?string $declaredBy = null,
+        public array $declaredBy = [],
     ) {}
+
+    /**
+     * Names the planner judges this donor by: the declaring packages
+     * for a vendor-declared external source, the donor's own name
+     * otherwise. Always non-empty.
+     *
+     * @return non-empty-list<non-empty-string>
+     *
+     * @psalm-mutation-free
+     */
+    public function trustNames(): array
+    {
+        return $this->declaredBy === [] ? [$this->packageName] : $this->declaredBy;
+    }
 
     /**
      * Absolute path to the directory whose immediate subdirectories are skills.
@@ -131,16 +147,16 @@ final readonly class VendorConfig
     }
 
     /**
-     * Return a copy of this donor attributed to the vendor package that
-     * declared it in `extra.skills.sources`. The planner then evaluates
-     * trust and positional filters against the declaring package's name
-     * instead of the donor's own.
+     * Return a copy of this donor attributed to the vendor package(s)
+     * that declared it in `extra.skills.sources`. The planner then
+     * evaluates trust and positional filters against the declaring
+     * packages' names instead of the donor's own.
      *
-     * @param non-empty-string $declaredBy
+     * @param non-empty-list<non-empty-string> $declaredBy
      *
      * @psalm-mutation-free
      */
-    public function withDeclaredBy(string $declaredBy): self
+    public function withDeclaredBy(array $declaredBy): self
     {
         return new self(
             packageName: $this->packageName,

--- a/src/Config/VendorConfig.php
+++ b/src/Config/VendorConfig.php
@@ -49,6 +49,12 @@ final readonly class VendorConfig
      *         catalog depth (`<source>/<category>/<name>/`). Always `null` for declared
      *         donors, whose `source` directory is the contract. Orthogonal to
      *         {@see $skillFilter}, which still applies on top.
+     * @param non-empty-string|null $declaredBy name of the installed Composer package whose
+     *         `extra.skills.sources` produced this donor; `null` for every other origin.
+     *         {@see \LLM\Skills\Sync\SyncPlanner} evaluates trust (and positional package
+     *         filters) against `declaredBy ?? packageName`, so a vendor-declared external
+     *         source is approved exactly when the declaring package itself would be —
+     *         unlike project `sources[]` entries, it is never implicit-trusted.
      *
      * @psalm-mutation-free
      */
@@ -61,6 +67,7 @@ final readonly class VendorConfig
         public bool $implicitTrust = false,
         public ?array $skillFilter = null,
         public ?array $discoveredSkillDirs = null,
+        public ?string $declaredBy = null,
     ) {}
 
     /**
@@ -92,6 +99,7 @@ final readonly class VendorConfig
             implicitTrust: $this->implicitTrust,
             skillFilter: $this->skillFilter,
             discoveredSkillDirs: $this->discoveredSkillDirs,
+            declaredBy: $this->declaredBy,
         );
     }
 
@@ -118,6 +126,32 @@ final readonly class VendorConfig
             implicitTrust: true,
             skillFilter: $this->skillFilter,
             discoveredSkillDirs: $this->discoveredSkillDirs,
+            declaredBy: $this->declaredBy,
+        );
+    }
+
+    /**
+     * Return a copy of this donor attributed to the vendor package that
+     * declared it in `extra.skills.sources`. The planner then evaluates
+     * trust and positional filters against the declaring package's name
+     * instead of the donor's own.
+     *
+     * @param non-empty-string $declaredBy
+     *
+     * @psalm-mutation-free
+     */
+    public function withDeclaredBy(string $declaredBy): self
+    {
+        return new self(
+            packageName: $this->packageName,
+            packageRoot: $this->packageRoot,
+            source: $this->source,
+            discovered: $this->discovered,
+            provenance: $this->provenance,
+            implicitTrust: $this->implicitTrust,
+            skillFilter: $this->skillFilter,
+            discoveredSkillDirs: $this->discoveredSkillDirs,
+            declaredBy: $declaredBy,
         );
     }
 
@@ -141,6 +175,7 @@ final readonly class VendorConfig
             implicitTrust: $this->implicitTrust,
             skillFilter: $skillFilter,
             discoveredSkillDirs: $this->discoveredSkillDirs,
+            declaredBy: $this->declaredBy,
         );
     }
 }

--- a/src/Discovery/Provider/DonorProviderBuilder.php
+++ b/src/Discovery/Provider/DonorProviderBuilder.php
@@ -17,6 +17,7 @@ use LLM\Skills\Discovery\Provider\Source\Http\ComposerHttpClient;
 use LLM\Skills\Discovery\Provider\Source\HttpArchiveFetcher;
 use LLM\Skills\Discovery\Provider\Source\SourceProvider;
 use LLM\Skills\Discovery\Provider\Source\SkillsJsonDonorRefSource;
+use LLM\Skills\Discovery\Provider\Source\VendorDeclaredRefSource;
 
 /**
  * Constructs the {@see CompositeDonorProvider} for an entrypoint.
@@ -35,14 +36,24 @@ use LLM\Skills\Discovery\Provider\Source\SkillsJsonDonorRefSource;
  *  1. **`ComposerProvider`** — local, honours the `dependencies.composer`
  *     toggle. Inactive when no Composer instance is supplied or when
  *     the toggle is `false`.
- *  2. **`SourceProvider`** — wired with a {@see SkillsJsonDonorRefSource}
- *     (reads `sources[]` from `skills.json`) and a {@see HttpArchiveFetcher}
- *     (downloads + extracts archives into `vendor/llm-skills/cache/...`).
- *     Inactive when `sources[]` is empty.
+ *  2. **`SourceProvider` over vendor declarations** — wired with a
+ *     {@see VendorDeclaredRefSource} (reads `extra.skills.sources`
+ *     from installed packages). Inactive when no package declares
+ *     external sources, when no Composer instance is supplied, or when
+ *     the project sets `vendor-sources: false`.
+ *  3. **`SourceProvider` over project config** — wired with a
+ *     {@see SkillsJsonDonorRefSource} (reads `sources[]` from
+ *     `skills.json`). Inactive when `sources[]` is empty.
  *
- * Source is wired LAST so the composite's "later-wins" semantic
- * makes explicit source entries override transitive local discoveries
- * of the same package name.
+ * Both source providers share the {@see HttpArchiveFetcher} (downloads
+ * + extracts archives into `vendor/llm-skills/cache/...`), so two
+ * origins pointing at the same archive resolve to one cached copy.
+ *
+ * Sources are wired after local, project entries LAST, so the
+ * composite's "later-wins" semantic makes explicit source entries
+ * override transitive local discoveries of the same package name, and
+ * the project's own entry override a vendor-declared one for the same
+ * donor.
  *
  * The builder does a **best-effort** read of `skills.json` to pick up
  * the `dependencies` toggles. If that read throws (malformed config), the
@@ -70,13 +81,14 @@ final readonly class DonorProviderBuilder
         $composerEnabled = $this->resolveManagerEnabled($projectRoot, $extra, ProviderId::COMPOSER);
 
         $local = new ComposerProvider($composer, enabled: $composerEnabled);
-        $source = $this->buildSourceProvider($composer);
+        [$vendorSource, $projectSource] = $this->buildSourceProviders($composer);
 
-        return new CompositeDonorProvider($local, $source);
+        return new CompositeDonorProvider($local, $vendorSource, $projectSource);
     }
 
     /**
-     * Build the source provider. Wires the GitHub adapter, an HTTP
+     * Build the two source providers — vendor-declared entries first,
+     * project entries second. Wires the GitHub/GitLab adapters, an HTTP
      * client (so auth.json credentials apply), and an archive fetcher
      * into the {@see SourceProvider} skeleton.
      *
@@ -93,8 +105,15 @@ final readonly class DonorProviderBuilder
      *   from `<cwd>`. This matters because the local Composer donor
      *   is just one provider — refusing to wire source when local is
      *   unavailable would defeat the multi-source design.
+     *
+     * Vendor declarations, however, do require a Composer instance —
+     * they live in the installed packages' metadata. Without one, the
+     * {@see VendorDeclaredRefSource} simply reports no refs.
+     *
+     * @return array{SourceProvider, SourceProvider} vendor-declared provider first,
+     *         project provider second — the wiring order the composite relies on
      */
-    private function buildSourceProvider(?Composer $composer): SourceProvider
+    private function buildSourceProviders(?Composer $composer): array
     {
         $config = $composer?->getConfig() ?? Factory::createConfig(new NullIO());
         $httpClient = ComposerHttpClient::fromConfig($config);
@@ -103,7 +122,6 @@ final readonly class DonorProviderBuilder
             new GithubAdapter($httpClient),
             new GitlabAdapter($httpClient),
         );
-        $source = new SkillsJsonDonorRefSource($registry, $this->mapper);
         $fetcher = new HttpArchiveFetcher(
             $httpClient,
             $composer !== null
@@ -112,7 +130,13 @@ final readonly class DonorProviderBuilder
             CachePathBuilder::fromVendorDir($config->get('vendor-dir')),
         );
 
-        return new SourceProvider($source, $fetcher);
+        $vendorSource = new VendorDeclaredRefSource($composer, $registry, projectMapper: $this->mapper);
+        $projectSource = new SkillsJsonDonorRefSource($registry, $this->mapper);
+
+        return [
+            new SourceProvider($vendorSource, $fetcher),
+            new SourceProvider($projectSource, $fetcher),
+        ];
     }
 
     /**

--- a/src/Discovery/Provider/Source/RefResolver.php
+++ b/src/Discovery/Provider/Source/RefResolver.php
@@ -15,17 +15,20 @@ namespace LLM\Skills\Discovery\Provider\Source;
  * - **Pick the best tag** from a list — highest stable, falling
  *   back to highest semver overall, falling back to the default
  *   branch HEAD (the cascade).
- * - **Apply range constraints** — match a caret (`^X.Y.Z`) or tilde
- *   (`~X.Y.Z`) constraint against a tag list.
+ * - **Apply constraints** — match a caret (`^X.Y.Z`) or tilde
+ *   (`~X.Y.Z`) range, or an exact version (`=X.Y.Z`), against a tag
+ *   list. The exact form matches by normalized equality, so `=1.4.2`
+ *   finds `v1.4.2` and `1.4.2` alike — this is what `self.version`
+ *   refs in vendor-declared sources compile down to.
  * - **Reject what it cannot do** — {@see self::looksLikeConstraint()}
- *   flags constraint syntax outside that pair, so the config layer can
+ *   flags constraint syntax outside that set, so the config layer can
  *   answer "unsupported constraint" instead of letting the string reach
  *   the wire as a literal tag name and come back a 404.
  *
  * Composer ships a full semver implementation in `composer/semver`,
- * but the resolver here intentionally rolls a narrow subset: caret and
- * tilde, no `*` / `>=` / `<` / `||` / hyphen-range / stability-flag
- * parsing. Both supported operators follow Composer's own rules —
+ * but the resolver here intentionally rolls a narrow subset: caret,
+ * tilde and exact, no `*` / `>=` / `<` / `||` / hyphen-range /
+ * stability-flag parsing. Both supported operators follow Composer's own rules —
  * caret honours the pre-1.0 special case (`^0.y.z` locks the minor),
  * so a version `skills:add` pins on a 0.x donor resolves the way
  * Composer would; tilde has no such special case, so `~0.2` allows the
@@ -58,6 +61,16 @@ final readonly class RefResolver
      * rule without re-parsing the string.
      */
     private const CONSTRAINT_REGEX = '/^([\^~])v?(\d+)(?:\.(\d+))?(?:\.(\d+))?$/';
+
+    /**
+     * Exact-version constraint: `=` followed by one to four numeric
+     * components and an optional prerelease suffix (`=1.4.2`,
+     * `=v1.4`, `=2.0.0-beta1`). Matching is by normalized equality —
+     * the `v` prefix is ignored, missing components count as zero, and
+     * trailing zero components collapse — so the constraint finds the
+     * tag regardless of the repository's prefix convention.
+     */
+    private const EXACT_CONSTRAINT_REGEX = '/^=v?\d+(?:\.\d+){0,3}(?:-[\w.+-]+)?$/';
 
     /**
      * Syntax that is unmistakably a version constraint rather than a
@@ -157,10 +170,16 @@ final readonly class RefResolver
     }
 
     /**
-     * Resolve a caret or tilde constraint against a tag list. Returns
-     * the highest stable tag that satisfies the constraint, or null
-     * when none does (including when `$constraint` is not a
+     * Resolve a caret, tilde, or exact constraint against a tag list.
+     * Returns the highest stable tag that satisfies the constraint, or
+     * null when none does (including when `$constraint` is not a
      * constraint at all).
+     *
+     * Exact — `=` followed by a version; matches the first tag whose
+     * normalized form (`v` prefix ignored, missing components counted
+     * as zero) equals the version, so `=1.4.2` finds `v1.4.2`,
+     * `1.4.2`, and `=1.4` finds `v1.4.0`. Prerelease suffixes must
+     * match verbatim.
      *
      * Caret — bump the left-most non-zero component the constraint
      * specified:
@@ -194,6 +213,10 @@ final readonly class RefResolver
      */
     public function resolveConstraint(string $constraint, array $tags): ?string
     {
+        if (\preg_match(self::EXACT_CONSTRAINT_REGEX, $constraint) === 1) {
+            return self::resolveExact(\substr($constraint, 1), $tags);
+        }
+
         $match = \preg_match(self::CONSTRAINT_REGEX, $constraint, $m);
         if ($match !== 1) {
             return null;
@@ -266,7 +289,8 @@ final readonly class RefResolver
      */
     public function isConstraint(string $ref): bool
     {
-        return \preg_match(self::CONSTRAINT_REGEX, $ref) === 1;
+        return \preg_match(self::CONSTRAINT_REGEX, $ref) === 1
+            || \preg_match(self::EXACT_CONSTRAINT_REGEX, $ref) === 1;
     }
 
     /**
@@ -289,6 +313,65 @@ final readonly class RefResolver
     public function looksLikeConstraint(string $ref): bool
     {
         return \preg_match(self::CONSTRAINT_SYNTAX_REGEX, $ref) === 1;
+    }
+
+    /**
+     * First tag equal to `$version` under exact-match normalization,
+     * or null when none is. The tag is returned verbatim (prefix
+     * preserved) so the archive URL uses the spelling the host knows.
+     *
+     * @param list<non-empty-string> $tags
+     *
+     * @return non-empty-string|null
+     *
+     * @psalm-pure
+     */
+    private static function resolveExact(string $version, array $tags): ?string
+    {
+        $wanted = self::normaliseExact($version);
+        foreach ($tags as $tag) {
+            if (self::normaliseExact($tag) === $wanted) {
+                return $tag;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Canonical spelling for exact-match comparison: the `v` prefix is
+     * dropped, a purely numeric core is padded to three zero-trimmed
+     * components (`1.4` → `1.4.0`), and a prerelease suffix rides along
+     * verbatim. Non-numeric cores (branch-like strings) are returned
+     * as-is minus the prefix, degrading to literal comparison.
+     *
+     * @psalm-pure
+     */
+    private static function normaliseExact(string $version): string
+    {
+        $bare = \preg_replace('/^v(?=\d)/', '', $version) ?? $version;
+
+        $dash = \strpos($bare, '-');
+        $core = $dash === false ? $bare : \substr($bare, 0, $dash);
+        $suffix = $dash === false ? '' : \substr($bare, $dash);
+
+        $parts = \explode('.', $core);
+        foreach ($parts as $part) {
+            if ($part === '' || !\ctype_digit($part)) {
+                return $bare;
+            }
+        }
+        while (\count($parts) < 3) {
+            $parts[] = '0';
+        }
+        $parts = \array_map(static fn(string $p): string => (string) (int) $p, $parts);
+        // A fourth (or later) all-zero component is noise Composer adds
+        // in normalized versions — `1.2.3.0` and `1.2.3` are the same
+        // release.
+        while (\count($parts) > 3 && $parts[\count($parts) - 1] === '0') {
+            \array_pop($parts);
+        }
+
+        return \implode('.', $parts) . $suffix;
     }
 
     /**

--- a/src/Discovery/Provider/Source/RemoteDonorRef.php
+++ b/src/Discovery/Provider/Source/RemoteDonorRef.php
@@ -43,12 +43,13 @@ final readonly class RemoteDonorRef
      *         package name when the archive ships skills without a `composer.json` —
      *         the only stable identifier we have for ad-hoc skill repos. `null` for
      *         URL-only entries the adapter couldn't reduce to a vendor/package pair.
-     * @param non-empty-string|null $declaredBy name of the installed Composer package whose
-     *         `extra.skills.sources` produced this ref; `null` for refs the user declared
+     * @param list<non-empty-string> $declaredBy names of the installed Composer packages whose
+     *         `extra.skills.sources` produced this ref — several when they point at the same
+     *         source and ref and were merged into one fetch. Empty for refs the user declared
      *         directly (project `sources[]`, `skills:add`). Carried through to
      *         {@see \LLM\Skills\Config\VendorConfig::$declaredBy} so trust follows the
-     *         declaring package instead of being implicit, and woven into {@see label()}
-     *         so diagnostics name both parties.
+     *         declaring packages instead of being implicit, and woven into {@see label()}
+     *         so diagnostics name every party.
      *
      * @psalm-mutation-free
      */
@@ -58,7 +59,7 @@ final readonly class RemoteDonorRef
         public ?string $provenance = null,
         public ?array $skillFilter = null,
         public ?string $packageHint = null,
-        public ?string $declaredBy = null,
+        public array $declaredBy = [],
     ) {}
 
     /**
@@ -81,8 +82,9 @@ final readonly class RemoteDonorRef
      * Falls back to the URL when the adapter could not reduce the entry
      * to a `vendor/repo` pair, which is the only identifier a URL-only
      * entry has. Vendor-declared refs are prefixed with the declaring
-     * package (`acme/foo → github:acme/skills`) so a failure names the
-     * `composer.json` the entry actually lives in.
+     * package(s) (`acme/foo → github:acme/skills`,
+     * `acme/one, acme/two → github:acme/bundle`) so a failure names
+     * every `composer.json` the entry actually lives in.
      *
      * @return non-empty-string
      *
@@ -92,6 +94,6 @@ final readonly class RemoteDonorRef
     {
         $own = ($this->provenance ?? 'source') . ':' . ($this->packageHint ?? $this->url);
 
-        return $this->declaredBy === null ? $own : $this->declaredBy . ' → ' . $own;
+        return $this->declaredBy === [] ? $own : \implode(', ', $this->declaredBy) . ' → ' . $own;
     }
 }

--- a/src/Discovery/Provider/Source/RemoteDonorRef.php
+++ b/src/Discovery/Provider/Source/RemoteDonorRef.php
@@ -43,6 +43,12 @@ final readonly class RemoteDonorRef
      *         package name when the archive ships skills without a `composer.json` —
      *         the only stable identifier we have for ad-hoc skill repos. `null` for
      *         URL-only entries the adapter couldn't reduce to a vendor/package pair.
+     * @param non-empty-string|null $declaredBy name of the installed Composer package whose
+     *         `extra.skills.sources` produced this ref; `null` for refs the user declared
+     *         directly (project `sources[]`, `skills:add`). Carried through to
+     *         {@see \LLM\Skills\Config\VendorConfig::$declaredBy} so trust follows the
+     *         declaring package instead of being implicit, and woven into {@see label()}
+     *         so diagnostics name both parties.
      *
      * @psalm-mutation-free
      */
@@ -52,6 +58,7 @@ final readonly class RemoteDonorRef
         public ?string $provenance = null,
         public ?array $skillFilter = null,
         public ?string $packageHint = null,
+        public ?string $declaredBy = null,
     ) {}
 
     /**
@@ -73,7 +80,9 @@ final readonly class RemoteDonorRef
      * `github:acme/skills` rather than {@see describe()}'s full URL.
      * Falls back to the URL when the adapter could not reduce the entry
      * to a `vendor/repo` pair, which is the only identifier a URL-only
-     * entry has.
+     * entry has. Vendor-declared refs are prefixed with the declaring
+     * package (`acme/foo → github:acme/skills`) so a failure names the
+     * `composer.json` the entry actually lives in.
      *
      * @return non-empty-string
      *
@@ -81,6 +90,8 @@ final readonly class RemoteDonorRef
      */
     public function label(): string
     {
-        return ($this->provenance ?? 'source') . ':' . ($this->packageHint ?? $this->url);
+        $own = ($this->provenance ?? 'source') . ':' . ($this->packageHint ?? $this->url);
+
+        return $this->declaredBy === null ? $own : $this->declaredBy . ' → ' . $own;
     }
 }

--- a/src/Discovery/Provider/Source/SourceProvider.php
+++ b/src/Discovery/Provider/Source/SourceProvider.php
@@ -326,23 +326,31 @@ final readonly class SourceProvider implements DonorProvider
     }
 
     /**
-     * Apply the provenance + implicit-trust + skill-filter that every
-     * remote donor inherits from its `RemoteDonorRef`.
+     * Apply the provenance + trust attribution + skill-filter that
+     * every remote donor inherits from its `RemoteDonorRef`.
      *
      * @psalm-mutation-free
      */
     private function decorate(VendorConfig $donor, RemoteDonorRef|DirDonorRef $ref): VendorConfig
     {
         $provenance = $ref->provenance ?? 'source';
-        // `sources[]` entries are user-declared and therefore
-        // implicit-trusted, regardless of `from` value. The planner's
-        // trust list applies to local-provider transitive discoveries
-        // only. The optional skill allowlist carries through to the
-        // enumerator via {@see VendorConfig::$skillFilter}; `null`
-        // keeps the default "sync every skill" behaviour.
-        return $donor
+        $donor = $donor
             ->withProvenance($provenance)
-            ->asImplicitlyTrusted()
             ->withSkillFilter($ref->skillFilter);
+
+        // A ref declared by an installed vendor package (its
+        // `extra.skills.sources`) is third-party input: it inherits the
+        // declaring package's trust verdict via `declaredBy` and is
+        // never implicit-trusted. Every other `sources[]` entry is
+        // something the user typed by hand, so the planner does not
+        // consult the trust list for it. The optional skill allowlist
+        // carries through to the enumerator via
+        // {@see VendorConfig::$skillFilter}; `null` keeps the default
+        // "sync every skill" behaviour.
+        if ($ref instanceof RemoteDonorRef && $ref->declaredBy !== null) {
+            return $donor->withDeclaredBy($ref->declaredBy);
+        }
+
+        return $donor->asImplicitlyTrusted();
     }
 }

--- a/src/Discovery/Provider/Source/SourceProvider.php
+++ b/src/Discovery/Provider/Source/SourceProvider.php
@@ -347,7 +347,7 @@ final readonly class SourceProvider implements DonorProvider
         // carries through to the enumerator via
         // {@see VendorConfig::$skillFilter}; `null` keeps the default
         // "sync every skill" behaviour.
-        if ($ref instanceof RemoteDonorRef && $ref->declaredBy !== null) {
+        if ($ref instanceof RemoteDonorRef && $ref->declaredBy !== []) {
             return $donor->withDeclaredBy($ref->declaredBy);
         }
 

--- a/src/Discovery/Provider/Source/VendorDeclaredRefSource.php
+++ b/src/Discovery/Provider/Source/VendorDeclaredRefSource.php
@@ -130,7 +130,7 @@ final class VendorDeclaredRefSource implements DonorRefSource
          *     entry: SourceEntry,
          *     ref: non-empty-string|null,
          *     skills: list<non-empty-string>|null,
-         *     declaredBy: non-empty-string,
+         *     declaredBy: non-empty-list<non-empty-string>,
          *     hasFilter: bool,
          * }> $merged
          */
@@ -176,15 +176,21 @@ final class VendorDeclaredRefSource implements DonorRefSource
                         'entry' => $entry,
                         'ref' => $ref,
                         'skills' => $entry->skills,
-                        'declaredBy' => $name,
+                        'declaredBy' => [$name],
                         'hasFilter' => $entry->skills !== null,
                     ];
                     continue;
                 }
 
-                // Shared bundle: union the allowlists. An absent list
-                // means "every skill" and absorbs the union; otherwise
-                // merge preserving first-seen order.
+                // Shared bundle: every declarer is recorded, so the
+                // planner can approve the donor when any of them is
+                // trusted (or positionally named) — not just whichever
+                // package the repository happened to list first.
+                $merged[$key]['declaredBy'][] = $name;
+
+                // Union the allowlists. An absent list means "every
+                // skill" and absorbs the union; otherwise merge
+                // preserving first-seen order.
                 if ($merged[$key]['hasFilter'] && $entry->skills !== null) {
                     $merged[$key]['skills'] = \array_values(\array_unique(
                         [...($merged[$key]['skills'] ?? []), ...$entry->skills],
@@ -324,18 +330,20 @@ final class VendorDeclaredRefSource implements DonorRefSource
     }
 
     /**
-     * `<declarer> → <from>:<identifier>` identity for failure rows —
-     * names both the `composer.json` the entry lives in and the
-     * external source it points at.
+     * `<declarer>[, <declarer>…] → <from>:<identifier>` identity for
+     * failure rows — names every `composer.json` the entry lives in and
+     * the external source it points at.
      *
-     * @param non-empty-string $declaredBy
+     * @param non-empty-string|non-empty-list<non-empty-string> $declaredBy
      *
      * @return non-empty-string
      *
      * @psalm-mutation-free
      */
-    private function entryLabel(string $declaredBy, SourceEntry $entry): string
+    private function entryLabel(string|array $declaredBy, SourceEntry $entry): string
     {
-        return $declaredBy . ' → ' . $entry->from . ':' . $entry->identifier();
+        $declarers = \is_string($declaredBy) ? $declaredBy : \implode(', ', $declaredBy);
+
+        return $declarers . ' → ' . $entry->from . ':' . $entry->identifier();
     }
 }

--- a/src/Discovery/Provider/Source/VendorDeclaredRefSource.php
+++ b/src/Discovery/Provider/Source/VendorDeclaredRefSource.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Discovery\Provider\Source;
+
+use Composer\Composer;
+use Composer\Package\AliasPackage;
+use Composer\Package\PackageInterface;
+use Internal\Path;
+use LLM\Skills\Config\Exception\MalformedVendorConfig;
+use LLM\Skills\Config\Mapper\ProjectConfigMapper;
+use LLM\Skills\Config\Mapper\VendorConfigMapper;
+use LLM\Skills\Config\SourceEntry;
+use LLM\Skills\Discovery\Provider\ProviderId;
+use LLM\Skills\Discovery\Provider\Source\Adapter\HostAdapterRegistry;
+use LLM\Skills\Discovery\Provider\Source\Adapter\RemoteResolveException;
+use LLM\Skills\Discovery\Provider\Source\Adapter\UnknownAdapterException;
+use LLM\Skills\Discovery\SourceFailure;
+
+/**
+ * {@see DonorRefSource} backed by the `extra.skills.sources` lists of
+ * the **installed vendor packages** — the donor side of the external
+ * source feature: a package whose skills live outside the package
+ * itself (a separate skills repository, a bundle shared by several
+ * integration packages) advertises them with the same `sources[]`
+ * vocabulary the project uses in `skills.json`.
+ *
+ * Differences from {@see SkillsJsonDonorRefSource}, all following from
+ * the entries being third-party input rather than something the user
+ * typed:
+ *
+ * - every ref carries {@see RemoteDonorRef::$declaredBy}, so the donor
+ *   is **not** implicit-trusted — {@see \LLM\Skills\Sync\SyncPlanner}
+ *   judges it by the declaring package's name;
+ * - the {@see SourceEntry::SELF_VERSION} ref alias resolves against the
+ *   declaring package's installed version before the adapter runs;
+ * - entries are deduplicated **across packages** by composite key +
+ *   resolved ref: several integration packages pointing at one shared
+ *   bundle produce a single fetch, with their `skills` allowlists
+ *   unioned (an absent allowlist means "all skills" and absorbs the
+ *   union). Without this, a shared bundle would conflict with itself
+ *   at sync time;
+ * - the whole source honours the project-level `vendor-sources` toggle
+ *   (`skills.json`, default `true`) and stays silent when it is off —
+ *   the same contract as `dependencies.composer: false`.
+ *
+ * The `sources` list of a *fetched archive* is never read — depth is
+ * exactly one, no remote → remote chains. Per-entry isolation matches
+ * the sibling source: one malformed package or unresolvable entry never
+ * blocks the rest.
+ *
+ * The failure list is populated as the iterator runs, so the class is
+ * intentionally NOT `readonly`; {@see SourceProvider} consumes the
+ * iterable to exhaustion before reading the failures.
+ */
+final class VendorDeclaredRefSource implements DonorRefSource
+{
+    /** @var list<SourceFailure> */
+    private array $lastFailures = [];
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private readonly ?Composer $composer,
+        private readonly HostAdapterRegistry $registry,
+        private readonly VendorConfigMapper $vendorMapper = new VendorConfigMapper(),
+        private readonly ProjectConfigMapper $projectMapper = new ProjectConfigMapper(),
+    ) {}
+
+    /**
+     * Bind a {@see SourceEntry::SELF_VERSION} ref to the declaring
+     * package's installed version, following Composer's own version
+     * grammar:
+     *
+     * - `dev-<branch>` → the branch itself (`dev-main` → `main`);
+     * - `<X.Y…>-dev` (numeric-branch form) → the branch (`1.x-dev` → `1.x`);
+     * - anything else is a released version → an exact constraint
+     *   (`1.4.2` → `=1.4.2`) the adapter resolves against the tag list
+     *   by normalized equality, so the skills repository may spell the
+     *   tag with or without the `v` prefix.
+     *
+     * Returns `null` when the version cannot be turned into a ref
+     * (empty or branch-less strings) — the caller reports a failure and
+     * skips the entry.
+     *
+     * @return non-empty-string|null
+     *
+     * @psalm-pure
+     */
+    public static function resolveSelfVersion(string $prettyVersion): ?string
+    {
+        if ($prettyVersion === '') {
+            return null;
+        }
+
+        if (\str_starts_with($prettyVersion, 'dev-')) {
+            $branch = \substr($prettyVersion, 4);
+            return $branch !== '' ? $branch : null;
+        }
+
+        if (\str_ends_with($prettyVersion, '-dev')) {
+            $branch = \substr($prettyVersion, 0, -4);
+            return $branch !== '' ? $branch : null;
+        }
+
+        return '=' . $prettyVersion;
+    }
+
+    /**
+     * @return iterable<RemoteDonorRef>
+     */
+    #[\Override]
+    public function refs(Path $projectRoot): iterable
+    {
+        $this->lastFailures = [];
+
+        if ($this->composer === null || !$this->vendorSourcesEnabled($projectRoot)) {
+            return;
+        }
+
+        /**
+         * Declarations surviving the per-package parse, merged across
+         * packages. Keyed by composite key + resolved ref so two
+         * packages pinning the same bundle at the same ref collapse
+         * into one fetch, while different pins stay separate donors.
+         *
+         * @var array<string, array{
+         *     entry: SourceEntry,
+         *     ref: non-empty-string|null,
+         *     skills: list<non-empty-string>|null,
+         *     declaredBy: non-empty-string,
+         *     hasFilter: bool,
+         * }> $merged
+         */
+        $merged = [];
+
+        foreach ($this->declaringPackages() as $package) {
+            /** @var non-empty-string $name */
+            $name = $package->getName();
+
+            try {
+                $entries = $this->vendorMapper->sourceEntriesFromExtra($name, $package->getExtra());
+            } catch (MalformedVendorConfig $e) {
+                /** @var non-empty-string $reason */
+                $reason = \preg_replace('/^Package "[^"]+": /', '', $e->getMessage())
+                    ?? $e->getMessage();
+                $this->lastFailures[] = new SourceFailure(
+                    label: ProviderId::COMPOSER . ':' . $name,
+                    summary: 'invalid extra.skills.sources',
+                    detail: $reason,
+                );
+                continue;
+            }
+
+            foreach ($entries as $entry) {
+                $ref = $entry->ref;
+                if ($ref === SourceEntry::SELF_VERSION) {
+                    $ref = self::resolveSelfVersion($package->getPrettyVersion());
+                    if ($ref === null) {
+                        $this->lastFailures[] = new SourceFailure(
+                            label: $this->entryLabel($name, $entry),
+                            summary: \sprintf(
+                                'cannot bind self.version — package version "%s" is not usable as a ref',
+                                $package->getPrettyVersion(),
+                            ),
+                        );
+                        continue;
+                    }
+                }
+
+                $key = $entry->compositeKey() . '|' . ($ref ?? '');
+                if (!isset($merged[$key])) {
+                    $merged[$key] = [
+                        'entry' => $entry,
+                        'ref' => $ref,
+                        'skills' => $entry->skills,
+                        'declaredBy' => $name,
+                        'hasFilter' => $entry->skills !== null,
+                    ];
+                    continue;
+                }
+
+                // Shared bundle: union the allowlists. An absent list
+                // means "every skill" and absorbs the union; otherwise
+                // merge preserving first-seen order.
+                if ($merged[$key]['hasFilter'] && $entry->skills !== null) {
+                    $merged[$key]['skills'] = \array_values(\array_unique(
+                        [...($merged[$key]['skills'] ?? []), ...$entry->skills],
+                    ));
+                } else {
+                    $merged[$key]['skills'] = null;
+                    $merged[$key]['hasFilter'] = false;
+                }
+            }
+        }
+
+        foreach ($merged as $declaration) {
+            $entry = $declaration['entry'];
+            $declaredBy = $declaration['declaredBy'];
+
+            try {
+                $adapter = $this->registry->get($entry->from);
+            } catch (UnknownAdapterException $e) {
+                $this->lastFailures[] = new SourceFailure(
+                    label: $this->entryLabel($declaredBy, $entry),
+                    summary: 'unknown source adapter',
+                    detail: $e->getMessage(),
+                );
+                continue;
+            }
+
+            // The adapter sees the entry with the ref already bound
+            // (self.version rewritten to a branch or exact constraint)
+            // and the allowlist already unioned across declarers.
+            $effective = new SourceEntry(
+                from: $entry->from,
+                package: $entry->package,
+                url: $entry->url,
+                host: $entry->host,
+                ref: $declaration['ref'],
+                extras: $entry->extras,
+                skills: $declaration['skills'],
+            );
+
+            try {
+                $resolved = $adapter->resolve($effective);
+            } catch (RemoteResolveException $e) {
+                $this->lastFailures[] = new SourceFailure(
+                    label: $this->entryLabel($declaredBy, $entry),
+                    summary: $e->reason,
+                );
+                continue;
+            }
+
+            yield new RemoteDonorRef(
+                url: $resolved->url,
+                ref: $resolved->ref,
+                provenance: $entry->from,
+                skillFilter: $declaration['skills'],
+                packageHint: $entry->package,
+                declaredBy: $declaredBy,
+            );
+        }
+    }
+
+    /**
+     * @return list<SourceFailure>
+     */
+    #[\Override]
+    public function failures(): array
+    {
+        return $this->lastFailures;
+    }
+
+    /**
+     * Config-level check: does any installed package declare a
+     * non-empty `extra.skills.sources` list, with the project-level
+     * `vendor-sources` toggle on? Cheap by design — metadata reads
+     * only, no adapter calls, no HTTP.
+     */
+    #[\Override]
+    public function hasRefs(Path $projectRoot): bool
+    {
+        if ($this->composer === null || !$this->vendorSourcesEnabled($projectRoot)) {
+            return false;
+        }
+
+        foreach ($this->declaringPackages() as $_package) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the project allows vendor-declared external sources.
+     * Best-effort read: a malformed project config answers `false`
+     * here and the runner surfaces the real error on its own read.
+     */
+    private function vendorSourcesEnabled(Path $projectRoot): bool
+    {
+        try {
+            return $this->projectMapper->forProject($projectRoot, null)->config->vendorSources;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Installed packages that declare `extra.skills.sources`,
+     * deduplicated by name — a dev-branch dependency surfaces both as
+     * the real package and as Composer's synthetic default-branch
+     * alias, and both carry the same declarations.
+     *
+     * @return iterable<PackageInterface>
+     */
+    private function declaringPackages(): iterable
+    {
+        if ($this->composer === null) {
+            return;
+        }
+
+        $seen = [];
+        foreach ($this->composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+            // Unwrap Composer's synthetic branch aliases so
+            // `self.version` binds to the real installed version, not
+            // the `9999999-dev` placeholder the alias carries.
+            if ($package instanceof AliasPackage) {
+                $package = $package->getAliasOf();
+            }
+
+            $name = $package->getName();
+            if (isset($seen[$name])) {
+                continue;
+            }
+            $seen[$name] = true;
+
+            if (VendorConfigMapper::declaresSources($package->getExtra())) {
+                yield $package;
+            }
+        }
+    }
+
+    /**
+     * `<declarer> → <from>:<identifier>` identity for failure rows —
+     * names both the `composer.json` the entry lives in and the
+     * external source it points at.
+     *
+     * @param non-empty-string $declaredBy
+     *
+     * @return non-empty-string
+     *
+     * @psalm-mutation-free
+     */
+    private function entryLabel(string $declaredBy, SourceEntry $entry): string
+    {
+        return $declaredBy . ' → ' . $entry->from . ':' . $entry->identifier();
+    }
+}

--- a/src/Sync/SyncPlanner.php
+++ b/src/Sync/SyncPlanner.php
@@ -35,11 +35,12 @@ use LLM\Skills\Config\VendorConfig;
  *   the source level (every project `sources[]` entry, regardless of `from`).
  *   The trust list applies to third-party declarations only, so the planner
  *   skips it for these donors.
- * - A donor carrying {@see VendorConfig::$declaredBy} was declared by an
- *   installed vendor package (`extra.skills.sources`); it is never implicit-
- *   trusted, and every rule below — positional filters, direct-dependency
- *   trust, the trust list — is evaluated against the declaring package's
- *   name instead of the donor's own.
+ * - A donor carrying {@see VendorConfig::$declaredBy} was declared by one or
+ *   more installed vendor packages (`extra.skills.sources`); it is never
+ *   implicit-trusted, and every rule below — positional filters, direct-
+ *   dependency trust, the trust list — is evaluated against the declaring
+ *   packages' names instead of the donor's own, passing when any of them
+ *   clears it.
  * - A package declared as a direct dependency in the consumer's root
  *   `composer.json` (under `require` or `require-dev`) is implicitly
  *   trusted — the user already owns the decision to depend on it. This
@@ -84,16 +85,11 @@ final readonly class SyncPlanner
                 // (project `sources[]` entries); the trust list applies
                 // only to third-party declarations, so we skip the
                 // check entirely. A donor carrying `declaredBy` came
-                // from a vendor package's `extra.skills.sources` and is
-                // judged by the declaring package's name — the external
-                // bundle is approved exactly when the package that
+                // from vendor packages' `extra.skills.sources` and is
+                // judged by the declaring packages' names — the external
+                // bundle is approved exactly when any package that
                 // pointed at it would be.
-                $trustName = $donor->declaredBy ?? $donor->packageName;
-                if (
-                    $donor->implicitTrust
-                    || isset($directSet[$trustName])
-                    || $trust->trusts($trustName)
-                ) {
+                if ($donor->implicitTrust || self::anyTrusted($donor->trustNames(), $directSet, $trust)) {
                     $approved[] = $donor;
                     continue;
                 }
@@ -160,6 +156,39 @@ final readonly class SyncPlanner
             }
             $current = $parent;
         }
+    }
+
+    /**
+     * @param non-empty-list<non-empty-string> $names
+     * @param array<non-empty-string, true> $directSet
+     *
+     * @psalm-mutation-free
+     */
+    private static function anyTrusted(array $names, array $directSet, TrustedVendors $trust): bool
+    {
+        foreach ($names as $name) {
+            if (isset($directSet[$name]) || $trust->trusts($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param non-empty-list<non-empty-string> $names
+     *
+     * @psalm-mutation-free
+     */
+    private static function anyMatchesFilter(array $names, SyncOptions $options): bool
+    {
+        foreach ($names as $name) {
+            if ($options->matchesFilter($name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -280,14 +309,11 @@ final readonly class SyncPlanner
         $kept = [];
         $rejected = [];
         foreach ($donors as $donor) {
-            // A vendor-declared external donor travels with the package
+            // A vendor-declared external donor travels with the packages
             // that declared it: naming `acme/foo` positionally keeps
             // foo's remote skills too, while naming the bundle itself
             // also works.
-            if (
-                $options->matchesFilter($donor->packageName)
-                || ($donor->declaredBy !== null && $options->matchesFilter($donor->declaredBy))
-            ) {
+            if (self::anyMatchesFilter([$donor->packageName, ...$donor->declaredBy], $options)) {
                 $kept[] = $donor;
             } else {
                 $rejected[] = $donor;

--- a/src/Sync/SyncPlanner.php
+++ b/src/Sync/SyncPlanner.php
@@ -32,9 +32,14 @@ use LLM\Skills\Config\VendorConfig;
  *   the bouncer for *auto-discovered* donors, not for ones the user already
  *   asked for by name.
  * - A donor flagged {@see VendorConfig::$implicitTrust} is user-declared at
- *   the source level (today: every `sources[]` entry, regardless of `from`).
- *   The trust list applies to local-provider transitive discoveries only,
- *   so the planner skips it for these donors.
+ *   the source level (every project `sources[]` entry, regardless of `from`).
+ *   The trust list applies to third-party declarations only, so the planner
+ *   skips it for these donors.
+ * - A donor carrying {@see VendorConfig::$declaredBy} was declared by an
+ *   installed vendor package (`extra.skills.sources`); it is never implicit-
+ *   trusted, and every rule below — positional filters, direct-dependency
+ *   trust, the trust list — is evaluated against the declaring package's
+ *   name instead of the donor's own.
  * - A package declared as a direct dependency in the consumer's root
  *   `composer.json` (under `require` or `require-dev`) is implicitly
  *   trusted — the user already owns the decision to depend on it. This
@@ -76,13 +81,18 @@ final readonly class SyncPlanner
                 : \array_fill_keys($directDependencies, true);
             foreach ($filtered as $donor) {
                 // A donor flagged `implicitTrust` is user-declared
-                // (today: every `sources[]` entry); the trust list
-                // applies only to local-provider transitive discoveries,
-                // so we skip the check entirely.
+                // (project `sources[]` entries); the trust list applies
+                // only to third-party declarations, so we skip the
+                // check entirely. A donor carrying `declaredBy` came
+                // from a vendor package's `extra.skills.sources` and is
+                // judged by the declaring package's name — the external
+                // bundle is approved exactly when the package that
+                // pointed at it would be.
+                $trustName = $donor->declaredBy ?? $donor->packageName;
                 if (
                     $donor->implicitTrust
-                    || isset($directSet[$donor->packageName])
-                    || $trust->trusts($donor->packageName)
+                    || isset($directSet[$trustName])
+                    || $trust->trusts($trustName)
                 ) {
                     $approved[] = $donor;
                     continue;
@@ -270,7 +280,14 @@ final readonly class SyncPlanner
         $kept = [];
         $rejected = [];
         foreach ($donors as $donor) {
-            if ($options->matchesFilter($donor->packageName)) {
+            // A vendor-declared external donor travels with the package
+            // that declared it: naming `acme/foo` positionally keeps
+            // foo's remote skills too, while naming the bundle itself
+            // also works.
+            if (
+                $options->matchesFilter($donor->packageName)
+                || ($donor->declaredBy !== null && $options->matchesFilter($donor->declaredBy))
+            ) {
                 $kept[] = $donor;
             } else {
                 $rejected[] = $donor;

--- a/tests/Acceptance/SkillsJsonConfigTest.php
+++ b/tests/Acceptance/SkillsJsonConfigTest.php
@@ -229,6 +229,51 @@ final class SkillsJsonConfigTest
 
     #[WithSkillsJson([
         'target' => 'external-target/skills',
+        'trusted' => ['acme/skills-basic'],
+        'vendor-sources' => false,
+    ])]
+    public function vendorSourcesToggleIsAcceptedAndSyncStillRuns(): void
+    {
+        // `vendor-sources: false` opts the project out of external
+        // sources declared by installed packages. No sandbox package
+        // declares any, so the observable contract here is that the key
+        // passes the strict skills.json loader and the sync proceeds
+        // normally.
+        $process = $this->runSync();
+
+        Assert::same($process->getExitCode(), 0, 'stderr: ' . $process->getErrorOutput());
+        Assert::true(
+            \is_file(self::EXTERNAL_TARGET . '/greeting/SKILL.md'),
+            'local donors must sync as usual with vendor-sources disabled',
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
+        'sources' => [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ],
+    ])]
+    public function selfVersionRefIsRejectedInProjectSources(): void
+    {
+        // `self.version` binds a ref to the version of the vendor
+        // package declaring it — meaningless in project config, where
+        // there is no declaring package. Caught at config load, before
+        // anything touches the network.
+        $process = $this->runSync();
+        $err = $process->getErrorOutput();
+
+        Assert::notSame($process->getExitCode(), 0, 'self.version in project sources must fail the run');
+        Assert::true(
+            \str_contains($err, 'sources[0].ref')
+            && \str_contains($err, 'self.version')
+            && \str_contains($err, 'vendor package'),
+            'the error must name the field and point at extra.skills.sources. Got: ' . $err,
+        );
+    }
+
+    #[WithSkillsJson([
+        'target' => 'external-target/skills',
         'rogue' => 'value',
     ])]
     public function unknownKeyInSkillsJsonIsFatal(): void

--- a/tests/Acceptance/SkillsSchemaTest.php
+++ b/tests/Acceptance/SkillsSchemaTest.php
@@ -71,6 +71,22 @@ final class SkillsSchemaTest
         $this->assertAccepts([
             'sources' => [
                 ['from' => 'github', 'package' => 'acme/skills'],
+                ['from' => 'gitlab', 'package' => 'team/skills', 'ref' => '^1.2'],
+            ],
+        ]);
+    }
+
+    public function urlOnlySourceIsRejectedBySchema(): void
+    {
+        // `http` / `zip` are reserved in the ProviderId vocabulary but
+        // have no adapter yet. The schema deliberately does not document
+        // them, so editors offer no autocomplete for entries that would
+        // only fail at resolve time with "unknown source adapter". The
+        // PHP mapper still accepts the shape (vocabulary is locked) —
+        // when a url-only adapter lands, the schema regains a
+        // sourceByUrl branch without a mapper change.
+        $this->assertRejects([
+            'sources' => [
                 ['from' => 'zip', 'url' => 'https://example.com/skills.zip'],
             ],
         ]);

--- a/tests/Feature/VendorDeclaredSourcesEndToEndTest.php
+++ b/tests/Feature/VendorDeclaredSourcesEndToEndTest.php
@@ -117,7 +117,7 @@ final class VendorDeclaredSourcesEndToEndTest
         Assert::count($result->donors, 1);
         $donor = $result->donors[0];
         Assert::same($donor->packageName, 'acme/project-skills');
-        Assert::same($donor->declaredBy, 'acme/foo');
+        Assert::same($donor->declaredBy, ['acme/foo']);
         Assert::same($donor->provenance, 'github');
         Assert::false($donor->implicitTrust, 'vendor-declared sources must not be implicit-trusted');
 
@@ -190,6 +190,7 @@ final class VendorDeclaredSourcesEndToEndTest
         Assert::same($result->failures, []);
         Assert::count($result->donors, 1);
         Assert::same($result->donors[0]->skillFilter, ['deploy', 'review']);
+        Assert::same($result->donors[0]->declaredBy, ['acme/integration-a', 'acme/integration-b']);
         Assert::same($this->httpHits[$zipballUrl] ?? 0, 1, 'the shared bundle must be downloaded exactly once');
 
         // The unioned allowlist drives enumeration: both declared skills

--- a/tests/Feature/VendorDeclaredSourcesEndToEndTest.php
+++ b/tests/Feature/VendorDeclaredSourcesEndToEndTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Feature;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\NullIO;
+use Composer\Package\CompletePackage;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\RepositoryManager;
+use Composer\Util\HttpDownloader;
+use Internal\Path;
+use LLM\Skills\Config\ProjectConfig;
+use LLM\Skills\Config\SyncOptions;
+use LLM\Skills\Config\TrustedVendors;
+use LLM\Skills\Discovery\Provider\Source\Adapter\GithubAdapter;
+use LLM\Skills\Discovery\Provider\Source\Adapter\HostAdapterRegistry;
+use LLM\Skills\Discovery\Provider\Source\Http\HttpClient;
+use LLM\Skills\Discovery\Provider\Source\Http\HttpResponse;
+use LLM\Skills\Discovery\Provider\Source\HttpArchiveFetcher;
+use LLM\Skills\Discovery\Provider\Source\SourceProvider;
+use LLM\Skills\Discovery\Provider\Source\VendorDeclaredRefSource;
+use LLM\Skills\Sync\SyncPlanner;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Exception\SkipTest;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+/**
+ * End-to-end Feature test for vendor-declared external sources
+ * (`extra.skills.sources` in an installed package).
+ *
+ * Substitutes the real network with a counting {@see HttpClient} stub
+ * and Composer's local repository with an in-memory one — everything
+ * else (vendor mapper, `self.version` binding, adapter, fetcher,
+ * provider, planner trust rules) is the production code path. Same
+ * tier and rationale as {@see SourceProviderEndToEndTest}: the
+ * Acceptance sandbox cannot stub HTTP, so this test pins the
+ * in-process contract.
+ */
+#[Test]
+#[Covers(VendorDeclaredRefSource::class)]
+#[Covers(SourceProvider::class)]
+final class VendorDeclaredSourcesEndToEndTest
+{
+    private string $tmp;
+
+    /** @var \ArrayObject<string, int> URL → number of times the stub served it */
+    private \ArrayObject $httpHits;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-vendor-e2e-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+        $this->httpHits = new \ArrayObject();
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    public function selfVersionSourceResolvesFetchesAndIsGatedByTheDeclarersTrust(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // An installed package at 1.4.2 advertises a skills repository
+        // pinned to its own version. `self.version` must compile to the
+        // exact constraint `=1.4.2`, resolve through the tag listing to
+        // the `v`-prefixed tag, and download that zipball.
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.4.2', [
+            ['from' => 'github', 'package' => 'acme/project-skills', 'ref' => 'self.version'],
+        ]));
+
+        $zipBytes = $this->buildGithubStyleZip(
+            topDir: 'acme-project-skills-v1.4.2',
+            files: [
+                'composer.json' => \json_encode([
+                    'name' => 'acme/project-skills',
+                    'extra' => ['skills' => ['source' => 'skills']],
+                ], \JSON_THROW_ON_ERROR),
+                'skills/deploy/SKILL.md' => "---\nname: deploy\n---\nbody",
+            ],
+        );
+
+        $http = $this->stubHttp([
+            'https://api.github.com/repos/acme/project-skills/tags?per_page=100' => new HttpResponse(
+                statusCode: 200,
+                body: \json_encode(
+                    [['name' => 'v1.0.0'], ['name' => 'v1.4.2'], ['name' => 'v2.0.0']],
+                    \JSON_THROW_ON_ERROR,
+                ),
+            ),
+            'https://api.github.com/repos/acme/project-skills/zipball/v1.4.2' => new HttpResponse(
+                statusCode: 200,
+                body: $zipBytes,
+            ),
+        ]);
+
+        $provider = $this->providerFor($composer, $http);
+
+        Assert::true($provider->isActive($this->root()));
+
+        $result = $provider->discover($this->root());
+
+        Assert::same($result->failures, []);
+        Assert::count($result->donors, 1);
+        $donor = $result->donors[0];
+        Assert::same($donor->packageName, 'acme/project-skills');
+        Assert::same($donor->declaredBy, 'acme/foo');
+        Assert::same($donor->provenance, 'github');
+        Assert::false($donor->implicitTrust, 'vendor-declared sources must not be implicit-trusted');
+
+        $skillFile = (string) $donor->sourcePath()->join('deploy/SKILL.md');
+        Assert::true(\is_file($skillFile), 'extracted skill file must exist at ' . $skillFile);
+
+        // Trust follows the declaring package, not the bundle name:
+        // trusting acme/foo approves the donor, an empty trust list
+        // skips it.
+        $planner = new SyncPlanner();
+
+        $approved = $planner->plan(
+            donors: $result->donors,
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::fromStrings('acme/foo'),
+            projectRoot: $this->root(),
+        );
+        Assert::count($approved->approvedDonors, 1);
+
+        $skipped = $planner->plan(
+            donors: $result->donors,
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->root(),
+        );
+        Assert::same($skipped->approvedDonors, []);
+        Assert::same($skipped->skippedUntrustedNames, ['acme/project-skills']);
+    }
+
+    public function sharedBundleDeclaredByTwoPackagesIsFetchedOnceWithUnionedAllowlist(): void
+    {
+        if (!\class_exists(\ZipArchive::class)) {
+            throw new SkipTest('ext-zip unavailable — cannot build fixture archive');
+        }
+
+        // The issue's motivating case: several integration packages
+        // share one skills bundle. One fetch, one donor, allowlists
+        // unioned — and no self-conflict at sync time.
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/integration-a', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0', 'skills' => ['deploy']],
+            ]),
+            self::declaringPackage('acme/integration-b', '2.3.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0', 'skills' => ['review']],
+            ]),
+        );
+
+        $zipBytes = $this->buildGithubStyleZip(
+            topDir: 'acme-bundle-v1.0.0',
+            files: [
+                'composer.json' => \json_encode([
+                    'name' => 'acme/bundle',
+                    'extra' => ['skills' => ['source' => 'skills']],
+                ], \JSON_THROW_ON_ERROR),
+                'skills/deploy/SKILL.md' => "---\nname: deploy\n---\nbody",
+                'skills/review/SKILL.md' => "---\nname: review\n---\nbody",
+                'skills/other/SKILL.md' => "---\nname: other\n---\nbody",
+            ],
+        );
+
+        $zipballUrl = 'https://api.github.com/repos/acme/bundle/zipball/v1.0.0';
+        $http = $this->stubHttp([
+            $zipballUrl => new HttpResponse(statusCode: 200, body: $zipBytes),
+        ]);
+
+        $result = $this->providerFor($composer, $http)->discover($this->root());
+
+        Assert::same($result->failures, []);
+        Assert::count($result->donors, 1);
+        Assert::same($result->donors[0]->skillFilter, ['deploy', 'review']);
+        Assert::same($this->httpHits[$zipballUrl] ?? 0, 1, 'the shared bundle must be downloaded exactly once');
+
+        // The unioned allowlist drives enumeration: both declared skills
+        // land, the undeclared one is dropped.
+        $enum = (new \LLM\Skills\Discovery\SkillEnumerator())->enumerate($result->donors);
+        $names = \array_map(static fn($s) => $s->name, $enum->skills);
+        \sort($names);
+        Assert::same($names, ['deploy', 'review']);
+    }
+
+    public function vendorSourcesFalseSilencesTheWholeSourceWithoutAnyHttp(): void
+    {
+        // The project-level kill switch: with `vendor-sources: false`
+        // in skills.json the provider is inactive, nothing is fetched,
+        // nothing fails. The stub would throw on any HTTP call.
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode(['vendor-sources' => false], \JSON_THROW_ON_ERROR),
+        );
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'github', 'package' => 'acme/project-skills', 'ref' => 'v1.0.0'],
+        ]));
+
+        $provider = $this->providerFor($composer, $this->stubHttp([]));
+
+        Assert::false($provider->isActive($this->root()));
+
+        $result = $provider->discover($this->root());
+        Assert::same($result->donors, []);
+        Assert::same($result->failures, []);
+    }
+
+    // ── helpers ──
+
+    private function root(): Path
+    {
+        return Path::create($this->tmp);
+    }
+
+    private function providerFor(Composer $composer, HttpClient $http): SourceProvider
+    {
+        return new SourceProvider(
+            new VendorDeclaredRefSource($composer, new HostAdapterRegistry(new GithubAdapter($http))),
+            new HttpArchiveFetcher($http, $this->root()),
+        );
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $version
+     * @param list<array<string, mixed>> $sources
+     */
+    private static function declaringPackage(string $name, string $version, array $sources): CompletePackage
+    {
+        $package = new CompletePackage($name, $version, $version);
+        $package->setType('library');
+        $package->setExtra(['skills' => ['sources' => $sources]]);
+
+        return $package;
+    }
+
+    /**
+     * Build a Composer whose local repository returns exactly the given
+     * packages — the ref source only reads repository metadata, so no
+     * installation manager or filesystem is involved.
+     */
+    private function composerWith(PackageInterface ...$packages): Composer
+    {
+        $io = new NullIO();
+        $config = new Config(false, \sys_get_temp_dir());
+
+        $local = new InstalledArrayRepository();
+        foreach ($packages as $package) {
+            $local->addPackage($package);
+        }
+
+        $repositoryManager = new RepositoryManager($io, $config, new HttpDownloader($io, $config));
+        $repositoryManager->setLocalRepository($local);
+
+        $composer = new Composer();
+        $composer->setConfig($config);
+        $composer->setRepositoryManager($repositoryManager);
+
+        return $composer;
+    }
+
+    /**
+     * @param array<string, HttpResponse> $responses
+     */
+    private function stubHttp(array $responses): HttpClient
+    {
+        return new class($responses, $this->httpHits) implements HttpClient {
+            /**
+             * @param array<string, HttpResponse> $responses
+             * @param \ArrayObject<string, int> $hits
+             */
+            public function __construct(
+                private readonly array $responses,
+                private readonly \ArrayObject $hits,
+            ) {}
+
+            #[\Override]
+            public function get(string $url, array $headers = []): HttpResponse
+            {
+                if (!isset($this->responses[$url])) {
+                    throw new \LogicException('unstubbed URL: ' . $url);
+                }
+                $this->hits[$url] = ($this->hits[$url] ?? 0) + 1;
+                return $this->responses[$url];
+            }
+        };
+    }
+
+    /**
+     * Build an in-memory zip with a single top-level directory wrapping
+     * the given files — the same shape GitHub's zipball endpoint
+     * returns.
+     *
+     * @param non-empty-string $topDir
+     * @param array<string, string> $files relative paths inside the top dir → file contents
+     */
+    private function buildGithubStyleZip(string $topDir, array $files): string
+    {
+        $tmpZip = \tempnam(\sys_get_temp_dir(), 'vendor-e2e-zip-');
+        if ($tmpZip === false) {
+            throw new \RuntimeException('failed to create tmp zip');
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException('failed to open zip for write');
+        }
+        $zip->addEmptyDir($topDir);
+        foreach ($files as $relPath => $content) {
+            $zip->addFromString($topDir . '/' . $relPath, $content);
+        }
+        $zip->close();
+
+        $bytes = \file_get_contents($tmpZip);
+        @\unlink($tmpZip);
+        if ($bytes === false) {
+            throw new \RuntimeException('failed to read built zip');
+        }
+        return $bytes;
+    }
+}

--- a/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/ProjectConfigMapperTest.php
@@ -1573,6 +1573,69 @@ final class ProjectConfigMapperTest
         Assert::same($resolution->usedDeprecatedDependencyKeys, []);
     }
 
+    // ── vendor-sources toggle ──
+
+    public function vendorSourcesDefaultsToTrue(): void
+    {
+        $config = (new ProjectConfigMapper())->fromExtra(['skills' => []]);
+
+        Assert::true($config->vendorSources);
+    }
+
+    public function vendorSourcesFalseIsMapped(): void
+    {
+        $config = (new ProjectConfigMapper())->fromExtra([
+            'skills' => ['vendor-sources' => false],
+        ]);
+
+        Assert::false($config->vendorSources);
+    }
+
+    public function vendorSourcesRejectsNonBoolean(): void
+    {
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('vendor-sources must be a boolean');
+
+        (new ProjectConfigMapper())->fromExtra(['skills' => ['vendor-sources' => 'yes']]);
+    }
+
+    public function vendorSourcesIsReportedAsShadowedInlineKey(): void
+    {
+        $this->writeSkillsJson(['target' => '.agents/skills']);
+
+        $resolution = (new ProjectConfigMapper())->forProject(
+            Path::create($this->tmp),
+            ['skills' => ['vendor-sources' => false]],
+        );
+
+        Assert::true(\in_array('vendor-sources', $resolution->ignoredInlineKeys, true));
+    }
+
+    // ── ref flavours in sources[] ──
+
+    public function sourcesRefSelfVersionIsRejectedInProjectConfig(): void
+    {
+        // `self.version` binds to the version of the declaring vendor
+        // package; project config has no such package, so the alias is
+        // caught at load time instead of 404-ing as a literal tag.
+        Expect::exception(MalformedProjectConfig::class)
+            ->withMessageContaining('"self.version" is only supported in a vendor package');
+
+        (new ProjectConfigMapper())->fromExtra(['skills' => [
+            'sources' => [['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version']],
+        ]]);
+    }
+
+    public function sourcesRefExactConstraintIsAccepted(): void
+    {
+        $config = (new ProjectConfigMapper())->fromExtra(['skills' => [
+            'sources' => [['from' => 'github', 'package' => 'acme/skills', 'ref' => '=1.2.3']],
+        ]]);
+
+        Assert::count($config->sources, 1);
+        Assert::same($config->sources[0]->ref, '=1.2.3');
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/tests/Unit/Config/Mapper/VendorConfigMapperTest.php
+++ b/tests/Unit/Config/Mapper/VendorConfigMapperTest.php
@@ -252,4 +252,159 @@ final class VendorConfigMapperTest
             ['skills' => ['source' => 'C:\\Windows']],
         );
     }
+
+    // ── declaresSources ──
+
+    public function declaresSourcesTrueForNonEmptyList(): void
+    {
+        Assert::true(VendorConfigMapper::declaresSources([
+            'skills' => ['sources' => [['from' => 'github', 'package' => 'acme/skills']]],
+        ]));
+    }
+
+    public function declaresSourcesTrueEvenWhenEntriesAreInvalid(): void
+    {
+        // Shape-only on purpose: a botched list must still activate the
+        // ref source so the parse error surfaces instead of the donor
+        // being skipped silently.
+        Assert::true(VendorConfigMapper::declaresSources(['skills' => ['sources' => ['garbage']]]));
+    }
+
+    public function declaresSourcesFalseForEmptyMissingOrNonListValues(): void
+    {
+        Assert::false(VendorConfigMapper::declaresSources(['skills' => ['sources' => []]]));
+        Assert::false(VendorConfigMapper::declaresSources(['skills' => ['source' => 'skills']]));
+        Assert::false(VendorConfigMapper::declaresSources(['skills' => ['sources' => 'not-a-list']]));
+        Assert::false(VendorConfigMapper::declaresSources(['skills' => 'not-an-object']));
+        Assert::false(VendorConfigMapper::declaresSources(null));
+    }
+
+    // ── sourceEntriesFromExtra ──
+
+    public function sourceEntriesMapsHappyPath(): void
+    {
+        $entries = (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => [
+                'source' => 'resources/skills',
+                'sources' => [
+                    ['from' => 'github', 'package' => 'acme/skills', 'ref' => '^1.2', 'skills' => ['deploy']],
+                    ['from' => 'gitlab', 'package' => 'acme/other'],
+                ],
+            ],
+        ]);
+
+        Assert::count($entries, 2);
+        Assert::same($entries[0]->from, 'github');
+        Assert::same($entries[0]->package, 'acme/skills');
+        Assert::same($entries[0]->ref, '^1.2');
+        Assert::same($entries[0]->skills, ['deploy']);
+        Assert::same($entries[1]->from, 'gitlab');
+    }
+
+    public function sourceEntriesAllowsSelfVersionRef(): void
+    {
+        $entries = (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => [
+                'sources' => [['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version']],
+            ],
+        ]);
+
+        Assert::count($entries, 1);
+        Assert::same($entries[0]->ref, 'self.version');
+    }
+
+    public function sourceEntriesReturnsEmptyWhenKeyAbsentOrExtraNotAnArray(): void
+    {
+        $mapper = new VendorConfigMapper();
+
+        Assert::same($mapper->sourceEntriesFromExtra('acme/foo', ['skills' => ['source' => 'skills']]), []);
+        Assert::same($mapper->sourceEntriesFromExtra('acme/foo', ['skills' => []]), []);
+        Assert::same($mapper->sourceEntriesFromExtra('acme/foo', []), []);
+        Assert::same($mapper->sourceEntriesFromExtra('acme/foo', 'not-an-array'), []);
+    }
+
+    public function sourceEntriesRejectsDirAdapterWithTailoredMessage(): void
+    {
+        // An in-package path is what `extra.skills.source` is for; a
+        // vendor-controlled `dir` entry would point at the consumer's
+        // filesystem and has no safe meaning.
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('extra.skills.sources[0].from "dir" is not allowed in a vendor package');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => [['from' => 'dir', 'path' => './skills']]],
+        ]);
+    }
+
+    public function sourceEntriesRejectsDirAdapterEvenWhenTheEntryShapeIsOtherwiseBroken(): void
+    {
+        // The tailored message wins over whichever shape rule the shared
+        // mapper would trip on first (here: a missing `path`).
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('not allowed in a vendor package');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => [['from' => 'dir']]],
+        ]);
+    }
+
+    public function sourceEntriesThrowsOnUnknownAdapter(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('not a known source adapter');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => [['from' => 'nonsense', 'package' => 'acme/skills']]],
+        ]);
+    }
+
+    public function sourceEntriesThrowsOnDuplicateCompositeKey(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('duplicates an earlier entry');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => [
+                ['from' => 'github', 'package' => 'acme/skills'],
+                ['from' => 'github', 'package' => 'acme/skills'],
+            ]],
+        ]);
+    }
+
+    public function sourceEntriesThrowsWhenSourcesIsNotAList(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('extra.skills.sources must be a list of objects');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => 'not-a-list'],
+        ]);
+    }
+
+    public function sourceEntriesErrorMessagesCarryTheVendorFieldPath(): void
+    {
+        Expect::exception(MalformedVendorConfig::class)
+            ->withMessageContaining('extra.skills.sources[0].package is required');
+
+        (new VendorConfigMapper())->sourceEntriesFromExtra('acme/foo', [
+            'skills' => ['sources' => [['from' => 'github']]],
+        ]);
+    }
+
+    public function fromExtraIgnoresTheSourcesKey(): void
+    {
+        // Local rows and external refs feed different discovery paths;
+        // `fromExtra` must neither validate nor map `sources` — a fetched
+        // archive's own `sources` list is never honoured (no transitive
+        // remote chains).
+        $donors = (new VendorConfigMapper())->fromExtra('acme/foo', Path::create(__DIR__), [
+            'skills' => [
+                'source' => 'resources/skills',
+                'sources' => 'total garbage that must not be parsed here',
+            ],
+        ]);
+
+        Assert::count($donors, 1);
+        Assert::same($donors[0]->source, 'resources/skills');
+    }
 }

--- a/tests/Unit/Discovery/Provider/Source/RefResolverTest.php
+++ b/tests/Unit/Discovery/Provider/Source/RefResolverTest.php
@@ -310,4 +310,48 @@ final class RefResolverTest
         Assert::false($r->looksLikeConstraint('feature/some-thing'));
         Assert::false($r->looksLikeConstraint('9f8e7d6c5b4a3928170615243342516079889900'));
     }
+
+    public function isConstraintMatchesExactShapes(): void
+    {
+        $r = new RefResolver();
+
+        Assert::true($r->isConstraint('=1.2.3'));
+        Assert::true($r->isConstraint('=v1.2.3'));
+        Assert::true($r->isConstraint('=1.2'));
+        Assert::true($r->isConstraint('=1'));
+        Assert::true($r->isConstraint('=1.2.3.4'));
+        Assert::true($r->isConstraint('=1.0.0-beta1'));
+
+        // `=` followed by a non-version stays unrecognised — the config
+        // layer rejects it as an unsupported constraint instead of the
+        // host 404-ing on a literal `=main` tag.
+        Assert::false($r->isConstraint('=main'));
+        Assert::false($r->isConstraint('='));
+        Assert::true($r->looksLikeConstraint('=main'));
+    }
+
+    public function exactConstraintMatchesByNormalizedEquality(): void
+    {
+        $r = new RefResolver();
+
+        // The `v` prefix is ignored on both sides, and the tag is
+        // returned verbatim so the archive URL keeps the host's spelling.
+        Assert::same($r->resolveConstraint('=1.4.2', ['v1.0.0', 'v1.4.2', 'v2.0.0']), 'v1.4.2');
+        Assert::same($r->resolveConstraint('=v1.4.2', ['1.4.2']), '1.4.2');
+
+        // Missing components count as zero; a trailing zero fourth
+        // component collapses (Composer-normalized version noise).
+        Assert::same($r->resolveConstraint('=1.4', ['v1.4.0']), 'v1.4.0');
+        Assert::same($r->resolveConstraint('=1.4.0', ['v1.4']), 'v1.4');
+        Assert::same($r->resolveConstraint('=1.2.3.0', ['1.2.3']), '1.2.3');
+
+        // Exact means exact — no range semantics.
+        Assert::same($r->resolveConstraint('=1.4.2', ['v1.4.3']), null);
+        Assert::same($r->resolveConstraint('=1.4.2', []), null);
+
+        // Prerelease suffixes must match verbatim.
+        Assert::same($r->resolveConstraint('=1.0.0-beta1', ['v1.0.0-beta1']), 'v1.0.0-beta1');
+        Assert::same($r->resolveConstraint('=1.0.0-beta1', ['v1.0.0']), null);
+        Assert::same($r->resolveConstraint('=1.0.0', ['v1.0.0-beta1']), null);
+    }
 }

--- a/tests/Unit/Discovery/Provider/Source/SourceProviderTest.php
+++ b/tests/Unit/Discovery/Provider/Source/SourceProviderTest.php
@@ -549,6 +549,48 @@ final class SourceProviderTest
         };
     }
 
+    public function vendorDeclaredRefIsAttributedInsteadOfImplicitlyTrusted(): void
+    {
+        // A ref carrying `declaredBy` came from a vendor package's
+        // `extra.skills.sources` — third-party input. The donor must
+        // carry the attribution for the planner's trust check and must
+        // NOT get the implicit trust that user-declared entries enjoy.
+        $extracted = $this->makeExtracted(
+            'vendor-declared',
+            \json_encode([
+                'name' => 'acme/bundle',
+                'extra' => ['skills' => ['source' => 'skills']],
+            ]),
+        );
+        $ref = new RemoteDonorRef(
+            url: 'https://example.com/bundle.zip',
+            ref: 'v1.0.0',
+            provenance: 'github',
+            skillFilter: ['deploy'],
+            packageHint: 'acme/bundle',
+            declaredBy: 'acme/foo',
+        );
+        $fetcher = new class($extracted) implements RemoteFetcher {
+            public function __construct(private readonly Path $extracted) {}
+
+            public function fetch(RemoteDonorRef $ref): Path
+            {
+                return $this->extracted;
+            }
+        };
+
+        $provider = new SourceProvider($this->sourceWithRefs($ref), $fetcher);
+        $result = $provider->discover($this->projectRoot());
+
+        Assert::count($result->donors, 1);
+        $donor = $result->donors[0];
+        Assert::same($donor->packageName, 'acme/bundle');
+        Assert::same($donor->declaredBy, 'acme/foo');
+        Assert::false($donor->implicitTrust);
+        Assert::same($donor->provenance, 'github');
+        Assert::same($donor->skillFilter, ['deploy']);
+    }
+
     private function sourceWithRefs(RemoteDonorRef ...$refs): DonorRefSource
     {
         return new class($refs) implements DonorRefSource {

--- a/tests/Unit/Discovery/Provider/Source/SourceProviderTest.php
+++ b/tests/Unit/Discovery/Provider/Source/SourceProviderTest.php
@@ -568,7 +568,7 @@ final class SourceProviderTest
             provenance: 'github',
             skillFilter: ['deploy'],
             packageHint: 'acme/bundle',
-            declaredBy: 'acme/foo',
+            declaredBy: ['acme/foo'],
         );
         $fetcher = new class($extracted) implements RemoteFetcher {
             public function __construct(private readonly Path $extracted) {}
@@ -585,7 +585,7 @@ final class SourceProviderTest
         Assert::count($result->donors, 1);
         $donor = $result->donors[0];
         Assert::same($donor->packageName, 'acme/bundle');
-        Assert::same($donor->declaredBy, 'acme/foo');
+        Assert::same($donor->declaredBy, ['acme/foo']);
         Assert::false($donor->implicitTrust);
         Assert::same($donor->provenance, 'github');
         Assert::same($donor->skillFilter, ['deploy']);

--- a/tests/Unit/Discovery/Provider/Source/VendorDeclaredRefSourceTest.php
+++ b/tests/Unit/Discovery/Provider/Source/VendorDeclaredRefSourceTest.php
@@ -98,7 +98,7 @@ final class VendorDeclaredRefSourceTest
         $refs = $this->collect($source->refs($this->root()));
 
         Assert::count($refs, 1);
-        Assert::same($refs[0]->declaredBy, 'acme/foo');
+        Assert::same($refs[0]->declaredBy, ['acme/foo']);
         Assert::same($refs[0]->provenance, 'github');
         Assert::same($refs[0]->packageHint, 'acme/skills');
         Assert::same($refs[0]->skillFilter, ['deploy']);
@@ -218,7 +218,31 @@ final class VendorDeclaredRefSourceTest
 
         Assert::count($refs, 1);
         Assert::same($refs[0]->skillFilter, ['deploy', 'review']);
-        Assert::same($refs[0]->declaredBy, 'acme/one');
+        Assert::same($refs[0]->declaredBy, ['acme/one', 'acme/two']);
+    }
+
+    public function sharedBundleFailureNamesEveryDeclarer(): void
+    {
+        // A resolve failure on a merged entry must point at both
+        // composer.json files it lives in, not just the first one seen.
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry): RemoteDonorRef {
+            throw new RemoteResolveException($entry, 'no matching tag');
+        }));
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/one', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => '^9.0'],
+            ]),
+            self::declaringPackage('acme/two', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => '^9.0'],
+            ]),
+        );
+        $source = new VendorDeclaredRefSource($composer, $registry);
+
+        $this->collect($source->refs($this->root()));
+
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('acme/one, acme/two → github:acme/bundle');
     }
 
     public function absentAllowlistAbsorbsTheUnion(): void
@@ -277,7 +301,7 @@ final class VendorDeclaredRefSourceTest
         $refs = $this->collect($source->refs($this->root()));
 
         Assert::count($refs, 1);
-        Assert::same($refs[0]->declaredBy, 'acme/good');
+        Assert::same($refs[0]->declaredBy, ['acme/good']);
         Assert::count($source->failures(), 1);
         Assert::string($source->failures()[0]->describe())
             ->contains('acme/broken')

--- a/tests/Unit/Discovery/Provider/Source/VendorDeclaredRefSourceTest.php
+++ b/tests/Unit/Discovery/Provider/Source/VendorDeclaredRefSourceTest.php
@@ -1,0 +1,489 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Skills\Tests\Unit\Discovery\Provider\Source;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\NullIO;
+use Composer\Package\AliasPackage;
+use Composer\Package\CompletePackage;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\RepositoryManager;
+use Composer\Util\HttpDownloader;
+use Internal\Path;
+use LLM\Skills\Config\SourceEntry;
+use LLM\Skills\Discovery\Provider\Source\Adapter\HostAdapter;
+use LLM\Skills\Discovery\Provider\Source\Adapter\HostAdapterRegistry;
+use LLM\Skills\Discovery\Provider\Source\Adapter\ParsedAddInput;
+use LLM\Skills\Discovery\Provider\Source\Adapter\RemoteResolveException;
+use LLM\Skills\Discovery\Provider\Source\RemoteDonorRef;
+use LLM\Skills\Discovery\Provider\Source\VendorDeclaredRefSource;
+use LLM\Skills\Tests\Testo\Filesystem;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+use Testo\Test;
+
+#[Test]
+#[Covers(VendorDeclaredRefSource::class)]
+final class VendorDeclaredRefSourceTest
+{
+    private string $tmp;
+
+    #[BeforeTest]
+    public function setUp(): void
+    {
+        $this->tmp = \sys_get_temp_dir() . '/llm-skills-vendor-source-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->tmp, 0o777, true);
+    }
+
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Filesystem::removeRecursive($this->tmp);
+    }
+
+    // ── activation ──
+
+    public function inactiveWithoutComposer(): void
+    {
+        $source = new VendorDeclaredRefSource(null, new HostAdapterRegistry());
+
+        Assert::false($source->hasRefs($this->root()));
+        Assert::same($this->collect($source->refs($this->root())), []);
+        Assert::same($source->failures(), []);
+    }
+
+    public function inactiveWhenNoPackageDeclaresSources(): void
+    {
+        $composer = $this->composerWith(
+            self::package('acme/local-only', '1.0.0', ['skills' => ['source' => 'skills']]),
+        );
+        $source = new VendorDeclaredRefSource($composer, new HostAdapterRegistry());
+
+        Assert::false($source->hasRefs($this->root()));
+        Assert::same($this->collect($source->refs($this->root())), []);
+    }
+
+    public function vendorSourcesToggleDisablesTheSource(): void
+    {
+        \file_put_contents(
+            $this->tmp . '/skills.json',
+            \json_encode(['vendor-sources' => false], \JSON_THROW_ON_ERROR),
+        );
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'github', 'package' => 'acme/skills'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        Assert::false($source->hasRefs($this->root()));
+        Assert::same($this->collect($source->refs($this->root())), []);
+        Assert::same($source->failures(), []);
+    }
+
+    // ── happy path ──
+
+    public function yieldsDeclaredRefWithTrustAttribution(): void
+    {
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0', 'skills' => ['deploy']],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        Assert::true($source->hasRefs($this->root()));
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($refs[0]->declaredBy, 'acme/foo');
+        Assert::same($refs[0]->provenance, 'github');
+        Assert::same($refs[0]->packageHint, 'acme/skills');
+        Assert::same($refs[0]->skillFilter, ['deploy']);
+        Assert::same($refs[0]->ref, 'v1.0.0');
+        Assert::same($refs[0]->label(), 'acme/foo → github:acme/skills');
+        Assert::same($source->failures(), []);
+    }
+
+    // ── self.version binding ──
+
+    public function selfVersionOnReleasedVersionBindsExactConstraint(): void
+    {
+        $seen = [];
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.4.2', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry($seen));
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($seen[0]->ref, '=1.4.2');
+    }
+
+    public function selfVersionOnDevBranchBindsBranchName(): void
+    {
+        $seen = [];
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', 'dev-main', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry($seen));
+
+        $this->collect($source->refs($this->root()));
+
+        Assert::same($seen[0]->ref, 'main');
+    }
+
+    public function selfVersionOnNumericBranchBindsBranchName(): void
+    {
+        $seen = [];
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.x-dev', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry($seen));
+
+        $this->collect($source->refs($this->root()));
+
+        Assert::same($seen[0]->ref, '1.x');
+    }
+
+    public function selfVersionUsesTheRealPackageBehindABranchAlias(): void
+    {
+        // Composer pairs a dev-branch dependency with a synthetic
+        // `9999999-dev` alias; binding self.version to the alias would
+        // produce a nonsense ref. The source must unwrap to the real
+        // package (and not yield the declaration twice).
+        $real = self::declaringPackage('acme/foo', 'dev-main', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ]);
+        $alias = new AliasPackage($real, '9999999-dev', '9999999-dev');
+
+        $seen = [];
+        $composer = $this->composerWith($alias, $real);
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry($seen));
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($seen[0]->ref, 'main');
+    }
+
+    public function selfVersionOnUnusableVersionProducesFailure(): void
+    {
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', 'dev-', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'self.version'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::same($refs, []);
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('acme/foo → github:acme/skills')
+            ->contains('self.version');
+    }
+
+    public function resolveSelfVersionTable(): void
+    {
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('1.4.2'), '=1.4.2');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('v1.4.2'), '=v1.4.2');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('1.0.0-beta1'), '=1.0.0-beta1');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('dev-main'), 'main');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('dev-feature/x'), 'feature/x');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('1.x-dev'), '1.x');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('2.0.x-dev'), '2.0.x');
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('dev-'), null);
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion('-dev'), null);
+        Assert::same(VendorDeclaredRefSource::resolveSelfVersion(''), null);
+    }
+
+    // ── cross-package dedup & allowlist union ──
+
+    public function sharedBundleIsFetchedOnceWithUnionedAllowlists(): void
+    {
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/one', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0', 'skills' => ['deploy']],
+            ]),
+            self::declaringPackage('acme/two', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0', 'skills' => ['review', 'deploy']],
+            ]),
+        );
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($refs[0]->skillFilter, ['deploy', 'review']);
+        Assert::same($refs[0]->declaredBy, 'acme/one');
+    }
+
+    public function absentAllowlistAbsorbsTheUnion(): void
+    {
+        // "No filter" means every skill; a sibling's narrower list must
+        // not un-widen it, in either declaration order.
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/one', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0', 'skills' => ['deploy']],
+            ]),
+            self::declaringPackage('acme/two', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0'],
+            ]),
+        );
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($refs[0]->skillFilter, null);
+    }
+
+    public function differentRefsForTheSameBundleStaySeparate(): void
+    {
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/one', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v1.0.0'],
+            ]),
+            self::declaringPackage('acme/two', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/bundle', 'ref' => 'v2.0.0'],
+            ]),
+        );
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 2);
+        Assert::same($refs[0]->ref, 'v1.0.0');
+        Assert::same($refs[1]->ref, 'v2.0.0');
+    }
+
+    // ── failure isolation ──
+
+    public function malformedSourcesFailsThePackageWithoutBlockingOthers(): void
+    {
+        $composer = $this->composerWith(
+            self::declaringPackage('acme/broken', '1.0.0', [
+                ['from' => 'nonsense', 'package' => 'acme/bundle'],
+            ]),
+            self::declaringPackage('acme/good', '1.0.0', [
+                ['from' => 'github', 'package' => 'acme/skills', 'ref' => 'v1.0.0'],
+            ]),
+        );
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::count($refs, 1);
+        Assert::same($refs[0]->declaredBy, 'acme/good');
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('acme/broken')
+            ->contains('invalid extra.skills.sources');
+    }
+
+    public function dirEntryIsRejectedWithATailoredMessage(): void
+    {
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'dir', 'path' => './skills'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $this->echoRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::same($refs, []);
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('not allowed in a vendor package')
+            ->contains('extra.skills.source');
+    }
+
+    public function unknownAdapterProducesLabeledFailure(): void
+    {
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'gitlab', 'package' => 'acme/skills'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, new HostAdapterRegistry());
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::same($refs, []);
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('acme/foo → gitlab:acme/skills')
+            ->contains('unknown source adapter');
+    }
+
+    public function resolveExceptionProducesLabeledFailure(): void
+    {
+        $registry = new HostAdapterRegistry(self::stubAdapter('github', static function (SourceEntry $entry): RemoteDonorRef {
+            throw new RemoteResolveException($entry, 'no matching tag');
+        }));
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'github', 'package' => 'acme/skills', 'ref' => '^9.0'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, $registry);
+
+        $refs = $this->collect($source->refs($this->root()));
+
+        Assert::same($refs, []);
+        Assert::count($source->failures(), 1);
+        Assert::string($source->failures()[0]->describe())
+            ->contains('acme/foo → github:acme/skills')
+            ->contains('no matching tag');
+    }
+
+    public function failuresResetBetweenIterations(): void
+    {
+        $composer = $this->composerWith(self::declaringPackage('acme/foo', '1.0.0', [
+            ['from' => 'gitlab', 'package' => 'acme/skills'],
+        ]));
+        $source = new VendorDeclaredRefSource($composer, new HostAdapterRegistry());
+
+        $this->collect($source->refs($this->root()));
+        Assert::count($source->failures(), 1);
+
+        $this->collect($source->refs($this->root()));
+        Assert::count($source->failures(), 1);
+    }
+
+    // ── helpers ──
+
+    private function root(): Path
+    {
+        return Path::create($this->tmp);
+    }
+
+    /**
+     * @return list<RemoteDonorRef>
+     */
+    private function collect(iterable $refs): array
+    {
+        $out = [];
+        foreach ($refs as $r) {
+            $out[] = $r;
+        }
+        return $out;
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $prettyVersion
+     * @param list<array<string, mixed>> $sources
+     */
+    private static function declaringPackage(string $name, string $prettyVersion, array $sources): CompletePackage
+    {
+        return self::package($name, $prettyVersion, ['skills' => ['sources' => $sources]]);
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $prettyVersion
+     * @param array<string, mixed> $extra
+     */
+    private static function package(string $name, string $prettyVersion, array $extra): CompletePackage
+    {
+        // The ref source reads pretty versions only, so the fixtures
+        // use the same string for both version fields.
+        $package = new CompletePackage($name, $prettyVersion, $prettyVersion);
+        $package->setType('library');
+        $package->setExtra($extra);
+
+        return $package;
+    }
+
+    /**
+     * Build a Composer whose local repository returns exactly the given
+     * packages. No real Composer bootstrap or filesystem access; the
+     * ref source only walks repository metadata.
+     */
+    private function composerWith(PackageInterface ...$packages): Composer
+    {
+        $io = new NullIO();
+        $config = new Config(false, \sys_get_temp_dir());
+
+        $local = new InstalledArrayRepository();
+        foreach ($packages as $package) {
+            $local->addPackage($package);
+        }
+
+        $repositoryManager = new RepositoryManager($io, $config, new HttpDownloader($io, $config));
+        $repositoryManager->setLocalRepository($local);
+
+        $composer = new Composer();
+        $composer->setConfig($config);
+        $composer->setRepositoryManager($repositoryManager);
+
+        return $composer;
+    }
+
+    /**
+     * Registry with a `github` adapter that echoes the entry back as a
+     * ref (`url` derived from identifier + ref) and optionally records
+     * every entry it was asked to resolve.
+     *
+     * @param list<SourceEntry> $seen populated by reference as entries resolve
+     */
+    private function echoRegistry(array &$seen = []): HostAdapterRegistry
+    {
+        return new HostAdapterRegistry(self::stubAdapter(
+            'github',
+            static function (SourceEntry $entry) use (&$seen): RemoteDonorRef {
+                $seen[] = $entry;
+                return new RemoteDonorRef(
+                    url: 'https://api.example.com/' . $entry->identifier() . '/zipball/' . ($entry->ref ?? 'main'),
+                    ref: $entry->ref ?? 'main',
+                );
+            },
+        ));
+    }
+
+    /**
+     * @param non-empty-string $id
+     * @param callable(SourceEntry): RemoteDonorRef $resolver
+     */
+    private static function stubAdapter(string $id, callable $resolver): HostAdapter
+    {
+        return new class($id, $resolver) implements HostAdapter {
+            /**
+             * @param non-empty-string $id
+             * @param callable(SourceEntry): RemoteDonorRef $resolver
+             */
+            public function __construct(
+                private readonly string $id,
+                private readonly mixed $resolver,
+            ) {}
+
+            #[\Override]
+            public function id(): string
+            {
+                return $this->id;
+            }
+
+            #[\Override]
+            public function defaultHost(): string
+            {
+                return 'https://example.com';
+            }
+
+            #[\Override]
+            public function parseAddInput(
+                string $input,
+                ?string $hostOverride = null,
+                ?string $refOverride = null,
+            ): ParsedAddInput {
+                throw new \LogicException('not used in source tests');
+            }
+
+            #[\Override]
+            public function resolve(SourceEntry $entry): RemoteDonorRef
+            {
+                /** @var callable(SourceEntry): RemoteDonorRef $resolver */
+                $resolver = $this->resolver;
+                return $resolver($entry);
+            }
+        };
+    }
+}

--- a/tests/Unit/Sync/SyncPlannerTest.php
+++ b/tests/Unit/Sync/SyncPlannerTest.php
@@ -985,7 +985,7 @@ final class SyncPlannerTest
     {
         // The external bundle's own name matches no trust pattern — the
         // approval must come from the declaring package.
-        $donor = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $donor = $this->donor('ext/bundle')->withDeclaredBy(['acme/foo']);
         $plan = $this->planner()->plan(
             donors: [$donor],
             project: ProjectConfig::default(),
@@ -1003,7 +1003,7 @@ final class SyncPlannerTest
         // Even a bundle whose OWN name matches a trust pattern must be
         // judged by its declarer: the declaration is the third-party
         // input, not the bundle name it advertises.
-        $donor = $this->donor('acme/bundle')->withDeclaredBy('evil/payload');
+        $donor = $this->donor('acme/bundle')->withDeclaredBy(['evil/payload']);
         $plan = $this->planner()->plan(
             donors: [$donor],
             project: ProjectConfig::default(),
@@ -1018,7 +1018,7 @@ final class SyncPlannerTest
 
     public function vendorDeclaredDonorInheritsDirectDependencyTrust(): void
     {
-        $donor = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $donor = $this->donor('ext/bundle')->withDeclaredBy(['acme/foo']);
         $plan = $this->planner()->plan(
             donors: [$donor],
             project: ProjectConfig::default(),
@@ -1037,7 +1037,7 @@ final class SyncPlannerTest
         // `skills:update acme/foo` must pull foo's external skills too;
         // an unrelated donor is still filtered out.
         $local = $this->donor('acme/foo');
-        $declared = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $declared = $this->donor('ext/bundle')->withDeclaredBy(['acme/foo']);
         $other = $this->donor('other/pkg');
         $plan = $this->planner()->plan(
             donors: [$local, $declared, $other],
@@ -1054,9 +1054,58 @@ final class SyncPlannerTest
         Assert::same($plan->filteredOutDonors[0]->packageName, 'other/pkg');
     }
 
+    public function sharedBundleIsApprovedWhenAnyDeclarerIsTrusted(): void
+    {
+        // Two packages declare the same bundle; only the second one is
+        // trusted. The merge order must not decide the verdict — one
+        // trusted declarer is enough.
+        $donor = $this->donor('ext/bundle')->withDeclaredBy(['evil/payload', 'acme/foo']);
+        $plan = $this->planner()->plan(
+            donors: [$donor],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::fromStrings('acme/*'),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->approvedDonors), 1);
+        Assert::same($plan->skippedUntrustedNames, []);
+    }
+
+    public function sharedBundleIsSkippedWhenNoDeclarerIsTrusted(): void
+    {
+        $donor = $this->donor('ext/bundle')->withDeclaredBy(['evil/payload', 'shady/other']);
+        $plan = $this->planner()->plan(
+            donors: [$donor],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::fromStrings('acme/*'),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same($plan->approvedDonors, []);
+        Assert::same($plan->skippedUntrustedNames, ['ext/bundle']);
+    }
+
+    public function positionalFilterOnAnyDeclarerKeepsTheSharedBundle(): void
+    {
+        // `skills:update acme/two` names the second declarer only.
+        $declared = $this->donor('ext/bundle')->withDeclaredBy(['acme/one', 'acme/two']);
+        $plan = $this->planner()->plan(
+            donors: [$declared],
+            project: ProjectConfig::default(),
+            options: $this->optionsWithFilters('acme/two'),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->approvedDonors), 1);
+        Assert::same($plan->approvedDonors[0]->packageName, 'ext/bundle');
+    }
+
     public function positionalFilterOnTheBundleNameAlsoKeepsTheDeclaredDonor(): void
     {
-        $declared = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $declared = $this->donor('ext/bundle')->withDeclaredBy(['acme/foo']);
         $plan = $this->planner()->plan(
             donors: [$declared],
             project: ProjectConfig::default(),

--- a/tests/Unit/Sync/SyncPlannerTest.php
+++ b/tests/Unit/Sync/SyncPlannerTest.php
@@ -979,6 +979,96 @@ final class SyncPlannerTest
         Assert::same($plan->skippedUntrustedNames, ['untrusted/local']);
     }
 
+    // ── vendor-declared donors (declaredBy) ──
+
+    public function vendorDeclaredDonorIsApprovedWhenTheDeclaringPackageIsTrusted(): void
+    {
+        // The external bundle's own name matches no trust pattern — the
+        // approval must come from the declaring package.
+        $donor = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $plan = $this->planner()->plan(
+            donors: [$donor],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::fromStrings('acme/*'),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->approvedDonors), 1);
+        Assert::same($plan->approvedDonors[0]->packageName, 'ext/bundle');
+    }
+
+    public function vendorDeclaredDonorIsSkippedWhenTheDeclaringPackageIsUntrusted(): void
+    {
+        // Even a bundle whose OWN name matches a trust pattern must be
+        // judged by its declarer: the declaration is the third-party
+        // input, not the bundle name it advertises.
+        $donor = $this->donor('acme/bundle')->withDeclaredBy('evil/payload');
+        $plan = $this->planner()->plan(
+            donors: [$donor],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::fromStrings('acme/*'),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same($plan->approvedDonors, []);
+        Assert::same($plan->skippedUntrustedNames, ['acme/bundle']);
+    }
+
+    public function vendorDeclaredDonorInheritsDirectDependencyTrust(): void
+    {
+        $donor = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $plan = $this->planner()->plan(
+            donors: [$donor],
+            project: ProjectConfig::default(),
+            options: SyncOptions::default(),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+            directDependencies: ['acme/foo'],
+        );
+
+        Assert::same(\count($plan->approvedDonors), 1);
+        Assert::same($plan->approvedDonors[0]->packageName, 'ext/bundle');
+    }
+
+    public function positionalFilterOnTheDeclaringPackageKeepsItsDeclaredDonors(): void
+    {
+        // `skills:update acme/foo` must pull foo's external skills too;
+        // an unrelated donor is still filtered out.
+        $local = $this->donor('acme/foo');
+        $declared = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $other = $this->donor('other/pkg');
+        $plan = $this->planner()->plan(
+            donors: [$local, $declared, $other],
+            project: ProjectConfig::default(),
+            options: $this->optionsWithFilters('acme/foo'),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        $approvedNames = \array_map(static fn($d) => $d->packageName, $plan->approvedDonors);
+        \sort($approvedNames);
+        Assert::same($approvedNames, ['acme/foo', 'ext/bundle']);
+        Assert::same(\count($plan->filteredOutDonors), 1);
+        Assert::same($plan->filteredOutDonors[0]->packageName, 'other/pkg');
+    }
+
+    public function positionalFilterOnTheBundleNameAlsoKeepsTheDeclaredDonor(): void
+    {
+        $declared = $this->donor('ext/bundle')->withDeclaredBy('acme/foo');
+        $plan = $this->planner()->plan(
+            donors: [$declared],
+            project: ProjectConfig::default(),
+            options: $this->optionsWithFilters('ext/bundle'),
+            builtin: TrustedVendors::empty(),
+            projectRoot: $this->projectRoot(),
+        );
+
+        Assert::same(\count($plan->approvedDonors), 1);
+        Assert::same($plan->approvedDonors[0]->packageName, 'ext/bundle');
+    }
+
     private function planner(): SyncPlanner
     {
         return new SyncPlanner();


### PR DESCRIPTION
## 🔍 What was changed

- A vendor package can now advertise skills that live outside the package itself — a separate skills repository, or a bundle shared by several integration packages — via `extra.skills.sources`, reusing the exact `sources[]` vocabulary of `skills.json` (shared `SourceEntryMapper`, same adapters, fetcher, and cache).
- New `ref: "self.version"` alias binds the external source to the declaring package's installed version (monorepos tagging the skills repo in lockstep): releases compile to a new exact `=X.Y.Z` `RefResolver` constraint (normalized tag matching, `v`-prefix agnostic; also usable directly in any `sources[]`), branch installs map to the branch (`dev-main` → `main`, `1.x-dev` → `1.x`).
- The JSON schema no longer documents the reserved-but-unimplemented url-only adapters (`http`, `zip`), so editors stop autocompleting entries that can only fail at resolve time; the mapper still accepts the ids as locked vocabulary.
- README: donor-side "External sources" section, and an explicit statement of the project-vs-vendor `sources[]` boundary (consumer's pull list vs donor's address book).

### How it works

- Discovery walks the installed packages' metadata; each declared entry resolves through the existing host adapters and archive fetcher, producing regular donors tagged with `declaredBy`.
- Trust follows the declaring package: the donor is approved exactly when the declarer would be (trust list, direct dependency, positional filter) — never implicitly, unlike the project's own `sources[]`. A project can opt out entirely with `"vendor-sources": false`.
- Several packages pointing at one bundle at the same ref collapse into a single fetch with unioned `skills` allowlists; a fetched archive's own `sources` is ignored (depth is exactly one), and `dir` entries are rejected vendor-side.

## Checklist

- Closes #4
- How was this tested:
  - [x] Unit tests added (`VendorDeclaredRefSource`, `VendorConfigMapper::sourceEntriesFromExtra`, `RefResolver` exact constraints, `SyncPlanner` `declaredBy` rules, `SourceProvider` attribution)
  - [x] Feature end-to-end test with stubbed HTTP (`self.version` through tag listing + zipball, shared-bundle single fetch, kill switch) — the Acceptance sandbox runs real subprocesses and cannot stub HTTP, same constraint as the rest of the remote pipeline
  - [x] Acceptance tests for the config surface (`vendor-sources` passes the strict `skills.json` loader; `self.version` in project `sources[]` fails loudly)
  - [x] Full suite (968 tests), psalm, and php-cs-fixer run locally — all clean

## Documentation

- README: new "External sources (`extra.skills.sources`)" section on the vendor side, `vendor-sources` row in the project-config table, explicit project-vs-vendor boundary note
- `resources/skills.schema.json`: new `vendor-sources` key, `sourceByUrl` branch removed
